### PR TITLE
FEAT:Support model aliases for api model handler

### DIFF
--- a/swama/Sources/SwamaKit/Server/CompletionsHandler.swift
+++ b/swama/Sources/SwamaKit/Server/CompletionsHandler.swift
@@ -227,8 +227,9 @@ public enum CompletionsHandler {
                 )
                 return
             }
+            let resolvedModelName = ModelAliasResolver.resolve(name: payload.model)
 
-            let container = try await modelPool.get(modelName: payload.model)
+            let container = try await modelPool.get(modelName: resolvedModelName)
             let runner = ModelRunner(container: container)
 
             let promptText = lastUserMessage.content.textContent


### PR DESCRIPTION
This PR adds support for model alias resolution in API calls, allowing users to specify either a model alias or the full model name when making API requests (such as /v1/chat/completions). Previously, only the run and pull commands supported model aliases, while API calls required the full model name
**What this PR does:**

1. Integrates ModelAliasResolver into the API request handling logic.
2. Ensures that model aliases (e.g., "deepseek-r1", "qwen3") are automatically resolved to their full Hugging Face model IDs during API calls.