### PR TITLE
Change the download path

### DIFF
--- a/swama/Sources/SwamaKit/Model/ModelDownloader.swift
+++ b/swama/Sources/SwamaKit/Model/ModelDownloader.swift
@@ -77,9 +77,7 @@ public enum ModelDownloader {
     public static func downloadModel(resolvedModelName: String) async throws {
         printMessage("Pulling model: \(resolvedModelName)")
 
-        let home = FileManager.default.homeDirectoryForCurrentUser
-        let modelDir = home.appendingPathComponent("Documents/huggingface/models")
-            .appendingPathComponent(resolvedModelName)
+        let modelDir = ModelManager.modelsBaseDirectory.appendingPathComponent(resolvedModelName)
         try FileManager.default.createDirectory(at: modelDir, withIntermediateDirectories: true)
 
         let fileInfos = try await listHuggingFaceFilesWithSize(repo: resolvedModelName)

--- a/swama/Sources/SwamaKit/Model/ModelManager.swift
+++ b/swama/Sources/SwamaKit/Model/ModelManager.swift
@@ -6,25 +6,24 @@ import Foundation
 public enum ModelManager {
     /// Lists all locally available models.
     /// It scans a predefined directory structure for models and their metadata.
+    // Standard directory for storing Hugging Face models.
+    public static let modelsBaseDirectory: URL = {
+            let home = FileManager.default.homeDirectoryForCurrentUser
+            return home.appendingPathComponent(".swama/models")
+        }()
     public static func models() -> [ModelInfo] {
-        let home = FileManager.default.homeDirectoryForCurrentUser
-        // Standard directory for storing Hugging Face models.
-        let modelsRootDirectory = home.appendingPathComponent("Documents")
-            .appendingPathComponent("huggingface")
-            .appendingPathComponent("models")
-
         var modelInfos: [ModelInfo] = []
         let orgDirs: [URL]
         do {
             orgDirs = try FileManager.default.contentsOfDirectory(
-                at: modelsRootDirectory,
+                at: modelsBaseDirectory,
                 includingPropertiesForKeys: [.isDirectoryKey],
                 options: [.skipsHiddenFiles]
             )
         }
         catch {
             fputs(
-                "SwamaKit.ModelManager: Error reading models root directory \(modelsRootDirectory.path): \(error.localizedDescription)\n",
+                "SwamaKit.ModelManager: Error reading models root directory \(modelsBaseDirectory.path): \(error.localizedDescription)\n",
                 stderr
             )
             return [] // Return empty if the root directory is inaccessible
@@ -98,10 +97,6 @@ public enum ModelManager {
 
     /// Loads detailed information for a specific model by its ID.
     public static func loadModel(id: String) throws -> LoadedModel {
-        let home = FileManager.default.homeDirectoryForCurrentUser
-        let modelsBaseDirectory = home.appendingPathComponent("Documents")
-            .appendingPathComponent("huggingface")
-            .appendingPathComponent("models")
         let modelDir = modelsBaseDirectory.appendingPathComponent(id)
         let configURL = modelDir.appendingPathComponent("config.json")
         let tokenizerURL = modelDir.appendingPathComponent("tokenizer.json")


### PR DESCRIPTION
# Pull Request Title
Change the download path

## 1. What does this PR do?
Change the download path to ~/.swama/models

## 2. Why is this PR needed?
Currently the download path is to documents, where icloud sync it.

## 3. Related Discussions
#8 

## 4. How was this tested?
Test in the terminal, run and can successfully run.

(base) yulinli@Yulins-MacBook-Air ~ % ls .swama/models
mlx-community
(base) yulinli@Yulins-MacBook-Air ~ % 


## 5. Impact Analysis
Important for experience.