### PR TITLE
Fix: Inability to get file size from HuggingFace downloader

### DIFF
--- a/swama/Sources/SwamaKit/Model/Downloaders/HuggingFaceDownloader.swift
+++ b/swama/Sources/SwamaKit/Model/Downloaders/HuggingFaceDownloader.swift
@@ -138,6 +138,44 @@ public class HuggingFaceDownloader: BaseDownloader {
             )
         }
 
-        return httpResponse.expectedContentLength > 0 ? httpResponse.expectedContentLength : 0
+        let contentLength = httpResponse.expectedContentLength
+        
+        // If HEAD request doesn't provide content length (common with compression),
+        // try a range request to get the actual file size
+        if contentLength <= 0 {
+            return try await getFileSizeWithRangeRequest(url: url)
+        }
+
+        return contentLength
+    }
+    
+    private func getFileSizeWithRangeRequest(url: URL) async throws -> Int64 {
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("bytes=0-0", forHTTPHeaderField: "Range") // Request only the first byte
+
+        let (_, response) = try await URLSession.shared.data(for: request)
+        
+        guard let httpResponse = response as? HTTPURLResponse else {
+            return 0
+        }
+        
+        // Check Content-Range header for total file size
+        if let contentRange = httpResponse.allHeaderFields["Content-Range"] as? String {
+            // Content-Range format: "bytes 0-0/1234" where 1234 is the total size
+            let components = contentRange.components(separatedBy: "/")
+            if components.count == 2, let totalSize = Int64(components[1]) {
+                return totalSize
+            }
+        }
+        
+        // If range request doesn't work, check if we got a Content-Length in the response
+        let contentLength = httpResponse.expectedContentLength
+        if contentLength > 0 {
+            return contentLength
+        }
+        
+        // Could not determine file size
+        return 0
     }
 }


### PR DESCRIPTION
# Fix: Inability to get file size from HuggingFace downloader

## 1. What does this PR do?
This PR fixes the file size retrieval logic in `HuggingFaceDownloader`. The key changes include:
- In the `getWhisperKitFileSize` method, a fallback mechanism is now triggered when the `Content-Length` from a `HEAD` request is invalid (e.g., less than or equal to 0).
- A new private method, `getFileSizeWithRangeRequest`, has been added. It sends a `GET` request with a `Range: bytes=0-0` header to retrieve the file's `Content-Range` information, from which the accurate total file size is parsed.

## 2. Why is this PR needed?
When running the `swama pull whisper-tiny` command, the program would crash due to a division-by-zero error. The root cause is:
- The HuggingFace server does not return a `Content-Length` header for `HEAD` requests on files with content compression enabled (like `gzip` or `br`), causing `httpResponse.expectedContentLength` to return `-1`.
- This invalid value was treated as `0` and passed as the `total` parameter to the `ProgressBar`.
- In the `ProgressBar`, a division-by-zero error occurred when calculating the download percentage (`percent = downloaded / total`), leading to a crash.

This PR resolves the issue by implementing a more reliable mechanism for fetching the file size.

## 3. Related Discussions
- Fixes the runtime crash `Fatal error: Double value cannot be converted to Int because it is either infinite or NaN` that occurred during `swama pull`.

## 4. How was this tested?
- **Manual Testing**:
  - Set the environment variable: `export SWAMA_REGISTRY=HUGGING_FACE`.
  - Run the command: `swama pull whisper-tiny`.
  - Verified that the download process no longer crashes and now displays the correct percentage progress bar.

## 5. Impact Analysis
- **Scope**: This change only affects the `HuggingFaceDownloader` and has no impact on `ModelScopeDownloader` or other modules.
- **Risk**: The risk is low. This change adds a more robust fallback for file size retrieval, improving the stability of model downloads from HuggingFace.
- **Reviewer Focus**:
  - The implementation logic of the `getFileSizeWithRangeRequest` method.
  - The condition for triggering the fallback mechanism