### PR TITLE
feat: add a feature create model from local path

### DIFF
--- a/swama/Sources/Swama/CLI/Command.swift
+++ b/swama/Sources/Swama/CLI/Command.swift
@@ -11,7 +11,16 @@ struct Swama: AsyncParsableCommand {
         commandName: "swama",
         abstract: "Swama - The Swift-native LLM runtime for macOS",
         version: "1.4.2",
-        subcommands: [Serve.self, Pull.self, Run.self, MenuBar.self, List.self, Remove.self, Transcribe.self],
+        subcommands: [
+            Serve.self,
+            Pull.self,
+            Run.self,
+            MenuBar.self,
+            List.self,
+            Remove.self,
+            Transcribe.self,
+            Create.self
+        ],
         defaultSubcommand: Serve.self
     )
 }

--- a/swama/Sources/Swama/CLI/Create.swift
+++ b/swama/Sources/Swama/CLI/Create.swift
@@ -1,0 +1,23 @@
+import ArgumentParser
+import Foundation
+import SwamaKit
+
+struct Create: AsyncParsableCommand {
+    static let configuration: CommandConfiguration = .init(
+        abstract: "Create a model entry from a user-specified path and name. The model metadata (.swama-meta.json) will be saved to ~/.swama/models/<name>, allowing the model to be run later using this name."
+    )
+
+    @Argument(help: "Path to user-provided path, e.g.  '/path/to/model'")
+    var path: String
+
+    @Option(name: .shortAndLong, help: "Output directory for the created model or project")
+    var name: String
+
+    func run() async throws {
+        print("Creating model from path: \(path) with name: \(name)")
+
+        try await ModelCreator.run(from: path, name: name)
+
+        print("Model created successfully at \(ModelPaths.preferredModelsDirectory.appendingPathComponent(name).path)")
+    }
+}

--- a/swama/Sources/SwamaKit/Model/ModelDownloader.swift
+++ b/swama/Sources/SwamaKit/Model/ModelDownloader.swift
@@ -173,7 +173,7 @@ public enum ModelDownloader {
 
     // MARK: Internal
 
-    static func printMessage(_ message: String) {
+    public static func printMessage(_ message: String) {
         // Use fputs to stdout to behave like print
         fputs(message + "\n", stdout)
         fflush(stdout)
@@ -182,20 +182,24 @@ public enum ModelDownloader {
     static func writeModelMetadata(modelName: String, modelDir: URL) throws {
         let size = try calculateFolderSize(at: modelDir)
         let created = Int(Date().timeIntervalSince1970)
+        let metaURL = (ModelPaths.customModelsDirectory ?? ModelPaths.preferredModelsDirectory)
+            .appendingPathComponent(modelName)
+            .appendingPathComponent(".swama-meta.json")
         let metadata: [String: Any] = [
             "id": modelName,
             "object": "model",
             "created": created,
             "owned_by": "swama",
-            "size_in_bytes": size
+            "size_in_bytes": size,
+            "path": modelDir.path
         ]
-        let metaURL = modelDir.appendingPathComponent(".swama-meta.json")
+
         let data = try JSONSerialization.data(withJSONObject: metadata, options: [.prettyPrinted])
         try data.write(to: metaURL)
         printMessage("📝 Metadata written to .swama-meta.json")
     }
 
-    static func calculateFolderSize(at url: URL) throws -> Int64 {
+    public static func calculateFolderSize(at url: URL) throws -> Int64 {
         var total: Int64 = 0
         let resourceKeys: [URLResourceKey] = [.isRegularFileKey, .fileSizeKey]
         guard let enumerator = FileManager.default.enumerator(

--- a/swama/Sources/SwamaKit/Model/ModelPaths.swift
+++ b/swama/Sources/SwamaKit/Model/ModelPaths.swift
@@ -37,12 +37,12 @@ public enum ModelPaths {
         if let customPath,
            FileManager.default.fileExists(atPath: customPath.appendingPathComponent(".swama-meta.json").path)
         {
-            return customPath
+            return parseModelMetadataPath(from: customPath.appendingPathComponent(".swama-meta.json"))
         }
 
         // Check if model exists in preferred location
         if FileManager.default.fileExists(atPath: preferredPath.appendingPathComponent(".swama-meta.json").path) {
-            return preferredPath
+            return parseModelMetadataPath(from: preferredPath.appendingPathComponent(".swama-meta.json"))
         }
 
         // Check if model exists in legacy location
@@ -56,6 +56,17 @@ public enum ModelPaths {
         }
         // Else return preferred location for new downloads
         return preferredPath
+    }
+
+    private static func parseModelMetadataPath(from metaURL: URL) -> URL {
+        guard let data = try? Data(contentsOf: metaURL),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let path = json["path"] as? String
+        else {
+            return metaURL.deletingLastPathComponent()
+        }
+
+        return URL(fileURLWithPath: path)
     }
 
     /// Check if a model exists locally (in either preferred or legacy location)

--- a/swama/Sources/SwamaKit/Model/ModeleCreator.swift
+++ b/swama/Sources/SwamaKit/Model/ModeleCreator.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public enum ModelCreator {
+    public static func run(from path: String, name: String) async throws {
+        ModelDownloader.printMessage("Creating model from path: \(path) with name: \(name)")
+
+        let modelDir = ModelPaths.preferredModelsDirectory.appendingPathComponent(name)
+        let sourceURL = URL(fileURLWithPath: path)
+
+        // Check if the model directory already exists
+        if FileManager.default.fileExists(atPath: modelDir.path) {
+            throw NSError(
+                domain: "ModelCreatorError",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Model directory already exists at \(modelDir.path)"]
+            )
+        }
+
+        // Create the model directory
+        try FileManager.default.createDirectory(at: modelDir, withIntermediateDirectories: true, attributes: nil)
+
+        // Write metadata
+        try ModelDownloader.writeModelMetadata(modelName: name, modelDir: sourceURL)
+    }
+}


### PR DESCRIPTION
# Title
Add a feature create model from local path.

## Why need?
Users may have some models in their local path and want to use the swama to load them. This feature allow user to create their own model from local and give a name then swama can load them.

## How test?
Create model from local path, give the name then use swama list and swama run. Also unitest.

## Relate
#37 