### PR TITLE
feat: add 'rm' command to remove models from local storage

### DIFF
--- a/swama/Sources/Swama/CLI/Command.swift
+++ b/swama/Sources/Swama/CLI/Command.swift
@@ -11,7 +11,7 @@ struct Swama: AsyncParsableCommand {
         commandName: "swama",
         abstract: "Swama - The Swift-native LLM runtime for macOS",
         version: "1.4.1",
-        subcommands: [Serve.self, Pull.self, Run.self, MenuBar.self, List.self, Transcribe.self], // Added Transcribe
+        subcommands: [Serve.self, Pull.self, Run.self, MenuBar.self, List.self, Remove.self, Transcribe.self], // Added Remove
         defaultSubcommand: Serve.self
     )
 }

--- a/swama/Sources/Swama/CLI/Remove.swift
+++ b/swama/Sources/Swama/CLI/Remove.swift
@@ -1,0 +1,69 @@
+import ArgumentParser
+import Foundation
+import SwamaKit
+
+struct Remove: AsyncParsableCommand {
+    static let configuration: CommandConfiguration = .init(
+        commandName: "rm",
+        abstract: "Remove a model from local storage"
+    )
+
+    @Argument(help: "Model name or alias to remove, e.g. qwen3-30b, whisperkit-base, or mlx-community/Llama-3.2-1B-Instruct-4bit")
+    var model: String
+
+    @Flag(name: .shortAndLong, help: "Force removal without confirmation prompt")
+    var force: Bool = false
+
+    func run() async throws {
+        // Resolve model name using the same logic as other commands
+        let resolvedModelName = ModelAliasResolver.resolve(name: model)
+
+        // Show resolved name if different from input
+        if model != resolvedModelName {
+            print("Info: Resolved model alias '\(model)' to '\(resolvedModelName)'")
+        }
+
+        // Check if model exists
+        guard ModelPaths.modelExistsLocally(resolvedModelName) else {
+            print("Error: Model '\(resolvedModelName)' not found locally.")
+            throw ExitCode.failure
+        }
+
+        // Get model info for confirmation
+        let models = ModelManager.models()
+        let modelInfo = models.first { $0.id == resolvedModelName }
+        
+        // Confirmation prompt (unless --force is used)
+        if !force {
+            print("Are you sure you want to remove model '\(resolvedModelName)'?")
+            if let modelInfo = modelInfo {
+                let sizeStr = ByteCountFormatter.string(fromByteCount: modelInfo.sizeInBytes, countStyle: .file)
+                print("Size: \(sizeStr)")
+            }
+            print("This action cannot be undone. Type 'y' or 'yes' to confirm:")
+            
+            guard let input = readLine()?.lowercased(),
+                  input == "y" || input == "yes" else {
+                print("Removal cancelled.")
+                return
+            }
+        }
+
+        // Remove model from disk
+        do {
+            let wasRemoved = try ModelPaths.removeModel(resolvedModelName)
+            if wasRemoved {
+                print("Successfully removed model '\(resolvedModelName)'")
+                
+                // Note: ModelPool cleanup is skipped to avoid MLX initialization issues
+                // Models will be automatically evicted from memory when needed
+            } else {
+                print("Error: Model '\(resolvedModelName)' not found on disk.")
+                throw ExitCode.failure
+            }
+        } catch {
+            print("Error removing model '\(resolvedModelName)': \(error.localizedDescription)")
+            throw ExitCode.failure
+        }
+    }
+}

--- a/swama/Sources/SwamaKit/Model/ModelPaths.swift
+++ b/swama/Sources/SwamaKit/Model/ModelPaths.swift
@@ -78,4 +78,25 @@ public enum ModelPaths {
         }
         return directories
     }
+
+    /// Remove a model from disk
+    /// Returns true if model was found and deleted, false if model wasn't found
+    public static func removeModel(_ modelName: String) throws -> Bool {
+        // Check all possible model locations in priority order
+        let locations = [
+            customModelsDirectory?.appendingPathComponent(modelName),
+            preferredModelsDirectory.appendingPathComponent(modelName),
+            legacyModelsDirectory.appendingPathComponent(modelName)
+        ].compactMap { $0 }
+        
+        for location in locations {
+            let metadataFile = location.appendingPathComponent(".swama-meta.json")
+            if FileManager.default.fileExists(atPath: metadataFile.path) {
+                try FileManager.default.removeItem(at: location)
+                return true
+            }
+        }
+        
+        return false // Model not found
+    }
 }


### PR DESCRIPTION
- Add new 'swama rm' CLI command with confirmation prompt and --force flag
- Add ModelPaths.removeModel() function to handle model deletion across all storage locations
- Support model aliases (e.g., qwen3, whisperkit-base) in removal process
- Add comprehensive tests for model removal and existence checking
- Reuse existing infrastructure (ModelAliasResolver, ModelManager, ModelPaths)

Usage:
  swama rm <model>         # Remove with confirmation
  swama rm <model> --force # Remove without confirmation

Resolves the need for manual model management and complements existing 'pull' and 'list' commands.