### PR TITLE
feat: cors support

### DIFF
--- a/swama/Sources/SwamaKit/Server/CompletionsHandler.swift
+++ b/swama/Sources/SwamaKit/Server/CompletionsHandler.swift
@@ -598,6 +598,7 @@ public enum CompletionsHandler {
         let jsonData = try encoder.encode(response)
         var headers = HTTPHeaders()
         headers.add(name: "Content-Type", value: "application/json")
+        HTTPHandler.applyCORSHeaders(&headers)
 
         let responseHead = HTTPResponseHead(version: .http1_1, status: .ok, headers: headers)
         let responseBody = HTTPServerResponsePart.body(.byteBuffer(ByteBuffer(bytes: jsonData)))
@@ -766,6 +767,7 @@ public enum CompletionsHandler {
         var headers = HTTPHeaders()
         headers.add(name: "Content-Type", value: "application/json")
         headers.add(name: "Content-Length", value: String(data.count))
+        HTTPHandler.applyCORSHeaders(&headers)
 
         let responseHead = HTTPResponseHead(version: version, status: status, headers: headers)
         let responseBody = HTTPServerResponsePart.body(.byteBuffer(ByteBuffer(bytes: data)))

--- a/swama/Sources/SwamaKit/Server/EmbeddingsHandler.swift
+++ b/swama/Sources/SwamaKit/Server/EmbeddingsHandler.swift
@@ -223,6 +223,7 @@ public enum EmbeddingsHandler {
         headers.add(name: "Content-Type", value: "application/json")
         headers.add(name: "Content-Length", value: "\(buffer.readableBytes)")
         headers.add(name: "Connection", value: "close")
+        HTTPHandler.applyCORSHeaders(&headers)
 
         try await channel.writeAndFlush(
             HTTPServerResponsePart.head(HTTPResponseHead(
@@ -263,6 +264,7 @@ public enum EmbeddingsHandler {
         headers.add(name: "Content-Type", value: "application/json")
         headers.add(name: "Content-Length", value: "\(buffer.readableBytes)")
         headers.add(name: "Connection", value: "close")
+        HTTPHandler.applyCORSHeaders(&headers)
 
         try await channel.writeAndFlush(
             HTTPServerResponsePart.head(HTTPResponseHead(

--- a/swama/Sources/SwamaKit/Server/TranscriptionsHandler.swift
+++ b/swama/Sources/SwamaKit/Server/TranscriptionsHandler.swift
@@ -377,6 +377,7 @@ public enum TranscriptionsHandler {
         headers.add(name: "Content-Type", value: contentType)
         headers.add(name: "Content-Length", value: "\(buffer.readableBytes)")
         headers.add(name: "Connection", value: "close")
+        HTTPHandler.applyCORSHeaders(&headers)
 
         channel.write(
             HTTPServerResponsePart.head(HTTPResponseHead(


### PR DESCRIPTION
# Feature: CORS Support

## What this PR does

- Adds a shared `applyCORSHeaders` function
- Appends CORS headers to all responses
- Handles `OPTIONS` preflight requests

## Why needed

- Enables cross-origin requests for frontend development

## How tested

- Verified with curl and browser that CORS headers are present and requests succeed
