### PR TITLE
fix: ensure tool calls are accumulated in streaming responses

### DIFF
--- a/swama/Sources/SwamaKit/Model/ModelRunner.swift
+++ b/swama/Sources/SwamaKit/Model/ModelRunner.swift
@@ -103,11 +103,10 @@ public actor ModelRunner {
                     capturedCompletionInfo = info
 
                 case let .toolCall(toolCall):
+                    // Always accumulate tool calls for the return value
+                    toolCalls.append(toolCall)
+                    // Also send to callback if provided (for streaming)
                     onToolCall?(toolCall)
-                    // Only accumulate if no onToolCall callback (for non-streaming)
-                    if onToolCall == nil {
-                        toolCalls.append(toolCall)
-                    }
                 }
             }
 


### PR DESCRIPTION
- Always accumulate tool calls to return value regardless of callback presence
- Fixes finish_reason being incorrectly set to "stop" instead of "tool_calls" 
  in streaming mode when tools are called
- Maintains backward compatibility for non-streaming responses

#50 