### PR TITLE
Improve clarity by logging existing model in fetchModel

### DIFF
--- a/swama/Sources/SwamaKit/Model/ModelDownloader.swift
+++ b/swama/Sources/SwamaKit/Model/ModelDownloader.swift
@@ -181,7 +181,9 @@ public enum ModelDownloader {
         let modelDir = ModelPaths.getModelDirectory(for: resolved)
         let modelExists = FileManager.default.fileExists(atPath: modelDir.path)
 
-        if !modelExists {
+        if modelExists {
+            print("✅ Model already exists: \(resolved)")
+        } else {
             try await ModelDownloader.downloadModel(resolvedModelName: resolved)
         }
 


### PR DESCRIPTION
This PR adds a simple log message when a requested model already exists locally in fetchModel.
It helps users understand that the model was found and no download was needed.

Checked if model already exists before download
Added log: ✅ Model already exists: <modelName> (skipping download)