### PR TITLE
Feat: View model pool info within menu

### DIFF
--- a/swama-macos/Swama/Swama/SwamaApp.swift
+++ b/swama-macos/Swama/Swama/SwamaApp.swift
@@ -15,8 +15,6 @@ struct SwamaApp: App {
     @NSApplicationDelegateAdaptor(SwamaKit.AppDelegate.self) var appDelegate
     var menuDelegate: MenuDelegate { .shared }
 
-    @State private var cliToolStatus: CLIToolStatus = .notInstalled
-
     init() {
         NSLog("SwamaApp: init() called. The application is starting.")
     }
@@ -24,29 +22,7 @@ struct SwamaApp: App {
     var body: some Scene {
         MenuBarExtra("Swama", image: "MenuBarIcon") {
             VStack {
-                // Only show CLI tool button if not up to date
-                if cliToolStatus != .upToDate {
-                    Button(cliToolButtonTitle) {
-                        menuDelegate.installCLITool()
-                        // Refresh status after installation
-                        cliToolStatus = menuDelegate.checkCLIToolStatus()
-                    }
-                    .keyboardShortcut("I", modifiers: [.command])
-                    .onAppear {
-                        // Check CLI tool status when menu appears
-                        cliToolStatus = menuDelegate.checkCLIToolStatus()
-                    }
-                    
-                    Divider()
-                } else {
-                    // Still need to check status when menu appears, even when button is hidden
-                    Color.clear
-                        .frame(height: 0)
-                        .onAppear {
-                            cliToolStatus = menuDelegate.checkCLIToolStatus()
-                        }
-                }
-
+                ToolStatusView()
                 Button("Quit Swama") {
                     NSApplication.shared.terminate(nil)
                 }
@@ -55,14 +31,43 @@ struct SwamaApp: App {
         }
     }
 
-    private var cliToolButtonTitle: String {
-        switch cliToolStatus {
-        case .notInstalled:
-            return "Install CLI…"
-        case .needsUpdate:
-            return "Update CLI…"
-        case .upToDate:
-            return ""
+    struct ToolStatusView: View {
+        var menuDelegate: MenuDelegate { .shared }
+        @State private var cliToolStatus: CLIToolStatus = .notInstalled
+
+        var body: some View {
+            // Only show CLI tool button if not up to date
+            if cliToolStatus != .upToDate {
+                Button(cliToolButtonTitle) {
+                    menuDelegate.installCLITool()
+                    // Refresh status after installation
+                    cliToolStatus = menuDelegate.checkCLIToolStatus()
+                }
+                .keyboardShortcut("I", modifiers: [.command])
+                .onAppear {
+                    // Check CLI tool status when menu appears
+                    cliToolStatus = menuDelegate.checkCLIToolStatus()
+                }
+                Divider()
+            } else {
+                // Still need to check status when menu appears, even when button is hidden
+                Color.clear
+                    .frame(height: 0)
+                    .onAppear {
+                        cliToolStatus = menuDelegate.checkCLIToolStatus()
+                    }
+            }
+        }
+
+        private var cliToolButtonTitle: String {
+            switch cliToolStatus {
+            case .notInstalled:
+                return "Install CLI…"
+            case .needsUpdate:
+                return "Update CLI…"
+            case .upToDate:
+                return ""
+            }
         }
     }
 }

--- a/swama-macos/Swama/Swama/SwamaApp.swift
+++ b/swama-macos/Swama/Swama/SwamaApp.swift
@@ -57,9 +57,9 @@ struct SwamaApp: App {
     private var cliToolButtonTitle: String {
         switch cliToolStatus {
         case .notInstalled:
-            return "Install Command Line Tool…"
+            return "Install CLI…"
         case .needsUpdate:
-            return "Update Command Line Tool…"
+            return "Update CLI…"
         case .upToDate:
             return ""
         }

--- a/swama-macos/Swama/Swama/SwamaApp.swift
+++ b/swama-macos/Swama/Swama/SwamaApp.swift
@@ -13,6 +13,7 @@ struct SwamaApp: App {
     /// Use NSApplicationDelegateAdaptor to integrate the existing AppDelegate
     /// from SwamaKit for managing the application lifecycle and menu bar.
     @NSApplicationDelegateAdaptor(SwamaKit.AppDelegate.self) var appDelegate
+    @StateObject private var menuDelegate = MenuDelegate()
 
     @State private var cliToolStatus: CLIToolStatus = .notInstalled
 
@@ -26,14 +27,14 @@ struct SwamaApp: App {
                 // Only show CLI tool button if not up to date
                 if cliToolStatus != .upToDate {
                     Button(cliToolButtonTitle) {
-                        appDelegate.installCLITool()
+                        menuDelegate.installCLITool()
                         // Refresh status after installation
-                        cliToolStatus = appDelegate.checkCLIToolStatus()
+                        cliToolStatus = menuDelegate.checkCLIToolStatus()
                     }
                     .keyboardShortcut("I", modifiers: [.command])
                     .onAppear {
                         // Check CLI tool status when menu appears
-                        cliToolStatus = appDelegate.checkCLIToolStatus()
+                        cliToolStatus = menuDelegate.checkCLIToolStatus()
                     }
                     
                     Divider()
@@ -42,7 +43,7 @@ struct SwamaApp: App {
                     Color.clear
                         .frame(height: 0)
                         .onAppear {
-                            cliToolStatus = appDelegate.checkCLIToolStatus()
+                            cliToolStatus = menuDelegate.checkCLIToolStatus()
                         }
                 }
 

--- a/swama-macos/Swama/Swama/SwamaApp.swift
+++ b/swama-macos/Swama/Swama/SwamaApp.swift
@@ -13,7 +13,7 @@ struct SwamaApp: App {
     /// Use NSApplicationDelegateAdaptor to integrate the existing AppDelegate
     /// from SwamaKit for managing the application lifecycle and menu bar.
     @NSApplicationDelegateAdaptor(SwamaKit.AppDelegate.self) var appDelegate
-    @StateObject private var menuDelegate = MenuDelegate()
+    var menuDelegate: MenuDelegate { .shared }
 
     @State private var cliToolStatus: CLIToolStatus = .notInstalled
 

--- a/swama-macos/Swama/Swama/SwamaApp.swift
+++ b/swama-macos/Swama/Swama/SwamaApp.swift
@@ -45,7 +45,7 @@ struct SwamaApp: App {
                 } else {
                     Text("Loaded Models")
                     ForEach(modelCache, id: \.self) { model in
-                        Text(model).foregroundStyle(.gray)
+                        Text(model)
                     }
                     Button("Unload All Models") {
                         Task { await ModelPool.shared.clearCache() }

--- a/swama/Sources/SwamaKit/AppDelegate.swift
+++ b/swama/Sources/SwamaKit/AppDelegate.swift
@@ -1,0 +1,43 @@
+import AppKit
+import Foundation
+
+// MARK: - AppDelegate
+
+@MainActor
+public class AppDelegate: NSObject, NSApplicationDelegate {
+    // MARK: Lifecycle
+
+    // MARK: ‑ Init
+
+    override public init() {
+        super.init()
+        NSLog("SwamaKit.AppDelegate: init() called.")
+
+        self.serverManager = ServerManager(host: "0.0.0.0", port: 28100)
+    }
+
+    // MARK: Public
+
+    // MARK: ‑ NSApplicationDelegate
+
+    public func applicationDidFinishLaunching(_: Notification) {
+        // turn app into a menu‑bar‑only application
+        if NSApp.activationPolicy() != .accessory {
+            NSApp.setActivationPolicy(.accessory)
+        }
+
+        // start backend server
+        Task {
+            do { try serverManager?.startInBackground() }
+            catch { NSLog("SwamaKit.AppDelegate: server failed to start → \(error)") }
+        }
+    }
+
+    public func applicationWillTerminate(_: Notification) {
+        Task { await serverManager?.stop() }
+    }
+
+    // MARK: Private
+
+    private var serverManager: ServerManager?
+}

--- a/swama/Sources/SwamaKit/MenuDelegate.swift
+++ b/swama/Sources/SwamaKit/MenuDelegate.swift
@@ -32,8 +32,10 @@ private struct CLIToolPaths {
 // MARK: ‑ MenuDelegate
 
 @MainActor
-public class MenuDelegate: ObservableObject {
+public class MenuDelegate {
     // MARK: Lifecycle
+
+    public static let shared = MenuDelegate()
 
     // MARK: ‑ Init
     public init() {}

--- a/swama/Sources/SwamaKit/MenuDelegate.swift
+++ b/swama/Sources/SwamaKit/MenuDelegate.swift
@@ -1,9 +1,15 @@
+//
+//  MenuDelegate.swift
+//  swama
+//
+//  Created by haol-co on 14/08/2025
+//
+
 import AppKit
 import Foundation
 
 // MARK: - CLIToolStatus
 
-/// AppDelegate for Swama menu‑bar application
 public enum CLIToolStatus {
     case notInstalled
     case needsUpdate
@@ -23,45 +29,19 @@ private struct CLIToolPaths {
     }
 }
 
-// MARK: - AppDelegate
+// MARK: ‑ MenuDelegate
 
 @MainActor
-public class AppDelegate: NSObject, NSApplicationDelegate {
+public class MenuDelegate: ObservableObject {
     // MARK: Lifecycle
 
     // MARK: ‑ Init
-
-    override public init() {
-        super.init()
-        NSLog("SwamaKit.AppDelegate: init() called.")
-
-        self.serverManager = ServerManager(host: "0.0.0.0", port: 28100)
-    }
+    public init() {}
 
     // MARK: Public
 
-    // MARK: ‑ NSApplicationDelegate
-
-    public func applicationDidFinishLaunching(_: Notification) {
-        // turn app into a menu‑bar‑only application
-        if NSApp.activationPolicy() != .accessory {
-            NSApp.setActivationPolicy(.accessory)
-        }
-
-        // start backend server
-        Task {
-            do { try serverManager?.startInBackground() }
-            catch { NSLog("SwamaKit.AppDelegate: server failed to start → \(error)") }
-        }
-    }
-
-    public func applicationWillTerminate(_: Notification) {
-        Task { await serverManager?.stop() }
-    }
-
     // MARK: Private
 
-    private var serverManager: ServerManager?
 
     // MARK: ‑ CLI Tool Paths
 

--- a/swama/Sources/SwamaKit/MenuDelegate.swift
+++ b/swama/Sources/SwamaKit/MenuDelegate.swift
@@ -37,7 +37,6 @@ public class MenuDelegate {
 
     public static let shared = MenuDelegate()
 
-    // MARK: ‑ Init
     public init() {}
 
     // MARK: Public

--- a/swama/Sources/SwamaKit/MenuDelegate.swift
+++ b/swama/Sources/SwamaKit/MenuDelegate.swift
@@ -88,7 +88,7 @@ public class MenuDelegate: ObservableObject {
 
         // locate Helpers directory & binary
         guard FileManager.default.isExecutableFile(atPath: paths.binPath) else {
-            alert("Installation Failed", "Mach‑O binary not found: \(paths.binPath)")
+            alert("Installation failed", "Mach‑O binary not found: \(paths.binPath)")
             return
         }
 
@@ -102,7 +102,7 @@ public class MenuDelegate: ObservableObject {
             try script.write(to: tmpURL, atomically: true, encoding: .utf8)
         }
         catch {
-            alert("Installation Failed", "Unable to write temporary wrapper script: \(error.localizedDescription)")
+            alert("Installation failed", "An error occurred while creating temporary wrapper script. \(error.localizedDescription)")
             return
         }
 
@@ -115,10 +115,10 @@ public class MenuDelegate: ObservableObject {
         if let osa = NSAppleScript(source: osaSrc) {
             let _ = osa.executeAndReturnError(&errDict)
             if errDict == nil {
-                alert("Installation Successful", "'swama' CLI wrapper installed to \(paths.wrapperPath)", info: true)
+                alert("Installation successful", "Installed `swama` command line tools to \(paths.wrapperPath).", info: true)
             }
             else {
-                let why = errDict?["NSAppleScriptErrorMessage"] as? String ?? "AppleScript failed"
+                let why = errDict?["NSAppleScriptErrorMessage"] as? String ?? "AppleScript failed."
                 manualMsg(tmp: tmpURL.path, dest: paths.wrapperPath, why: why)
             }
         }


### PR DESCRIPTION
Names of models loaded in the model pool cache can be viewed within the menu bar app. Loaded models can be purged from cache directly from the menu.

### Changes
- Added `ModelCacheView` for menu
- Implemented publisher for model pool caches
- Refactor: Menu logic now defined in the `MenuDelegate`
- Refactor: Separate menu views
- Updated menu and alert strings for clarity

### Tests

- Passes `swift test`
- Command line builds with `swift build`
- Xcode project builds

### Files
- `—` `SwamaKit/MenuBarApp.swift`
- `+` `SwamaKit/AppDelegate.swift`
- `+` `SwamaKit/MenuDelegate.swift`
- `•` `SwamaApp.swift`
- `•` `SwamaKit/Model/ModelPool.swift`