### PR TITLE
Add index: Int to ResponseToolCall

### DIFF
--- a/swama/Sources/SwamaKit/Server/CompletionsHandler.swift
+++ b/swama/Sources/SwamaKit/Server/CompletionsHandler.swift
@@ -661,6 +661,14 @@ public enum CompletionsHandler {
         parameters: GenerateParameters,
         tools: [ToolSpec]? = nil
     ) async throws {
+        actor ToolCallCounter {
+            private var index = 0
+            func next() -> Int {
+                let current = index
+                index += 1
+                return current
+            }
+        }
         // Send SSE headers
         let headers = HTTPHeaders([
             ("Content-Type", "text/event-stream"),
@@ -697,6 +705,7 @@ public enum CompletionsHandler {
                     modelName: modelName,
                     tools: tools
                 )
+                let toolCallCounter = ToolCallCounter()
                 return try await runner.runChat(
                     userInput: userInput,
                     parameters: parameters,
@@ -724,25 +733,27 @@ public enum CompletionsHandler {
                             else {
                                 "{}"
                             }
-
-                        let toolCallDict: [String: Any] = [
-                            "id": "call_\(UUID().uuidString)",
-                            "type": "function",
-                            "function": [
-                                "name": toolCall.function.name,
-                                "arguments": argumentsJSON
-                            ]
-                        ]
-
-                        let toolCallDelta: [String: Any] = [
-                            "id": chunkId,
-                            "object": "chat.completion.chunk",
-                            "created": timestamp,
-                            "model": model,
-                            "choices": [["index": 0, "delta": ["tool_calls": [toolCallDict]],
-                                         "finish_reason": NSNull()]]
-                        ]
                         Task {
+                            let index = await toolCallCounter.next()
+                            let toolCallDict: [String: Any] = [
+                                "index": index,
+                                "id": "call_\(UUID().uuidString)",
+                                "type": "function",
+                                "function": [
+                                    "name": toolCall.function.name,
+                                    "arguments": argumentsJSON
+                                ]
+                            ]
+
+                            let toolCallDelta: [String: Any] = [
+                                "id": chunkId,
+                                "object": "chat.completion.chunk",
+                                "created": timestamp,
+                                "model": model,
+                                "choices": [["index": 0, "delta": ["tool_calls": [toolCallDict]],
+                                             "finish_reason": NSNull()]]
+                            ]
+
                             try? await writeSSEJSON(channel: channel, payload: toolCallDelta)
                         }
                     }

--- a/swama/Sources/SwamaKit/Server/CompletionsHandler.swift
+++ b/swama/Sources/SwamaKit/Server/CompletionsHandler.swift
@@ -205,11 +205,13 @@ public enum CompletionsHandler {
 
     /// OpenAI-compatible tool call structures for response
     public struct ResponseToolCall: Encodable, Decodable, Sendable {
+        let index: Int?
         let id: String
         let type: String
         let function: ResponseFunction
 
-        public init(id: String, type: String = "function", function: ResponseFunction) {
+        public init(index: Int = 0, id: String, type: String = "function", function: ResponseFunction) {
+            self.index = index
             self.id = id
             self.type = type
             self.function = function
@@ -217,6 +219,7 @@ public enum CompletionsHandler {
 
         public init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
+            index = try container.decodeIfPresent(Int.self, forKey: .index)
             id = try container.decode(String.self, forKey: .id)
             type = try container.decode(String.self, forKey: .type)
             function = try container.decode(ResponseFunction.self, forKey: .function)
@@ -578,7 +581,7 @@ public enum CompletionsHandler {
         let completionTokens = result.completionInfo?.generationTokenCount ?? 0
 
         // Convert MLX ToolCalls to OpenAI format
-        let toolCalls: [ResponseToolCall]? = result.toolCalls.isEmpty ? nil : result.toolCalls.compactMap { toolCall in
+        let toolCalls: [ResponseToolCall]? = result.toolCalls.isEmpty ? nil : result.toolCalls.enumerated().compactMap { index, toolCall in
             let argumentsDict = toolCall.function.arguments.mapValues { $0.anyValue }
             let argumentsJSON: String =
                 if let jsonData = try? JSONSerialization.data(withJSONObject: argumentsDict),
@@ -590,6 +593,7 @@ public enum CompletionsHandler {
                 }
 
             return ResponseToolCall(
+                index: index,
                 id: "call_\(UUID().uuidString)",
                 type: "function",
                 function: ResponseFunction(


### PR DESCRIPTION
Per OpenAI spec, the tool call response must have an "index" field with integer type. This adds an auto-incrementing index to tool_calls.

This fixes compatibility with OpenCode and possibly other clients.