### PR TITLE
Pass through sampling params the engine already supports

### DIFF
--- a/swama/Sources/SwamaKit/Server/CompletionsHandler.swift
+++ b/swama/Sources/SwamaKit/Server/CompletionsHandler.swift
@@ -21,6 +21,12 @@ public enum CompletionsHandler {
         let messages: [Message]
         let temperature: Float?
         let top_p: Float?
+        let top_k: Int?
+        let min_p: Float?
+        let repetition_penalty: Float?
+        let repetition_context_size: Int?
+        let presence_penalty: Float?
+        let frequency_penalty: Float?
         let max_tokens: Int?
         let stream: Bool?
         let tools: [Tool]?
@@ -420,11 +426,7 @@ public enum CompletionsHandler {
             // Convert messages to MLX Chat.Message format
             let chatMessages = try convertToMLXChatMessages(payload.messages)
 
-            let parameters = GenerateParameters(
-                maxTokens: payload.max_tokens,
-                temperature: payload.temperature ?? 0.6,
-                topP: payload.top_p ?? 1.0
-            )
+            let parameters = generateParameters(from: payload)
 
             // Convert tools to MLX ToolSpec format once here
             let tools: [ToolSpec]? = convertToolsToMLX(payload.tools)
@@ -845,6 +847,22 @@ public enum CompletionsHandler {
 
         let jsonData = try JSONSerialization.data(withJSONObject: errorJSON)
         try await sendFullResponse(channel: channel, data: jsonData, status: status, version: .http1_1)
+    }
+
+    /// Maps request sampling fields onto the engine's `GenerateParameters`,
+    /// falling back to the engine defaults when a field is absent.
+    static func generateParameters(from payload: CompletionRequest) -> GenerateParameters {
+        GenerateParameters(
+            maxTokens: payload.max_tokens,
+            temperature: payload.temperature ?? 0.6,
+            topP: payload.top_p ?? 1.0,
+            topK: payload.top_k ?? 0,
+            minP: payload.min_p ?? 0.0,
+            repetitionPenalty: payload.repetition_penalty,
+            repetitionContextSize: payload.repetition_context_size ?? 20,
+            presencePenalty: payload.presence_penalty,
+            frequencyPenalty: payload.frequency_penalty
+        )
     }
 
     private static func parsePayload(_ buffer: ByteBuffer?) -> CompletionRequest? {

--- a/swama/Tests/SwamaKitTests/CompletionsHandlerTests.swift
+++ b/swama/Tests/SwamaKitTests/CompletionsHandlerTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+@preconcurrency import MLXLMCommon
 import NIOCore
 import NIOHTTP1
 @testable import SwamaKit
@@ -83,6 +84,80 @@ final class CompletionsHandlerTests {
 
         #expect(payload != nil)
         #expect(payload?.messages.isEmpty == true)
+    }
+
+    // MARK: - Sampling Parameter Tests
+
+    private func createSamplingCompletionRequest() -> Data {
+        let request: [String: Any] = [
+            "model": "test-model",
+            "messages": [
+                [
+                    "role": "user",
+                    "content": "Hello, world!"
+                ]
+            ],
+            "top_k": 40,
+            "min_p": 0.05,
+            "repetition_penalty": 1.15,
+            "repetition_context_size": 64,
+            "presence_penalty": 0.5,
+            "frequency_penalty": 0.3
+        ]
+        return try! JSONSerialization.data(withJSONObject: request)
+    }
+
+    @Test func parseSamplingParameters() {
+        let requestData = createSamplingCompletionRequest()
+        let buffer = ByteBuffer(bytes: requestData)
+
+        let payload = CompletionsHandler.parsePayload(buffer)
+
+        #expect(payload != nil)
+        #expect(payload?.top_k == 40)
+        #expect(payload?.min_p == 0.05)
+        #expect(payload?.repetition_penalty == 1.15)
+        #expect(payload?.repetition_context_size == 64)
+        #expect(payload?.presence_penalty == 0.5)
+        #expect(payload?.frequency_penalty == 0.3)
+    }
+
+    @Test func samplingParametersMapToGenerateParameters() throws {
+        let requestData = createSamplingCompletionRequest()
+        let buffer = ByteBuffer(bytes: requestData)
+
+        let payload = try #require(CompletionsHandler.parsePayload(buffer))
+        let parameters = CompletionsHandler.generateParameters(from: payload)
+
+        #expect(parameters.topK == 40)
+        #expect(parameters.minP == 0.05)
+        #expect(parameters.repetitionPenalty == 1.15)
+        #expect(parameters.repetitionContextSize == 64)
+        #expect(parameters.presencePenalty == 0.5)
+        #expect(parameters.frequencyPenalty == 0.3)
+    }
+
+    @Test func absentSamplingParametersKeepEngineDefaults() throws {
+        let requestData = createValidCompletionRequest()
+        let buffer = ByteBuffer(bytes: requestData)
+
+        let payload = try #require(CompletionsHandler.parsePayload(buffer))
+        #expect(payload.top_k == nil)
+        #expect(payload.min_p == nil)
+        #expect(payload.repetition_penalty == nil)
+        #expect(payload.repetition_context_size == nil)
+        #expect(payload.presence_penalty == nil)
+        #expect(payload.frequency_penalty == nil)
+
+        let parameters = CompletionsHandler.generateParameters(from: payload)
+        let defaults = GenerateParameters()
+
+        #expect(parameters.topK == defaults.topK)
+        #expect(parameters.minP == defaults.minP)
+        #expect(parameters.repetitionPenalty == defaults.repetitionPenalty)
+        #expect(parameters.repetitionContextSize == defaults.repetitionContextSize)
+        #expect(parameters.presencePenalty == defaults.presencePenalty)
+        #expect(parameters.frequencyPenalty == defaults.frequencyPenalty)
     }
 
     // MARK: - Message Content Tests


### PR DESCRIPTION
Fixes #118.

### Problem

The `/v1/chat/completions` handler decodes only `temperature` and `top_p`; every other sampling field in a request body is silently dropped. The engine (`MLXLMCommon.GenerateParameters`) supports several more, and the CLI already exposes `--repetition-penalty` — so the server transport was the only place these knobs didn't exist. Clients sending OpenAI-standard `presence_penalty`/`frequency_penalty` (or the widely used `top_k`/`min_p`/`repetition_penalty`) got default sampling with no indication anything was ignored.

### Fix

- `CompletionRequest` decodes six new optional fields with their ecosystem names (as accepted by vLLM, llama.cpp server, and mlx-lm's HTTP server): `top_k`, `min_p`, `repetition_penalty`, `repetition_context_size`, `presence_penalty`, `frequency_penalty`.
- They map onto `GenerateParameters` in a small helper (`generateParameters(from:)`), shared by the stream and non-stream paths. Absent fields keep the exact defaults used before, so existing requests behave identically.

### Tests

- `parseSamplingParameters` — the new fields decode from a request body.
- `samplingParametersMapToGenerateParameters` — decoded payload maps onto the right `GenerateParameters` values.
- `absentSamplingParametersKeepEngineDefaults` — a request without the new fields produces the engine's own defaults, pinned against `GenerateParameters()` itself.

`swift build` and `swift test` pass (54 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
