### PR TITLE
Add prompt/KV-cache reuse for the chat completions path

### DIFF
--- a/swama/Sources/SwamaKit/Config/PromptCacheConfig.swift
+++ b/swama/Sources/SwamaKit/Config/PromptCacheConfig.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Whether the OpenAI-compatible chat path reuses KV-cache state between requests on the same
+/// model (longest-common-prefix restore against `PromptCacheStore`, suffix-only prefill).
+///
+/// On by default. Set `SWAMA_PROMPT_CACHE=0` to force every request through the uncached
+/// full-prefill path -- an escape hatch for A/B latency comparisons, or to rule out a
+/// cache-related issue in the field without a redeploy. The environment is re-read on every
+/// access (rather than cached once at process start) so the switch can be toggled within a
+/// single process, which is also what lets it be exercised directly in tests; the cost is one
+/// dictionary lookup per chat request, not per token.
+public enum PromptCacheConfig {
+    public static var isEnabled: Bool {
+        ProcessInfo.processInfo.environment["SWAMA_PROMPT_CACHE"] != "0"
+    }
+}

--- a/swama/Sources/SwamaKit/Model/ModelPool.swift
+++ b/swama/Sources/SwamaKit/Model/ModelPool.swift
@@ -420,6 +420,7 @@ public actor ModelPool {
         modelTypeCache.removeAll() // Clear type cache too
         vlmRegistryCache = nil // Reset VLM registry cache
         embeddingRunnerCache.removeAll() // Clear embedding cache
+        PromptCacheStore.shared.dropAll() // Clear prompt/KV-cache slots
         sttRunnerCache.removeAll() // Clear speech-to-text cache
         ttsRunnerCache.removeAll() // Clear TTS cache
         modelUsageInfo.removeAll() // Clear usage tracking
@@ -467,6 +468,7 @@ public actor ModelPool {
         cache.removeValue(forKey: modelName)
         modelTypeCache.removeValue(forKey: modelName) // Clear type cache for this model
         embeddingRunnerCache.removeValue(forKey: modelName) // Clear embedding cache for this model
+        PromptCacheStore.shared.drop(modelName: modelName) // Clear prompt/KV-cache slot for this model
         sttRunnerCache.removeValue(forKey: modelName) // Clear speech-to-text cache for this model
         ttsRunnerCache.removeValue(forKey: modelName) // Clear TTS cache for this model
         modelUsageInfo.removeValue(forKey: modelName) // Clear usage tracking for this model
@@ -956,6 +958,7 @@ public actor ModelPool {
         cache.removeValue(forKey: modelName)
         modelTypeCache.removeValue(forKey: modelName)
         embeddingRunnerCache.removeValue(forKey: modelName)
+        PromptCacheStore.shared.drop(modelName: modelName)
         sttRunnerCache.removeValue(forKey: modelName)
         ttsRunnerCache.removeValue(forKey: modelName)
         modelUsageInfo.removeValue(forKey: modelName)

--- a/swama/Sources/SwamaKit/Model/ModelRunner.swift
+++ b/swama/Sources/SwamaKit/Model/ModelRunner.swift
@@ -135,6 +135,7 @@ public actor ModelRunner {
             }
 
             let maxKVSize = generationParameters.maxKVSize ?? effectiveContextLimit
+            let kvConfig = PromptCacheKVConfig(parameters: generationParameters, maxKVSize: maxKVSize)
             let modelName = await container.configuration.name
             let fullTokens = promptCacheTokenArray(lmInput.text.tokens)
 
@@ -143,16 +144,56 @@ public actor ModelRunner {
                 hasMediaInput: hasMediaInput,
                 modelName: modelName,
                 newTokens: fullTokens,
-                maxKVSize: maxKVSize,
+                kvConfig: kvConfig,
                 store: promptCacheStore
             )
 
+            // `resolvePromptCacheReuse` cannot see `generationParameters` at all, so it has no way
+            // to know whether a `.reuse` it just returned would actually need
+            // `FullHistoryLogitProcessor` wrapped around a processor that also wants a quantized
+            // KV cache -- the one combination no `TokenIterator` initializer can honour correctly
+            // (see `PromptCacheIteratorStrategy.bypass`). Override that specific case to an
+            // equivalent `.miss` here, once, so both the switch below and the log line after it
+            // agree on the same effective decision without duplicating this check.
+            let effectiveCacheDecision: PromptCacheResolution =
+                if case let .reuse(_, _, _, epoch) = cacheDecision,
+                promptCacheIteratorStrategy(
+                    needsFullHistoryWrapper: true,
+                    hasPenaltyProcessor: generationParameters.processor() != nil,
+                    kvBits: generationParameters.kvBits
+                ) == .bypass {
+                    .miss(reason: .kvQuantizationUnsupported, epoch: epoch)
+                }
+                else {
+                    cacheDecision
+                }
+
+            // Captured up front (before generation starts) on every path that will ever write a
+            // slot back -- `nil` only for `.disabled`/`.multimodal`, which never touch the store
+            // at all. `resolvePromptCacheReuse` already captured this from `checkout` (reuse,
+            // and the checked-out-but-rejected miss reasons) or `currentEpoch` (`.noSlot`); see
+            // `PromptCacheEpoch`'s doc comment for why it has to be this early.
+            let cacheEpoch: PromptCacheEpoch? =
+                switch effectiveCacheDecision {
+                case let .reuse(_, _, _, epoch):
+                    epoch
+                case let .miss(_, epoch):
+                    epoch
+                }
+
             let run: PromptCacheGenerationRun = try await container.perform { context in
-                switch cacheDecision {
-                case .miss(.disabled), .miss(.multimodal):
-                    // Cache untouched -- feature off, or bypassed for multimodal content (image
-                    // embeddings aren't in the token sequence a KV cache indexes by). This is
-                    // today's path exactly, unchanged from before this feature existed.
+                switch effectiveCacheDecision {
+                case .miss(.disabled, _),
+                     .miss(.kvQuantizationUnsupported, _),
+                     .miss(.multimodal, _):
+                    // Cache untouched (feature off, or bypassed for multimodal content -- image
+                    // embeddings aren't in the token sequence a KV cache indexes by), or a cache
+                    // hit we've deliberately declined to reuse because its full-history wrapper
+                    // would silently drop the caller's KV-quantization settings
+                    // (.kvQuantizationUnsupported). In every one of these cases, any slot
+                    // `resolvePromptCacheReuse` already checked out is simply never checked back
+                    // in below (`run.cache` is `nil` here), exactly like every other
+                    // rejected-but-checked-out miss reason.
                     let stream = try generate(
                         input: lmInput,
                         parameters: generationParameters,
@@ -160,7 +201,7 @@ public actor ModelRunner {
                     )
                     return PromptCacheGenerationRun(stream: stream, task: nil, cache: nil, prefillMs: nil)
 
-                case let .reuse(matchedLength, reusedCache, _):
+                case let .reuse(matchedLength, reusedCache, _, _):
                     // Cache hit: feed only the unmatched suffix, but prime the penalty
                     // processors with the FULL history (not just the suffix), or their windowed
                     // state would silently diverge from the uncached baseline.
@@ -174,7 +215,7 @@ public actor ModelRunner {
                     )
 
                 case .miss:
-                    // A cacheable miss (no prior slot, mismatch, rotated, or a maxKVSize change):
+                    // A cacheable miss (no prior slot, mismatch, rotated, or a KV config change):
                     // full prefill on a fresh cache, captured so it can be stored for next turn.
                     let freshCache = context.model.newCache(parameters: generationParameters)
                     return try buildPromptCacheGenerationRun(
@@ -188,7 +229,7 @@ public actor ModelRunner {
             }
 
             logPromptCacheDecision(
-                decision: cacheDecision,
+                decision: effectiveCacheDecision,
                 promptTokens: promptTokens,
                 prefillMs: run.prefillMs
             )
@@ -247,14 +288,18 @@ public actor ModelRunner {
             // Only ever store on a clean, uncancelled, unthrown completion: on any abort the slot
             // stays absent (it was already removed from the store by `checkout` inside
             // `resolvePromptCacheReuse`, or was never created for a fresh miss), never
-            // half-written.
-            if let cache = run.cache, thrownError == nil, !Task.isCancelled {
+            // half-written. `cacheEpoch` is non-nil whenever `run.cache` is (see the comment
+            // where it's captured above); binding it alongside the `run.cache` check rather than
+            // asserting that pairing means a future divergence skips the store instead of
+            // trapping.
+            if let cache = run.cache, let cacheEpoch, thrownError == nil, Task.isCancelled == false {
                 storePromptCacheIfReusable(
                     cache: cache,
                     fullTokens: fullTokens,
                     promptTokenCount: promptTokens,
-                    maxKVSize: maxKVSize,
+                    kvConfig: kvConfig,
                     modelName: modelName,
+                    epoch: cacheEpoch,
                     store: promptCacheStore
                 )
             }
@@ -520,7 +565,7 @@ private func tokenLength(_ tokens: MLXArray) -> Int {
     }
 }
 
-// MARK: - Prompt-cache integration
+// MARK: - PromptCacheGenerationRun
 
 /// One generation attempt's stream/task/cache, as built inside `container.perform` and consumed
 /// back in `runChat` after crossing the actor boundary.
@@ -540,6 +585,8 @@ private struct PromptCacheGenerationRun: @unchecked Sendable {
     let cache: [KVCache]?
     let prefillMs: Double?
 }
+
+// MARK: - FullHistoryLogitProcessor
 
 /// Wraps a `LogitProcessor` so `TokenIterator.prepare`'s call to `processor?.prompt(...)` --
 /// which only sees the tokens actually fed to this iterator, i.e. the cache-hit suffix -- is
@@ -565,10 +612,86 @@ private struct FullHistoryLogitProcessor: LogitProcessor {
     }
 }
 
-/// Builds a `TokenIterator` (applying, on a cache hit, the full-history processor
-/// wrapper) and starts it via `generateTask`, capturing the `Task` so the caller can await it
-/// before ever touching `cache` again -- unlike `generate(input:cache:parameters:context:)`,
-/// which starts the same task but discards the handle.
+// MARK: - PromptCacheIteratorError
+
+/// Thrown when `buildPromptCacheGenerationRun` is reached in a state its
+/// `PromptCacheIteratorStrategy` says cannot happen -- `runChat` routes `.bypass` to the ordinary
+/// uncached path before ever calling it, and `.processorWrapper` is only ever returned when both
+/// a processor and a full history exist to wrap.
+///
+/// This is deliberately a thrown error rather than a `preconditionFailure`: swama is a long-lived
+/// server, and a future refactor that broke the invariant should fail this one request (the
+/// caller already surfaces a thrown error as a failed completion) rather than take the whole
+/// daemon down with every other in-flight request. Silently falling back to the parameters
+/// initializer is not an option -- that would drop the caller's KV-quantization settings, exactly
+/// what this fix exists to prevent.
+enum PromptCacheIteratorError: Error {
+    case unreachableStrategy(PromptCacheIteratorStrategy)
+}
+
+// MARK: - PromptCacheIteratorStrategy
+
+/// Which `TokenIterator` initializer `buildPromptCacheGenerationRun` should use for one
+/// generation attempt. Factored out as a pure function of three plain values (rather than
+/// asserted on a constructed `TokenIterator`, whose `kvBits`/`kvGroupSize`/`quantizedKVStart` are
+/// internal `let`s not visible from SwamaKit at all) so the initializer-selection decision itself
+/// is directly unit-testable, independent of MLX/model machinery.
+enum PromptCacheIteratorStrategy: Equatable {
+    /// `TokenIterator(input:model:cache:parameters:)` -- kvBits/kvGroupSize/quantizedKVStart are
+    /// honoured because this initializer reads them directly off `GenerateParameters`. Used
+    /// whenever no full-history wrapper is needed at all: every cacheable-miss path (`iterInput`
+    /// already *is* the full prompt) and any cache hit whose `GenerateParameters` yield no
+    /// penalty processor (there is nothing for `FullHistoryLogitProcessor` to wrap).
+    case parameters
+
+    /// `TokenIterator(input:model:cache:processor:sampler:prefillStepSize:maxTokens:)` with a
+    /// `FullHistoryLogitProcessor`-wrapped processor -- a cache hit with a penalty processor,
+    /// where the wrapper is required to re-prime penalty state with the full conversation
+    /// history rather than just the unmatched suffix. Safe only because this overload's
+    /// hardcoded `kvBits: nil` is indistinguishable from what an unset `kvBits` would have
+    /// produced via the other initializer: `maybeQuantizeKVCache` is already a no-op whenever
+    /// `kvBits == nil`, regardless of `kvGroupSize`/`quantizedKVStart` -- see `.bypass` for the
+    /// case where that is *not* true.
+    case processorWrapper
+
+    /// Neither initializer can correctly serve this request: a cache hit needs the full-history
+    /// wrapper (a penalty processor is configured) *and* the caller wants a quantized KV cache
+    /// (`kvBits != nil`), but the only initializer that accepts a custom processor hardcodes
+    /// `kvBits: nil` and cannot be told otherwise -- and the initializer that does honour
+    /// `kvBits` does not accept a custom processor. There is no combination of the two upstream
+    /// initializers that satisfies both requirements at once, so the caller must not build a
+    /// `TokenIterator` here at all: decline this cache hit and fall back to an ordinary,
+    /// uncached prefill for this one request instead (see
+    /// `PromptCacheMissReason.kvQuantizationUnsupported`).
+    case bypass
+}
+
+/// Pure decision function backing `PromptCacheIteratorStrategy`.
+///
+/// - Parameters:
+///   - needsFullHistoryWrapper: `true` on a cache hit (`iterInput` is only the unmatched
+///     suffix, so a penalty processor needs `FullHistoryLogitProcessor` to see the full
+///     history); `false` on a miss, where `iterInput` already is the full prompt.
+///   - hasPenaltyProcessor: whether `generationParameters.processor()` returned non-nil --
+///     i.e. whether there is anything to wrap in the first place.
+///   - kvBits: `generationParameters.kvBits`, forwarded as-is.
+func promptCacheIteratorStrategy(
+    needsFullHistoryWrapper: Bool,
+    hasPenaltyProcessor: Bool,
+    kvBits: Int?
+) -> PromptCacheIteratorStrategy {
+    guard needsFullHistoryWrapper, hasPenaltyProcessor else {
+        return .parameters
+    }
+
+    return kvBits == nil ? .processorWrapper : .bypass
+}
+
+/// Builds a `TokenIterator` (applying, on a cache hit with a penalty processor, the full-history
+/// wrapper -- see `PromptCacheIteratorStrategy`) and starts it via `generateTask`, capturing the
+/// `Task` so the caller can await it before ever touching `cache` again -- unlike
+/// `generate(input:cache:parameters:context:)`, which starts the same task but discards the
+/// handle.
 ///
 /// - Parameter fullHistory: the full post-template token sequence to prime penalty
 ///   processors with, when non-nil (a cache hit, where `iterInput` is only the unmatched
@@ -582,25 +705,49 @@ private func buildPromptCacheGenerationRun(
     generationParameters: GenerateParameters
 ) throws -> PromptCacheGenerationRun {
     let baseProcessor: LogitProcessor? = generationParameters.processor()
-
-    let processor: LogitProcessor?
-    if let fullHistory, let baseProcessor {
-        processor = FullHistoryLogitProcessor(inner: baseProcessor, fullHistory: fullHistory)
-    }
-    else {
-        processor = baseProcessor
-    }
+    let strategy = promptCacheIteratorStrategy(
+        needsFullHistoryWrapper: fullHistory != nil,
+        hasPenaltyProcessor: baseProcessor != nil,
+        kvBits: generationParameters.kvBits
+    )
 
     let prefillStart = Date()
-    let iterator = try TokenIterator(
-        input: iterInput,
-        model: context.model,
-        cache: cache,
-        processor: processor,
-        sampler: generationParameters.sampler(),
-        prefillStepSize: generationParameters.prefillStepSize,
-        maxTokens: generationParameters.maxTokens
-    )
+    let iterator: TokenIterator
+    switch strategy {
+    case .parameters:
+        iterator = try TokenIterator(
+            input: iterInput,
+            model: context.model,
+            cache: cache,
+            parameters: generationParameters
+        )
+
+    case .processorWrapper:
+        guard let baseProcessor, let fullHistory else {
+            throw PromptCacheIteratorError.unreachableStrategy(.processorWrapper)
+        }
+
+        let wrappedProcessor = FullHistoryLogitProcessor(inner: baseProcessor, fullHistory: fullHistory)
+        iterator = try TokenIterator(
+            input: iterInput,
+            model: context.model,
+            cache: cache,
+            processor: wrappedProcessor,
+            sampler: generationParameters.sampler(),
+            prefillStepSize: generationParameters.prefillStepSize,
+            maxTokens: generationParameters.maxTokens
+        )
+
+    case .bypass:
+        // Unreachable: `runChat` already rewrites a `.bypass` decision to
+        // `.miss(.kvQuantizationUnsupported, _)` before ever entering the branch that calls this
+        // function (see the `effectiveCacheDecision` override in `runChat`), so this function is
+        // only ever invoked for `.parameters`/`.processorWrapper`. Failing loudly rather than
+        // silently falling back to `.parameters` keeps this file's "assert, don't assume"
+        // register -- see `promptCacheLayerIsReusable`'s rotation guard -- without crashing a
+        // long-lived server (see `PromptCacheIteratorError`).
+        throw PromptCacheIteratorError.unreachableStrategy(.bypass)
+    }
     let prefillMs = Date().timeIntervalSince(prefillStart) * 1000
 
     let (stream, task) = generateTask(
@@ -629,10 +776,11 @@ private func logPromptCacheDecision(
     let cachedPrefix: Int
     let reason: PromptCacheMissReason?
     switch decision {
-    case let .reuse(matchedLength, _, reuseReason):
+    case let .reuse(matchedLength, _, reuseReason, _):
         cachedPrefix = matchedLength
         reason = reuseReason
-    case let .miss(missReason):
+
+    case let .miss(missReason, _):
         cachedPrefix = 0
         reason = missReason
     }
@@ -648,13 +796,16 @@ private func logPromptCacheDecision(
 /// After a generation completes cleanly, trims `cache` back down to exactly the prompt tokens
 /// (discarding the tokens generated during this turn -- see the plan's "what's in the cache
 /// after generation" note) and stores it for the next turn, unless rotation makes it unsafe to
-/// reuse, in which case the slot is simply not written and the miss is logged for diagnosability.
+/// reuse, or `epoch` has been invalidated by a `drop(modelName:)`/`dropAll()` that ran while this
+/// generation was in flight (see `PromptCacheEpoch`), in which case the slot is simply not
+/// written and the miss is logged for diagnosability.
 private func storePromptCacheIfReusable(
     cache: [KVCache],
     fullTokens: [Int],
     promptTokenCount: Int,
-    maxKVSize: Int,
+    kvConfig: PromptCacheKVConfig,
     modelName: String,
+    epoch: PromptCacheEpoch,
     store: PromptCacheStore
 ) {
     guard promptCacheIsReusable(cache) else {
@@ -668,8 +819,14 @@ private func storePromptCacheIfReusable(
         layer.trim(layer.offset - promptTokenCount)
     }
 
-    store.checkin(
+    let stored = store.checkin(
         modelName: modelName,
-        slot: PromptCacheSlot(tokens: fullTokens, cache: cache, maxKVSize: maxKVSize)
+        slot: PromptCacheSlot(tokens: fullTokens, cache: cache, kvConfig: kvConfig),
+        epoch: epoch
     )
+    if stored == false {
+        modelRunnerLogger.info(
+            "prompt_cache store skipped model=\(modelName, privacy: .public) reason=\(PromptCacheMissReason.invalidated.rawValue, privacy: .public)"
+        )
+    }
 }

--- a/swama/Sources/SwamaKit/Model/ModelRunner.swift
+++ b/swama/Sources/SwamaKit/Model/ModelRunner.swift
@@ -33,8 +33,11 @@ public actor ModelRunner {
 
     // MARK: Lifecycle
 
-    public init(container: ModelContainer) {
+    /// - Parameter promptCacheStore: defaults to the process-wide singleton; overridable so
+    ///   tests can inject an isolated store instead of sharing global state.
+    public init(container: ModelContainer, promptCacheStore: PromptCacheStore = .shared) {
         self.container = container
+        self.promptCacheStore = promptCacheStore
     }
 
     // MARK: Public
@@ -131,46 +134,133 @@ public actor ModelRunner {
                 )
             }
 
-            let generationStream = try await container.perform { context in
-                try generate(
-                    input: lmInput,
-                    parameters: generationParameters,
-                    context: context
-                )
+            let maxKVSize = generationParameters.maxKVSize ?? effectiveContextLimit
+            let modelName = await container.configuration.name
+            let fullTokens = promptCacheTokenArray(lmInput.text.tokens)
+
+            let cacheDecision = resolvePromptCacheReuse(
+                enabled: PromptCacheConfig.isEnabled,
+                hasMediaInput: hasMediaInput,
+                modelName: modelName,
+                newTokens: fullTokens,
+                maxKVSize: maxKVSize,
+                store: promptCacheStore
+            )
+
+            let run: PromptCacheGenerationRun = try await container.perform { context in
+                switch cacheDecision {
+                case .miss(.disabled), .miss(.multimodal):
+                    // Cache untouched -- feature off, or bypassed for multimodal content (image
+                    // embeddings aren't in the token sequence a KV cache indexes by). This is
+                    // today's path exactly, unchanged from before this feature existed.
+                    let stream = try generate(
+                        input: lmInput,
+                        parameters: generationParameters,
+                        context: context
+                    )
+                    return PromptCacheGenerationRun(stream: stream, task: nil, cache: nil, prefillMs: nil)
+
+                case let .reuse(matchedLength, reusedCache, _):
+                    // Cache hit: feed only the unmatched suffix, but prime the penalty
+                    // processors with the FULL history (not just the suffix), or their windowed
+                    // state would silently diverge from the uncached baseline.
+                    let suffixInput = LMInput(tokens: MLXArray(Array(fullTokens[matchedLength...])))
+                    return try buildPromptCacheGenerationRun(
+                        iterInput: suffixInput,
+                        cache: reusedCache,
+                        fullHistory: lmInput.text.tokens,
+                        context: context,
+                        generationParameters: generationParameters
+                    )
+
+                case .miss:
+                    // A cacheable miss (no prior slot, mismatch, rotated, or a maxKVSize change):
+                    // full prefill on a fresh cache, captured so it can be stored for next turn.
+                    let freshCache = context.model.newCache(parameters: generationParameters)
+                    return try buildPromptCacheGenerationRun(
+                        iterInput: lmInput,
+                        cache: freshCache,
+                        fullHistory: nil,
+                        context: context,
+                        generationParameters: generationParameters
+                    )
+                }
             }
 
-            for await generationEvent in generationStream {
+            logPromptCacheDecision(
+                decision: cacheDecision,
+                promptTokens: promptTokens,
+                prefillMs: run.prefillMs
+            )
+
+            var thrownError: Error?
+            for await generationEvent in run.stream {
                 if Task.isCancelled {
                     break
                 }
 
-                switch generationEvent {
-                case let .chunk(chunkString):
-                    rawOutputStorage.append(chunkString)
+                do {
+                    switch generationEvent {
+                    case let .chunk(chunkString):
+                        rawOutputStorage.append(chunkString)
 
-                    if let onToken {
-                        // Awaited (and fully written) before the next generation event is
-                        // processed, so writes land on the channel in generation order and are
-                        // guaranteed drained by the time this call returns; a failed write
-                        // throws here and stops generation.
-                        try await onToken(chunkString)
-                    }
-                    else {
-                        // Only accumulate if no onToken callback (for non-streaming)
-                        output += chunkString
-                    }
+                        if let onToken {
+                            // Awaited (and fully written) before the next generation event is
+                            // processed, so writes land on the channel in generation order and are
+                            // guaranteed drained by the time this call returns; a failed write
+                            // throws here and stops generation.
+                            try await onToken(chunkString)
+                        }
+                        else {
+                            // Only accumulate if no onToken callback (for non-streaming)
+                            output += chunkString
+                        }
 
-                case let .info(info):
-                    capturedCompletionInfo = info
+                    case let .info(info):
+                        capturedCompletionInfo = info
 
-                case let .toolCall(toolCall):
-                    // Always accumulate tool calls for the return value
-                    toolCalls.append(toolCall)
-                    // Also send to callback if provided (for streaming)
-                    if let onToolCall {
-                        try await onToolCall(toolCall)
+                    case let .toolCall(toolCall):
+                        // Always accumulate tool calls for the return value
+                        toolCalls.append(toolCall)
+                        // Also send to callback if provided (for streaming)
+                        if let onToolCall {
+                            try await onToolCall(toolCall)
+                        }
                     }
                 }
+                catch {
+                    thrownError = error
+                    break
+                }
+            }
+
+            // Whether the loop above finished normally, broke on cancellation, or broke on a
+            // thrown error, the background generation task may still be touching the cache for a
+            // few more ms (see `generateTask`'s doc comment). Await it before this function either
+            // stores the cache or returns/rethrows, exactly as ChatSession does -- this is also
+            // what makes it safe for the very next request on this model (ModelPool.run serializes
+            // by model name) to start touching the same cache/weights right after this returns.
+            if let task = run.task {
+                await task.value
+            }
+
+            // Only ever store on a clean, uncancelled, unthrown completion: on any abort the slot
+            // stays absent (it was already removed from the store by `checkout` inside
+            // `resolvePromptCacheReuse`, or was never created for a fresh miss), never
+            // half-written.
+            if let cache = run.cache, thrownError == nil, !Task.isCancelled {
+                storePromptCacheIfReusable(
+                    cache: cache,
+                    fullTokens: fullTokens,
+                    promptTokenCount: promptTokens,
+                    maxKVSize: maxKVSize,
+                    modelName: modelName,
+                    store: promptCacheStore
+                )
+            }
+
+            if let thrownError {
+                throw thrownError
             }
 
             let rawOutput = rawOutputStorage.consume()
@@ -192,6 +282,7 @@ public actor ModelRunner {
     // MARK: Private
 
     private let container: ModelContainer
+    private let promptCacheStore: PromptCacheStore
 }
 
 // MARK: - RawOutputBuffer
@@ -427,4 +518,158 @@ private func tokenLength(_ tokens: MLXArray) -> Int {
     default:
         tokens.dim(-1)
     }
+}
+
+// MARK: - Prompt-cache integration
+
+/// One generation attempt's stream/task/cache, as built inside `container.perform` and consumed
+/// back in `runChat` after crossing the actor boundary.
+///
+/// `task` and `cache` are `nil` together on the two paths that never touch `PromptCacheStore` at
+/// all (`SWAMA_PROMPT_CACHE=0`, and multimodal requests, which bypass the cache entirely): those
+/// keep calling `generate(input:parameters:context:)` exactly as before this feature existed, so
+/// there is no task to await or cache to store. Whenever `cache` is non-nil, `task` is too --
+/// `runChat` awaits it before ever touching `cache`, exactly as `ChatSession` does.
+///
+/// `@unchecked Sendable`: `cache` (when present) is `[KVCache]`, a mutable, non-Sendable MLX
+/// type; safety comes from this value being built once inside `container.perform` and consumed
+/// exactly once back in `runChat`, never shared concurrently.
+private struct PromptCacheGenerationRun: @unchecked Sendable {
+    let stream: AsyncStream<Generation>
+    let task: Task<Void, Never>?
+    let cache: [KVCache]?
+    let prefillMs: Double?
+}
+
+/// Wraps a `LogitProcessor` so `TokenIterator.prepare`'s call to `processor?.prompt(...)` --
+/// which only sees the tokens actually fed to this iterator, i.e. the cache-hit suffix -- is
+/// redirected to the full post-template token history instead. Repetition/presence/frequency
+/// penalties must see the same history the uncached path would give them (in particular
+/// `RepetitionContext`'s ring buffer keeps only the last `repetitionContextSize` tokens of
+/// whatever it's primed with), or their windowed state silently diverges from the cache-off
+/// baseline the moment a request crosses the suffix boundary.
+private struct FullHistoryLogitProcessor: LogitProcessor {
+    var inner: LogitProcessor
+    let fullHistory: MLXArray
+
+    mutating func prompt(_: MLXArray) {
+        inner.prompt(fullHistory)
+    }
+
+    func process(logits: MLXArray) -> MLXArray {
+        inner.process(logits: logits)
+    }
+
+    mutating func didSample(token: MLXArray) {
+        inner.didSample(token: token)
+    }
+}
+
+/// Builds a `TokenIterator` (applying, on a cache hit, the full-history processor
+/// wrapper) and starts it via `generateTask`, capturing the `Task` so the caller can await it
+/// before ever touching `cache` again -- unlike `generate(input:cache:parameters:context:)`,
+/// which starts the same task but discards the handle.
+///
+/// - Parameter fullHistory: the full post-template token sequence to prime penalty
+///   processors with, when non-nil (a cache hit, where `iterInput` is only the unmatched
+///   suffix). `nil` on a miss, where `iterInput` already *is* the full prompt and needs no
+///   wrapper.
+private func buildPromptCacheGenerationRun(
+    iterInput: LMInput,
+    cache: [KVCache],
+    fullHistory: MLXArray?,
+    context: ModelContext,
+    generationParameters: GenerateParameters
+) throws -> PromptCacheGenerationRun {
+    let baseProcessor: LogitProcessor? = generationParameters.processor()
+
+    let processor: LogitProcessor?
+    if let fullHistory, let baseProcessor {
+        processor = FullHistoryLogitProcessor(inner: baseProcessor, fullHistory: fullHistory)
+    }
+    else {
+        processor = baseProcessor
+    }
+
+    let prefillStart = Date()
+    let iterator = try TokenIterator(
+        input: iterInput,
+        model: context.model,
+        cache: cache,
+        processor: processor,
+        sampler: generationParameters.sampler(),
+        prefillStepSize: generationParameters.prefillStepSize,
+        maxTokens: generationParameters.maxTokens
+    )
+    let prefillMs = Date().timeIntervalSince(prefillStart) * 1000
+
+    let (stream, task) = generateTask(
+        promptTokenCount: iterInput.text.tokens.size,
+        modelConfiguration: context.configuration,
+        tokenizer: context.tokenizer,
+        iterator: iterator
+    )
+
+    return PromptCacheGenerationRun(stream: stream, task: task, cache: cache, prefillMs: prefillMs)
+}
+
+/// Converts a token `MLXArray` (as produced by `container.prepare(input:)`) to a plain `[Int]`
+/// for prefix matching and slot storage.
+private func promptCacheTokenArray(_ tokens: MLXArray) -> [Int] {
+    tokens.asType(.int32).asArray(Int32.self).map(Int.init)
+}
+
+/// Logs the per-request prompt-cache metrics required for diagnosability: a silently-zero-hit
+/// cache should never look identical to a working one in the logs.
+private func logPromptCacheDecision(
+    decision: PromptCacheResolution,
+    promptTokens: Int,
+    prefillMs: Double?
+) {
+    let cachedPrefix: Int
+    let reason: PromptCacheMissReason?
+    switch decision {
+    case let .reuse(matchedLength, _, reuseReason):
+        cachedPrefix = matchedLength
+        reason = reuseReason
+    case let .miss(missReason):
+        cachedPrefix = 0
+        reason = missReason
+    }
+    let prefilledSuffix = promptTokens - cachedPrefix
+    let prefillDescription = prefillMs.map { String(format: "%.1f", $0) } ?? "n/a"
+    let reasonDescription = reason?.rawValue ?? "none"
+
+    modelRunnerLogger.info(
+        "prompt_cache prompt_tokens=\(promptTokens) cached_prefix=\(cachedPrefix) prefilled_suffix=\(prefilledSuffix) prefill_ms=\(prefillDescription, privacy: .public) reason=\(reasonDescription, privacy: .public)"
+    )
+}
+
+/// After a generation completes cleanly, trims `cache` back down to exactly the prompt tokens
+/// (discarding the tokens generated during this turn -- see the plan's "what's in the cache
+/// after generation" note) and stores it for the next turn, unless rotation makes it unsafe to
+/// reuse, in which case the slot is simply not written and the miss is logged for diagnosability.
+private func storePromptCacheIfReusable(
+    cache: [KVCache],
+    fullTokens: [Int],
+    promptTokenCount: Int,
+    maxKVSize: Int,
+    modelName: String,
+    store: PromptCacheStore
+) {
+    guard promptCacheIsReusable(cache) else {
+        modelRunnerLogger.info(
+            "prompt_cache store skipped model=\(modelName, privacy: .public) reason=\(PromptCacheMissReason.rotated.rawValue, privacy: .public)"
+        )
+        return
+    }
+
+    for layer in cache {
+        layer.trim(layer.offset - promptTokenCount)
+    }
+
+    store.checkin(
+        modelName: modelName,
+        slot: PromptCacheSlot(tokens: fullTokens, cache: cache, maxKVSize: maxKVSize)
+    )
 }

--- a/swama/Sources/SwamaKit/Model/PromptCacheStore.swift
+++ b/swama/Sources/SwamaKit/Model/PromptCacheStore.swift
@@ -46,8 +46,52 @@ public enum PromptCacheMissReason: String, Sendable {
     /// original sequence, so it cannot be reused at all.
     case rotated
 
-    /// The slot exists but was built with a different `maxKVSize` than this request wants.
+    /// The slot exists but was built with a different `PromptCacheKVConfig` than this request
+    /// wants -- `maxKVSize`, `kvBits`, `kvGroupSize`, or `quantizedKVStart` differs.
     case kvConfigChanged = "kv_config_changed"
+
+    /// This request's `PromptCacheEpoch` (captured at `checkout`, or at `currentEpoch` on a
+    /// miss) no longer matched the store's current epoch by the time the request tried to
+    /// check its slot back in -- `drop(modelName:)` or `dropAll()` ran while this request's
+    /// generation was still in flight. The freshly-built or reused-and-trimmed cache this
+    /// request produced is discarded rather than resurrecting state the store had already
+    /// invalidated (see `PromptCacheEpoch`).
+    case invalidated
+
+    /// A cache hit whose reuse would need `FullHistoryLogitProcessor` (a penalty processor is
+    /// configured, so the wrapper must re-prime it with the full history) together with a
+    /// caller-requested quantized KV cache (`GenerateParameters.kvBits != nil`). The
+    /// `TokenIterator` overload that accepts a custom processor hardcodes
+    /// `kvBits: nil`/`kvGroupSize: 64`/`quantizedKVStart: 0` and cannot be told otherwise --
+    /// those are internal `let`s, set only by the sibling initializer that derives them from
+    /// `GenerateParameters`, which does not itself accept a custom processor. Rather than
+    /// silently drop the caller's quantization request, `ModelRunner.runChat` declines this
+    /// cache hit entirely and falls back to an ordinary, uncached, fully-quantization-correct
+    /// prefill for this one request. See `PromptCacheIteratorStrategy.bypass`.
+    case kvQuantizationUnsupported = "kv_quantization_unsupported"
+}
+
+// MARK: - PromptCacheEpoch
+
+/// A snapshot of `PromptCacheStore`'s invalidation counters, captured up front (at `checkout` on
+/// a reuse attempt, or at `currentEpoch` on a miss) and re-checked at `checkin`.
+///
+/// This closes the race described on `ModelPool.clearCache()`'s call to `PromptCacheStore
+/// .shared.dropAll()`: `ModelPool.run` suspends while an inference is in flight, so
+/// `clearCache()`/`remove(modelName:)` can run -- and mutate the store -- while a still-running
+/// `ModelRunner` already holds (or is about to build) a slot for the very model being cleared.
+/// Without this token, that runner's eventual `checkin` would silently resurrect a slot the store
+/// had already dropped, undoing the clear/remove and leaking the resurrected slot's KV memory
+/// forever. `checkin` only stores when the token presented still equals the store's current one;
+/// otherwise the slot the caller built is simply discarded.
+///
+/// This is a supplement to, not a replacement for, the checkout-is-destructive discipline
+/// documented on `PromptCacheStore` itself: checkout still atomically removes a slot so at most
+/// one caller ever owns it, and the epoch only guards the additional window where the store was
+/// mutated *while* that caller held the slot (or, on a miss, before it wrote a fresh one back).
+public struct PromptCacheEpoch: Equatable, Sendable {
+    fileprivate let global: UInt64
+    fileprivate let perModel: UInt64
 }
 
 // MARK: - PromptCacheResolution
@@ -60,19 +104,65 @@ enum PromptCacheResolution: @unchecked Sendable {
     /// Reuse the cache starting at `matchedLength` tokens in (already capped so the caller has
     /// at least one suffix token to feed the `TokenIterator`, and already trimmed to that
     /// offset). `reason` is `.partialMismatch` when the match was shorter than the entire
-    /// cached prefix, `nil` for a clean full-prefix hit (a plain append).
-    case reuse(matchedLength: Int, cache: [KVCache], reason: PromptCacheMissReason?)
+    /// cached prefix, `nil` for a clean full-prefix hit (a plain append). `epoch` is the token
+    /// captured at the `checkout` that produced this slot -- carried by the caller all the way
+    /// through generation and presented back to `checkin`.
+    case reuse(matchedLength: Int, cache: [KVCache], reason: PromptCacheMissReason?, epoch: PromptCacheEpoch)
 
-    /// No reuse at all; the caller must prefill the full prompt.
-    case miss(reason: PromptCacheMissReason)
+    /// No reuse at all; the caller must prefill the full prompt. `epoch` is `nil` for
+    /// `.disabled`/`.multimodal`, which never touch the store at all (nothing will ever be
+    /// checked in for this request), and otherwise the token from `currentEpoch(modelName:)`
+    /// (`.noSlot`) or from the checkout that was attempted and rejected (`.kvConfigChanged`,
+    /// `.rotated`, `.mismatchAtZero`) -- in every case, captured before generation starts.
+    case miss(reason: PromptCacheMissReason, epoch: PromptCacheEpoch?)
+}
+
+// MARK: - PromptCacheKVConfig
+
+/// The KV-cache *layout* a slot's `KVCache` layers were built with -- everything that changes the
+/// shape or numeric representation of the cache tensors themselves, as opposed to the token
+/// content they represent. A mismatch on any field here means the stored `KVCache` layers are
+/// simply the wrong shape/type for this request's iterator to keep appending to, independent of
+/// whether the token prefix matches: `maxKVSize` selects `RotatingKVCache` vs `KVCacheSimple` (and
+/// its window size), while `kvBits`/`kvGroupSize`/`quantizedKVStart` select whether/when the
+/// cache gets transparently swapped for a `QuantizedKVCache` mid-generation (see
+/// `maybeQuantizeKVCache`). Compared as a whole struct in `resolvePromptCacheReuse` so a change to
+/// any one field -- not just `maxKVSize` -- correctly forces a `.kvConfigChanged` miss rather than
+/// reusing a cache whose layout no longer matches what this request's `GenerateParameters` asked
+/// for.
+public struct PromptCacheKVConfig: Equatable, Sendable {
+    public var maxKVSize: Int
+    public var kvBits: Int?
+    public var kvGroupSize: Int
+    public var quantizedKVStart: Int
+
+    public init(maxKVSize: Int, kvBits: Int? = nil, kvGroupSize: Int = 64, quantizedKVStart: Int = 0) {
+        self.maxKVSize = maxKVSize
+        self.kvBits = kvBits
+        self.kvGroupSize = kvGroupSize
+        self.quantizedKVStart = quantizedKVStart
+    }
+
+    /// Builds a config from `GenerateParameters`, with `maxKVSize` supplied separately since
+    /// `ModelRunner.runChat` computes the *effective* value (falling back to the context limit
+    /// when the caller left `parameters.maxKVSize` unset) rather than trusting
+    /// `parameters.maxKVSize` directly.
+    public init(parameters: GenerateParameters, maxKVSize: Int) {
+        self.init(
+            maxKVSize: maxKVSize,
+            kvBits: parameters.kvBits,
+            kvGroupSize: parameters.kvGroupSize,
+            quantizedKVStart: parameters.quantizedKVStart
+        )
+    }
 }
 
 // MARK: - PromptCacheSlot
 
 /// One model's cached prompt/KV state: the exact token sequence the cache represents, the live
-/// `KVCache` layers (one per model layer), and the `maxKVSize` the cache was built with (a
-/// mismatch there means a different `RotatingKVCache` window, so the cache cannot be reused
-/// as-is even if the tokens match).
+/// `KVCache` layers (one per model layer), and the `PromptCacheKVConfig` the cache was built with
+/// (a mismatch there means the stored layers are the wrong shape/layout, so the cache cannot be
+/// reused as-is even if the tokens match).
 ///
 /// `@unchecked Sendable`: `KVCache` is a mutable, non-Sendable MLX type. Safety comes from
 /// `PromptCacheStore`'s checkout discipline, not from the type system -- a slot has exactly one
@@ -80,12 +170,12 @@ enum PromptCacheResolution: @unchecked Sendable {
 public struct PromptCacheSlot: @unchecked Sendable {
     public var tokens: [Int]
     public var cache: [KVCache]
-    public var maxKVSize: Int
+    public var kvConfig: PromptCacheKVConfig
 
-    public init(tokens: [Int], cache: [KVCache], maxKVSize: Int) {
+    public init(tokens: [Int], cache: [KVCache], kvConfig: PromptCacheKVConfig) {
         self.tokens = tokens
         self.cache = cache
-        self.maxKVSize = maxKVSize
+        self.kvConfig = kvConfig
     }
 }
 
@@ -101,7 +191,9 @@ public struct PromptCacheSlot: @unchecked Sendable {
 ///
 /// Access is a simple mutex rather than an actor: `ModelPool.run` already serializes inference
 /// per model name, so contention is not expected, but the store itself makes no assumption
-/// about that -- `checkout`/`checkin`/`drop` are individually atomic regardless.
+/// about that -- `checkout`/`checkin`/`drop` are individually atomic regardless, and the epoch
+/// counters live under the same lock as the slots so "is this token still current" and "mutate
+/// the slots" can never observe each other torn.
 public final class PromptCacheStore: Sendable {
     // MARK: Lifecycle
 
@@ -109,40 +201,113 @@ public final class PromptCacheStore: Sendable {
 
     // MARK: Public
 
-    public static let shared = PromptCacheStore()
+    public static let shared: PromptCacheStore = .init()
 
-    /// Removes and returns the slot for `modelName`, if any -- see the checkout-semantics note
-    /// on the type itself.
-    public func checkout(modelName: String) -> PromptCacheSlot? {
-        slots.withLock { $0.removeValue(forKey: modelName) }
+    /// Removes and returns the slot for `modelName`, if any, together with the `PromptCacheEpoch`
+    /// in force at that same instant -- see the checkout-semantics note on the type itself, and
+    /// `PromptCacheEpoch`'s doc comment for why the epoch has to be captured atomically with the
+    /// removal rather than read separately afterward.
+    public func checkout(modelName: String) -> (slot: PromptCacheSlot, epoch: PromptCacheEpoch)? {
+        let (slot, epoch) = checkoutOrCurrentEpoch(modelName: modelName)
+        guard let slot else {
+            return nil
+        }
+
+        return (slot, epoch)
+    }
+
+    /// Checks a slot out if there is one, and reports the `PromptCacheEpoch` in force either way
+    /// -- both under a single acquisition of the lock.
+    ///
+    /// The atomicity is the point. Reading the epoch in a second, separate call after a checkout
+    /// that found nothing would leave a window in which `dropAll()` lands between the two: the
+    /// caller would then capture the *post*-drop epoch, its later `checkin` would be accepted,
+    /// and the slot it built while holding a container that `clearCache()` has since evicted
+    /// would survive the clear -- which is the very resurrection `PromptCacheEpoch` exists to
+    /// prevent, just through a narrower window.
+    public func checkoutOrCurrentEpoch(modelName: String) -> (slot: PromptCacheSlot?, epoch: PromptCacheEpoch) {
+        state.withLock { state in
+            (state.slots.removeValue(forKey: modelName), state.currentEpoch(modelName: modelName))
+        }
+    }
+
+    /// The `PromptCacheEpoch` in force for `modelName` right now, without touching any slot --
+    /// for the miss path, where `checkout` found nothing to remove but a slot will still be
+    /// written back at the end of generation, so a token still has to be captured before that
+    /// generation starts.
+    public func currentEpoch(modelName: String) -> PromptCacheEpoch {
+        state.withLock { $0.currentEpoch(modelName: modelName) }
     }
 
     /// Non-destructive lookup of a model's slot, for diagnostics and tests -- does not affect
     /// checkout state (unlike `checkout`, this does not remove the slot).
     public func peek(modelName: String) -> PromptCacheSlot? {
-        slots.withLock { $0[modelName] }
+        state.withLock { $0.slots[modelName] }
     }
 
-    /// Stores `slot` for `modelName`, checking it back in after clean completion.
-    public func checkin(modelName: String, slot: PromptCacheSlot) {
-        slots.withLock { $0[modelName] = slot }
+    /// Stores `slot` for `modelName`, checking it back in after clean completion, but only if
+    /// `epoch` still equals the store's current epoch for `modelName`. A mismatch means
+    /// `drop(modelName:)` or `dropAll()` ran while this slot's generation was in flight; the
+    /// slot is dropped on the floor instead (which also releases its KV arrays) rather than
+    /// resurrecting state the store had already invalidated. Returns whether the slot was
+    /// actually stored, so the caller can log a rejection for diagnosability.
+    @discardableResult
+    public func checkin(modelName: String, slot: PromptCacheSlot, epoch: PromptCacheEpoch) -> Bool {
+        state.withLock { state in
+            guard state.currentEpoch(modelName: modelName) == epoch else {
+                return false
+            }
+
+            state.slots[modelName] = slot
+            return true
+        }
     }
 
-    /// Drops any slot for `modelName` -- used on model eviction and under memory pressure,
-    /// where the cache's underlying weights/buffers are going away regardless of the slot's
-    /// content, and available for explicit invalidation elsewhere.
+    /// Drops any slot for `modelName` and bumps that model's epoch -- used on model eviction and
+    /// under memory pressure, where the cache's underlying weights/buffers are going away
+    /// regardless of the slot's content, and available for explicit invalidation elsewhere. The
+    /// epoch bump happens unconditionally, even when no slot is currently present, so a
+    /// generation that is mid-flight for this model right now (and so already checked its slot
+    /// out, or never found one) is still correctly invalidated when it tries to check in later.
     public func drop(modelName: String) {
-        slots.withLock { _ = $0.removeValue(forKey: modelName) }
+        state.withLock { state in
+            _ = state.slots.removeValue(forKey: modelName)
+            state.modelEpochs[modelName, default: 0] += 1
+        }
     }
 
-    /// Drops every slot -- used when the whole model cache is cleared.
+    /// Drops every slot and bumps the global epoch -- used when the whole model cache is
+    /// cleared. Per-model epoch counters are left untouched (bumping the global epoch already
+    /// invalidates every model), and are never reset by this call either -- see `State
+    /// .modelEpochs`.
     public func dropAll() {
-        slots.withLock { $0.removeAll() }
+        state.withLock { state in
+            state.slots.removeAll()
+            state.globalEpoch += 1
+        }
     }
 
     // MARK: Private
 
-    private let slots = Mutex<[String: PromptCacheSlot]>([:])
+    /// Bundles the slots with the epoch counters that guard them so both live under one lock.
+    private struct State {
+        var slots: [String: PromptCacheSlot] = [:]
+
+        /// Per-model invalidation counters, bumped by `drop(modelName:)`. Deliberately **not**
+        /// cleared when a model's slot is removed (by `checkout`, `drop`, or eviction) -- a model
+        /// with no live slot right now must still correctly invalidate a write-back a past
+        /// generation for that model is about to attempt.
+        var modelEpochs: [String: UInt64] = [:]
+
+        /// Global invalidation counter, bumped by `dropAll()`.
+        var globalEpoch: UInt64 = 0
+
+        func currentEpoch(modelName: String) -> PromptCacheEpoch {
+            PromptCacheEpoch(global: globalEpoch, perModel: modelEpochs[modelName] ?? 0)
+        }
+    }
+
+    private let state: Mutex<State> = .init(State())
 }
 
 // MARK: - Pure helpers (free functions for direct unit testing via @testable import)
@@ -166,6 +331,7 @@ func promptCacheLayerIsReusable(_ layer: KVCache) -> Bool {
     guard layer.isTrimmable else {
         return false
     }
+
     if let maxSize = layer.maxSize {
         return layer.offset < maxSize
     }
@@ -174,7 +340,7 @@ func promptCacheLayerIsReusable(_ layer: KVCache) -> Bool {
 
 /// Whether every layer of a cache can still be trimmed and reused.
 func promptCacheIsReusable(_ cache: [KVCache]) -> Bool {
-    !cache.isEmpty && cache.allSatisfy(promptCacheLayerIsReusable)
+    cache.isEmpty == false && cache.allSatisfy(promptCacheLayerIsReusable)
 }
 
 /// Resolves whether `newTokens` can reuse `store`'s slot for `modelName`, checking the slot out
@@ -189,28 +355,33 @@ func resolvePromptCacheReuse(
     hasMediaInput: Bool,
     modelName: String,
     newTokens: [Int],
-    maxKVSize: Int,
+    kvConfig: PromptCacheKVConfig,
     store: PromptCacheStore
 ) -> PromptCacheResolution {
     guard enabled else {
-        return .miss(reason: .disabled)
+        return .miss(reason: .disabled, epoch: nil)
     }
-    guard !hasMediaInput else {
-        return .miss(reason: .multimodal)
+    guard hasMediaInput == false else {
+        return .miss(reason: .multimodal, epoch: nil)
     }
-    guard let slot = store.checkout(modelName: modelName) else {
-        return .miss(reason: .noSlot)
+
+    // Nothing may be checked out here, but a fresh cache will still be built and written back at
+    // the end of generation, so the token it will need is captured now -- in the same locked
+    // step as the checkout attempt, never as a separate read afterward.
+    let (checkedOutSlot, epoch) = store.checkoutOrCurrentEpoch(modelName: modelName)
+    guard let slot = checkedOutSlot else {
+        return .miss(reason: .noSlot, epoch: epoch)
     }
-    guard slot.maxKVSize == maxKVSize else {
-        return .miss(reason: .kvConfigChanged)
+    guard slot.kvConfig == kvConfig else {
+        return .miss(reason: .kvConfigChanged, epoch: epoch)
     }
     guard promptCacheIsReusable(slot.cache) else {
-        return .miss(reason: .rotated)
+        return .miss(reason: .rotated, epoch: epoch)
     }
 
     let matched = promptCacheLongestCommonPrefix(slot.tokens, newTokens)
     guard matched > 0 else {
-        return .miss(reason: .mismatchAtZero)
+        return .miss(reason: .mismatchAtZero, epoch: epoch)
     }
 
     // The TokenIterator needs at least one prompt token to prime the pump, so a full-prefix
@@ -221,5 +392,5 @@ func resolvePromptCacheReuse(
     }
 
     let reason: PromptCacheMissReason? = matched < slot.tokens.count ? .partialMismatch : nil
-    return .reuse(matchedLength: trimTarget, cache: slot.cache, reason: reason)
+    return .reuse(matchedLength: trimTarget, cache: slot.cache, reason: reason, epoch: epoch)
 }

--- a/swama/Sources/SwamaKit/Model/PromptCacheStore.swift
+++ b/swama/Sources/SwamaKit/Model/PromptCacheStore.swift
@@ -1,0 +1,225 @@
+//
+//  PromptCacheStore.swift
+//  SwamaKit
+//
+//  In-memory, one-slot-per-model prompt/KV-cache used by `ModelRunner.runChat` to avoid
+//  re-prefilling the shared prefix of a multi-turn conversation. See
+//  claude/specs/prompt-cache/plan.md ("Design (v1)" and "Phase-1 amendments") for the design
+//  this implements.
+//
+
+import Foundation
+@preconcurrency import MLXLMCommon
+import Synchronization
+
+// MARK: - PromptCacheMissReason
+
+/// Why a request could not reuse cached KV state. Logged on every miss (including a *partial*
+/// reuse, which still counts as one for diagnostic purposes -- see `PromptCacheResolution`)
+/// so a silently-zero-hit cache is diagnosable rather than looking identical to a working one.
+public enum PromptCacheMissReason: String, Sendable {
+    /// `SWAMA_PROMPT_CACHE=0`.
+    case disabled
+
+    /// No slot exists for this model yet (first request, or the previous slot was dropped by
+    /// eviction/memory pressure/cancellation). Also covers a model swap, since slots are keyed
+    /// by model name.
+    case noSlot = "no_slot"
+
+    /// The request carries image/video content; multimodal requests bypass the cache entirely
+    /// (both restore and store), since image embeddings are not represented in the token
+    /// sequence a KV cache indexes by.
+    case multimodal
+
+    /// The new token sequence shares no prefix at all with the cached one (position 0 already
+    /// differs) -- typically a system-prompt change or an unrelated conversation.
+    case mismatchAtZero = "mismatch_at_0"
+
+    /// The new token sequence shares a non-empty prefix with the cached one, but not the whole
+    /// cached prefix -- typically a mid-history edit. The shared prefix is still reused (causal
+    /// attention means cache state at position i depends only on tokens[0..<i], so this remains
+    /// exact), this reason exists purely to flag that the reuse was partial.
+    case partialMismatch = "partial_mismatch"
+
+    /// The cached `KVCache` has rotated (a `RotatingKVCache` at or past `maxSize`) or is
+    /// otherwise not trimmable; its layout no longer corresponds to a simple prefix of the
+    /// original sequence, so it cannot be reused at all.
+    case rotated
+
+    /// The slot exists but was built with a different `maxKVSize` than this request wants.
+    case kvConfigChanged = "kv_config_changed"
+}
+
+// MARK: - PromptCacheResolution
+
+/// The outcome of trying to reuse a model's prompt cache for one request's token sequence.
+///
+/// `@unchecked Sendable`: carries `[KVCache]` (see `PromptCacheSlot`); this value is built once
+/// per request, handed across a single `container.perform` boundary, and not shared afterward.
+enum PromptCacheResolution: @unchecked Sendable {
+    /// Reuse the cache starting at `matchedLength` tokens in (already capped so the caller has
+    /// at least one suffix token to feed the `TokenIterator`, and already trimmed to that
+    /// offset). `reason` is `.partialMismatch` when the match was shorter than the entire
+    /// cached prefix, `nil` for a clean full-prefix hit (a plain append).
+    case reuse(matchedLength: Int, cache: [KVCache], reason: PromptCacheMissReason?)
+
+    /// No reuse at all; the caller must prefill the full prompt.
+    case miss(reason: PromptCacheMissReason)
+}
+
+// MARK: - PromptCacheSlot
+
+/// One model's cached prompt/KV state: the exact token sequence the cache represents, the live
+/// `KVCache` layers (one per model layer), and the `maxKVSize` the cache was built with (a
+/// mismatch there means a different `RotatingKVCache` window, so the cache cannot be reused
+/// as-is even if the tokens match).
+///
+/// `@unchecked Sendable`: `KVCache` is a mutable, non-Sendable MLX type. Safety comes from
+/// `PromptCacheStore`'s checkout discipline, not from the type system -- a slot has exactly one
+/// owner at a time (see `PromptCacheStore`).
+public struct PromptCacheSlot: @unchecked Sendable {
+    public var tokens: [Int]
+    public var cache: [KVCache]
+    public var maxKVSize: Int
+
+    public init(tokens: [Int], cache: [KVCache], maxKVSize: Int) {
+        self.tokens = tokens
+        self.cache = cache
+        self.maxKVSize = maxKVSize
+    }
+}
+
+// MARK: - PromptCacheStore
+
+/// One prompt/KV-cache slot per model name, with checkout semantics: `checkout` atomically
+/// removes and returns a model's slot, so the caller has exclusive ownership of it until it
+/// explicitly `checkin`s it. This makes the cancellation-safe lifecycle free -- a caller that
+/// hits an error, is cancelled, or decides the resulting cache is unusable (rotated, etc.)
+/// simply never calls `checkin`, and the slot stays absent. There is no separate "invalidate"
+/// step and no way to leave a half-written slot behind: the slot the caller checked out is
+/// already gone from the store the moment `checkout` returns it.
+///
+/// Access is a simple mutex rather than an actor: `ModelPool.run` already serializes inference
+/// per model name, so contention is not expected, but the store itself makes no assumption
+/// about that -- `checkout`/`checkin`/`drop` are individually atomic regardless.
+public final class PromptCacheStore: Sendable {
+    // MARK: Lifecycle
+
+    public init() {}
+
+    // MARK: Public
+
+    public static let shared = PromptCacheStore()
+
+    /// Removes and returns the slot for `modelName`, if any -- see the checkout-semantics note
+    /// on the type itself.
+    public func checkout(modelName: String) -> PromptCacheSlot? {
+        slots.withLock { $0.removeValue(forKey: modelName) }
+    }
+
+    /// Non-destructive lookup of a model's slot, for diagnostics and tests -- does not affect
+    /// checkout state (unlike `checkout`, this does not remove the slot).
+    public func peek(modelName: String) -> PromptCacheSlot? {
+        slots.withLock { $0[modelName] }
+    }
+
+    /// Stores `slot` for `modelName`, checking it back in after clean completion.
+    public func checkin(modelName: String, slot: PromptCacheSlot) {
+        slots.withLock { $0[modelName] = slot }
+    }
+
+    /// Drops any slot for `modelName` -- used on model eviction and under memory pressure,
+    /// where the cache's underlying weights/buffers are going away regardless of the slot's
+    /// content, and available for explicit invalidation elsewhere.
+    public func drop(modelName: String) {
+        slots.withLock { _ = $0.removeValue(forKey: modelName) }
+    }
+
+    /// Drops every slot -- used when the whole model cache is cleared.
+    public func dropAll() {
+        slots.withLock { $0.removeAll() }
+    }
+
+    // MARK: Private
+
+    private let slots = Mutex<[String: PromptCacheSlot]>([:])
+}
+
+// MARK: - Pure helpers (free functions for direct unit testing via @testable import)
+
+/// Longest common prefix length of two token sequences.
+func promptCacheLongestCommonPrefix(_ a: [Int], _ b: [Int]) -> Int {
+    var index = 0
+    let limit = min(a.count, b.count)
+    while index < limit, a[index] == b[index] {
+        index += 1
+    }
+    return index
+}
+
+/// Whether a single cache layer can still be trimmed and treated as an exact prefix of the
+/// original sequence. `RotatingKVCache.isTrimmable` already encodes `offset < maxSize`, but the
+/// `maxSize` check is repeated explicitly here (rather than trusting `isTrimmable` alone) per
+/// the design's "assert, don't assume" rotation guard: the failure mode on getting this wrong is
+/// corrupt output, not extra latency.
+func promptCacheLayerIsReusable(_ layer: KVCache) -> Bool {
+    guard layer.isTrimmable else {
+        return false
+    }
+    if let maxSize = layer.maxSize {
+        return layer.offset < maxSize
+    }
+    return true
+}
+
+/// Whether every layer of a cache can still be trimmed and reused.
+func promptCacheIsReusable(_ cache: [KVCache]) -> Bool {
+    !cache.isEmpty && cache.allSatisfy(promptCacheLayerIsReusable)
+}
+
+/// Resolves whether `newTokens` can reuse `store`'s slot for `modelName`, checking the slot out
+/// of the store in the process whenever one exists and is even considered (see the type docs on
+/// `PromptCacheStore` for why not checking a considered-but-rejected slot back in is sufficient
+/// to invalidate it).
+///
+/// `hasMediaInput` and `!enabled` short-circuit before any checkout, so a multimodal or
+/// cache-disabled request never disturbs a slot a later, ordinary request could still use.
+func resolvePromptCacheReuse(
+    enabled: Bool,
+    hasMediaInput: Bool,
+    modelName: String,
+    newTokens: [Int],
+    maxKVSize: Int,
+    store: PromptCacheStore
+) -> PromptCacheResolution {
+    guard enabled else {
+        return .miss(reason: .disabled)
+    }
+    guard !hasMediaInput else {
+        return .miss(reason: .multimodal)
+    }
+    guard let slot = store.checkout(modelName: modelName) else {
+        return .miss(reason: .noSlot)
+    }
+    guard slot.maxKVSize == maxKVSize else {
+        return .miss(reason: .kvConfigChanged)
+    }
+    guard promptCacheIsReusable(slot.cache) else {
+        return .miss(reason: .rotated)
+    }
+
+    let matched = promptCacheLongestCommonPrefix(slot.tokens, newTokens)
+    guard matched > 0 else {
+        return .miss(reason: .mismatchAtZero)
+    }
+
+    // The TokenIterator needs at least one prompt token to prime the pump, so a full-prefix
+    // match (matched == newTokens.count) still leaves the last token to be fed as the suffix.
+    let trimTarget = min(matched, max(newTokens.count - 1, 0))
+    for layer in slot.cache {
+        layer.trim(layer.offset - trimTarget)
+    }
+
+    let reason: PromptCacheMissReason? = matched < slot.tokens.count ? .partialMismatch : nil
+    return .reuse(matchedLength: trimTarget, cache: slot.cache, reason: reason)
+}

--- a/swama/Tests/SwamaKitTests/PromptCacheTests.swift
+++ b/swama/Tests/SwamaKitTests/PromptCacheTests.swift
@@ -1,0 +1,827 @@
+//
+//  PromptCacheTests.swift
+//  SwamaKitTests
+//
+//  Coverage for the prompt/KV-cache feature (claude/specs/prompt-cache/). Two complementary
+//  styles are used throughout:
+//
+//  - Whitebox: `resolvePromptCacheReuse` is called directly against a hand-built
+//    `PromptCacheStore` slot, using real `KVCacheSimple`/`RotatingKVCache` instances fed via
+//    their real `update(keys:values:)`. This pins down matched-length and miss-reason
+//    classification precisely and deterministically.
+//  - Blackbox: a small deterministic `LanguageModel` (`WordEchoModel`) is wired into a real
+//    `ModelContainer`/`ModelRunner`, so `TokenIterator`, `LLMModel.prepare`'s chunked prefill,
+//    and the full `runChat` generation path are genuinely exercised end to end, with no model
+//    downloads. The model's logits are a deterministic function of the token history it reads
+//    back from the cache it's handed (via `KVCache.update`'s return value, which always covers
+//    the full history up to the current offset) -- so if the cache/suffix stitching in
+//    `ModelRunner.runChat` is wrong, cached and uncached runs of the same conversation diverge.
+//
+//  Every blackbox test compares a "cached" run (one `ModelRunner`/`PromptCacheStore` reused
+//  across turns) against an "uncached" baseline (a fresh `PromptCacheStore` per turn, so every
+//  turn is a `no_slot` miss) built from the *same* container -- any mismatch means the cache
+//  path computed something different from a full, correct prefill.
+
+import Foundation
+import MLX
+import MLXLLM
+@preconcurrency import MLXLMCommon
+import MLXNN
+@testable import SwamaKit
+import Testing
+
+// MARK: - WordVocabTokenizer
+
+/// A tiny, fully deterministic tokenizer. Content tokens are written as "w<N>" words (e.g.
+/// "w3 w1 w7"); `encode` parses them directly to `N % contentVocabSize`, so tests can construct
+/// exact token sequences without going through real BPE. `decode` is the exact inverse (each id
+/// maps back to "w<N> "), so text a model generates can be re-encoded losslessly if fed back in
+/// as a later turn's context -- as a real client resending conversation history would.
+private struct WordVocabTokenizer: MLXLMCommon.Tokenizer {
+    static let systemToken = 16
+    static let userToken = 17
+    static let assistantToken = 18
+    static let sepToken = 19
+
+    let contentVocabSize: Int
+
+    var bosToken: String? { nil }
+    var eosToken: String? { nil }
+    var unknownToken: String? { nil }
+
+    func encode(text: String, addSpecialTokens _: Bool) -> [Int] {
+        text.split(separator: " ").compactMap { piece -> Int? in
+            guard piece.hasPrefix("w"), let value = Int(piece.dropFirst()) else {
+                return nil
+            }
+            return ((value % contentVocabSize) + contentVocabSize) % contentVocabSize
+        }
+    }
+
+    func decode(tokenIds: [Int], skipSpecialTokens _: Bool) -> String {
+        tokenIds.map { id in
+            switch id {
+            case 0 ..< contentVocabSize: "w\(id) "
+            case Self.systemToken: "<sys> "
+            case Self.userToken: "<user> "
+            case Self.assistantToken: "<asst> "
+            case Self.sepToken: "<sep> "
+            default: "<unk\(id)> "
+            }
+        }.joined()
+    }
+
+    func convertTokenToId(_ token: String) -> Int? {
+        if token.hasPrefix("w"), let value = Int(token.dropFirst()) {
+            return value
+        }
+        switch token {
+        case "<sys>": return Self.systemToken
+        case "<user>": return Self.userToken
+        case "<asst>": return Self.assistantToken
+        case "<sep>": return Self.sepToken
+        default: return nil
+        }
+    }
+
+    func convertIdToToken(_ id: Int) -> String? {
+        decode(tokenIds: [id], skipSpecialTokens: false).trimmingCharacters(in: .whitespaces)
+    }
+
+    func applyChatTemplate(
+        messages: [[String: any Sendable]],
+        tools _: [[String: any Sendable]]?,
+        additionalContext _: [String: any Sendable]?
+    ) throws -> [Int] {
+        var tokens: [Int] = []
+        for message in messages {
+            let role = message["role"] as? String ?? "user"
+            switch role {
+            case "system": tokens.append(Self.systemToken)
+            case "assistant": tokens.append(Self.assistantToken)
+            default: tokens.append(Self.userToken)
+            }
+            if let content = message["content"] as? String {
+                tokens.append(contentsOf: encode(text: content, addSpecialTokens: false))
+            }
+            tokens.append(Self.sepToken)
+        }
+        return tokens
+    }
+}
+
+// MARK: - WordVocabUserInputProcessor
+
+/// Mirrors `LLMModelFactory`'s real (but non-public) `LLMUserInputProcessor`: render the chat
+/// messages with `DefaultMessageGenerator`, then run them through the tokenizer's chat template.
+private struct WordVocabUserInputProcessor: UserInputProcessor {
+    let tokenizer: WordVocabTokenizer
+    private let messageGenerator = MLXLMCommon.DefaultMessageGenerator()
+
+    func prepare(input: MLXLMCommon.UserInput) throws -> LMInput {
+        let messages = messageGenerator.generate(from: input)
+        let tokens = try tokenizer.applyChatTemplate(
+            messages: messages, tools: input.tools, additionalContext: input.additionalContext
+        )
+        return LMInput(tokens: MLXArray(tokens))
+    }
+}
+
+// MARK: - WordEchoModel
+
+/// A deterministic `LanguageModel`: its "prediction" for the next token is the content token
+/// `period` positions back in the *full* history, read back from the cache's own
+/// `update(keys:values:)` return value (which always covers everything up to the new offset --
+/// exactly like a real attention cache). This creates a period-`period` repeating pattern that
+/// repetition penalties have real, visible leverage over, making equivalence a meaningful
+/// check rather than a trivial one: the wrong window (e.g. suffix-only instead of full history)
+/// changes which token wins.
+private final class WordEchoModel: MLXNN.Module, LLMModel, KVCacheDimensionProvider {
+    let kvHeads: [Int]
+    private let outputVocabSize: Int
+    private let contentVocabSize: Int
+    private let period: Int
+    private let predictedLogit: Float
+    private let alternativeLogit: Float
+
+    var loraLayers: [MLXNN.Module] { [] }
+
+    init(
+        numLayers: Int,
+        outputVocabSize: Int,
+        contentVocabSize: Int,
+        period: Int = 2,
+        predictedLogit: Float = 10,
+        alternativeLogit: Float = 8
+    ) {
+        self.kvHeads = Array(repeating: 1, count: numLayers)
+        self.outputVocabSize = outputVocabSize
+        self.contentVocabSize = contentVocabSize
+        self.period = period
+        self.predictedLogit = predictedLogit
+        self.alternativeLogit = alternativeLogit
+        super.init()
+    }
+
+    func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+        let sequenceLength = inputs.dim(1)
+        let keysIn = inputs.asType(.float32).reshaped([1, 1, sequenceLength, 1])
+
+        var history: [Float] = []
+        if let cache, !cache.isEmpty {
+            for (index, layer) in cache.enumerated() {
+                let (k, _) = layer.update(keys: keysIn, values: keysIn)
+                if index == 0 {
+                    history = k.reshaped([-1]).asArray(Float32.self)
+                }
+            }
+        }
+        else {
+            history = keysIn.reshaped([-1]).asArray(Float32.self)
+        }
+
+        let historyTokens = history.map { Int($0.rounded()) }
+        let predicted = Self.predictNextToken(
+            history: historyTokens, period: period, contentVocabSize: contentVocabSize
+        )
+        let alternative = (predicted + 1) % contentVocabSize
+
+        var row = [Float](repeating: 0, count: outputVocabSize)
+        row[predicted] = predictedLogit
+        row[alternative] = max(row[alternative], alternativeLogit)
+
+        let flat = Array(repeating: row, count: sequenceLength).flatMap { $0 }
+        return MLXArray(flat, [1, sequenceLength, outputVocabSize])
+    }
+
+    static func predictNextToken(history: [Int], period: Int, contentVocabSize: Int) -> Int {
+        guard history.count >= period else {
+            return 0
+        }
+        let candidate = history[history.count - period]
+        return ((candidate % contentVocabSize) + contentVocabSize) % contentVocabSize
+    }
+}
+
+// MARK: - Test fixtures
+
+/// Space-separated "w<N>" content words, matching `WordVocabTokenizer.encode`.
+private func words(_ ids: [Int]) -> String {
+    ids.map { "w\($0)" }.joined(separator: " ")
+}
+
+/// Builds a fresh, isolated (never-before-used) model container: a unique model name (so
+/// `PromptCacheStore.shared` could never leak between tests even if used), a small deterministic
+/// vocabulary, and `WordEchoModel` as the `LanguageModel`.
+private func makeTestContainer(
+    numLayers: Int = 2,
+    contentVocabSize: Int = 16,
+    period: Int = 2
+) -> (container: MLXLMCommon.ModelContainer, tokenizer: WordVocabTokenizer) {
+    let tokenizer = WordVocabTokenizer(contentVocabSize: contentVocabSize)
+    let model = WordEchoModel(
+        numLayers: numLayers,
+        outputVocabSize: contentVocabSize + 4,
+        contentVocabSize: contentVocabSize,
+        period: period
+    )
+    let configuration = MLXLMCommon.ModelConfiguration(id: "prompt-cache-test-\(UUID().uuidString)")
+    let context = MLXLMCommon.ModelContext(
+        configuration: configuration,
+        model: model,
+        processor: WordVocabUserInputProcessor(tokenizer: tokenizer),
+        tokenizer: tokenizer
+    )
+    return (MLXLMCommon.ModelContainer(context: context), tokenizer)
+}
+
+/// Feeds `tokens` through fresh `KVCacheSimple` layers in one `update` call each, as a stand-in
+/// for "a slot stored after some earlier, already-completed turn". Unbounded (no rotation), so
+/// suitable for prefix-matching tests that aren't about rotation.
+private func makeSimpleCacheFedWithTokens(_ tokens: [Int], layerCount: Int) -> [KVCache] {
+    let cache: [KVCache] = (0 ..< layerCount).map { _ in KVCacheSimple() }
+    guard !tokens.isEmpty else {
+        return cache
+    }
+    let keys = MLXArray(tokens.map(Float.init), [1, 1, tokens.count, 1])
+    for layer in cache {
+        _ = layer.update(keys: keys, values: keys)
+    }
+    return cache
+}
+
+/// Feeds `tokens` through fresh `RotatingKVCache` layers **one token at a time**, matching real
+/// autoregressive decode (`updateInPlace`) rather than a bulk multi-token prefill
+/// (`updateConcat`, which has its own, unrelated temporary-growth trimming). With
+/// `tokens.count > maxKVSize` this reliably drives the cache past rotation
+/// (`offset >= maxKVSize`, `isTrimmable == false`).
+private func makeRotatedCache(tokens: [Int], layerCount: Int, maxKVSize: Int, keep: Int = 4) -> [KVCache] {
+    let cache: [KVCache] = (0 ..< layerCount).map { _ in RotatingKVCache(maxSize: maxKVSize, keep: keep) }
+    for token in tokens {
+        let keys = MLXArray([Float(token)], [1, 1, 1, 1])
+        for layer in cache {
+            _ = layer.update(keys: keys, values: keys)
+        }
+    }
+    return cache
+}
+
+/// Runs an uncached baseline: a brand-new `PromptCacheStore` per call means every turn is a
+/// `no_slot` miss, so this is equivalent to the feature not existing, while still sharing the
+/// exact same container/model as whatever cached run it's compared against.
+private func runUncached(
+    container: MLXLMCommon.ModelContainer,
+    messages: [MLXLMCommon.Chat.Message],
+    parameters: GenerateParameters
+) async throws -> ModelRunner.ChatRunResult {
+    let runner = ModelRunner(container: container, promptCacheStore: PromptCacheStore())
+    return try await runner.runChat(
+        userInput: MLXLMCommon.UserInput(chat: messages), parameters: parameters
+    )
+}
+
+// MARK: - PromptCacheReuseClassificationTests (whitebox)
+
+@Suite("Prompt cache: reuse classification")
+struct PromptCacheReuseClassificationTests {
+    @Test func hitOnAppendMatchesEntirePreviousPrompt() {
+        let store = PromptCacheStore()
+        let modelName = "model-append"
+        let previousTokens = [16, 1, 2, 19, 17, 3, 4, 19]
+        let cache = makeSimpleCacheFedWithTokens(previousTokens, layerCount: 2)
+        store.checkin(
+            modelName: modelName,
+            slot: PromptCacheSlot(tokens: previousTokens, cache: cache, maxKVSize: 4096)
+        )
+
+        let newTokens = previousTokens + [18, 5, 6, 19, 17, 7, 8, 19]
+        let decision = resolvePromptCacheReuse(
+            enabled: true, hasMediaInput: false, modelName: modelName,
+            newTokens: newTokens, maxKVSize: 4096, store: store
+        )
+
+        guard case let .reuse(matchedLength, reusedCache, reason) = decision else {
+            Issue.record("expected .reuse, got \(decision)")
+            return
+        }
+        #expect(matchedLength == previousTokens.count)
+        #expect(reason == nil)
+        #expect(reusedCache[0].offset == previousTokens.count)
+        #expect(store.checkout(modelName: modelName) == nil, "slot must be consumed by checkout")
+    }
+
+    @Test func partialMismatchOnMidHistoryEditStillReusesTheSharedPrefix() {
+        let store = PromptCacheStore()
+        let modelName = "model-edit"
+        let priorTokens = [16, 1, 19, 17, 2, 19, 18, 3, 19]
+        let cache = makeSimpleCacheFedWithTokens(priorTokens, layerCount: 2)
+        store.checkin(
+            modelName: modelName,
+            slot: PromptCacheSlot(tokens: priorTokens, cache: cache, maxKVSize: 4096)
+        )
+
+        var editedTokens = priorTokens
+        editedTokens[4] = 99 // edit deep inside the already-cached "user" content
+        editedTokens.append(contentsOf: [17, 5, 19])
+
+        let decision = resolvePromptCacheReuse(
+            enabled: true, hasMediaInput: false, modelName: modelName,
+            newTokens: editedTokens, maxKVSize: 4096, store: store
+        )
+
+        guard case let .reuse(matchedLength, _, reason) = decision else {
+            Issue.record("expected .reuse (partial), got \(decision)")
+            return
+        }
+        #expect(matchedLength == 4)
+        #expect(reason == .partialMismatch)
+    }
+
+    @Test func mismatchAtZeroWhenNothingInCommon() {
+        let store = PromptCacheStore()
+        let modelName = "model-system-change"
+        let priorTokens = [16, 1, 19, 17, 2, 19]
+        let cache = makeSimpleCacheFedWithTokens(priorTokens, layerCount: 2)
+        store.checkin(
+            modelName: modelName,
+            slot: PromptCacheSlot(tokens: priorTokens, cache: cache, maxKVSize: 4096)
+        )
+
+        // No system message this time: the sequence starts with the user-role token instead of
+        // the system-role token, so position 0 itself differs.
+        let newTokens = [17, 5, 19]
+        let decision = resolvePromptCacheReuse(
+            enabled: true, hasMediaInput: false, modelName: modelName,
+            newTokens: newTokens, maxKVSize: 4096, store: store
+        )
+
+        guard case let .miss(reason) = decision else {
+            Issue.record("expected .miss, got \(decision)")
+            return
+        }
+        #expect(reason == .mismatchAtZero)
+    }
+
+    @Test func fullPrefixMatchCapsAtNMinusOneForTheIterator() {
+        let store = PromptCacheStore()
+        let modelName = "model-resend"
+        let previousTokens = [16, 1, 19, 17, 2, 3, 19]
+        let cache = makeSimpleCacheFedWithTokens(previousTokens, layerCount: 2)
+        store.checkin(
+            modelName: modelName,
+            slot: PromptCacheSlot(tokens: previousTokens, cache: cache, maxKVSize: 4096)
+        )
+
+        // The exact same prompt, resent verbatim.
+        let decision = resolvePromptCacheReuse(
+            enabled: true, hasMediaInput: false, modelName: modelName,
+            newTokens: previousTokens, maxKVSize: 4096, store: store
+        )
+
+        guard case let .reuse(matchedLength, reusedCache, reason) = decision else {
+            Issue.record("expected .reuse, got \(decision)")
+            return
+        }
+        #expect(matchedLength == previousTokens.count - 1)
+        #expect(reason == nil)
+        #expect(reusedCache[0].offset == previousTokens.count - 1)
+    }
+
+    @Test func rotatedCacheRefusesReuseRegardlessOfMatchingPrefix() {
+        let store = PromptCacheStore()
+        let modelName = "model-rotated"
+        let maxKVSize = 6
+        let priorTokens = Array(1 ... 10) // fed one at a time, exceeds maxKVSize -> rotates
+        let cache = makeRotatedCache(tokens: priorTokens, layerCount: 2, maxKVSize: maxKVSize)
+        #expect(!promptCacheIsReusable(cache), "setup sanity: cache should have rotated")
+
+        store.checkin(
+            modelName: modelName,
+            slot: PromptCacheSlot(tokens: priorTokens, cache: cache, maxKVSize: maxKVSize)
+        )
+
+        let newTokens = priorTokens + [11, 12] // would share a full prefix if reuse were attempted
+        let decision = resolvePromptCacheReuse(
+            enabled: true, hasMediaInput: false, modelName: modelName,
+            newTokens: newTokens, maxKVSize: maxKVSize, store: store
+        )
+
+        guard case let .miss(reason) = decision else {
+            Issue.record("expected .miss, got \(decision)")
+            return
+        }
+        #expect(reason == .rotated)
+        #expect(store.checkout(modelName: modelName) == nil, "rotated slot must be dropped, not reused")
+    }
+
+    @Test func kvConfigChangeIsAMiss() {
+        let store = PromptCacheStore()
+        let modelName = "model-kv-change"
+        let priorTokens = [16, 1, 19, 17, 2, 19]
+        let cache = makeSimpleCacheFedWithTokens(priorTokens, layerCount: 1)
+        store.checkin(
+            modelName: modelName,
+            slot: PromptCacheSlot(tokens: priorTokens, cache: cache, maxKVSize: 2048)
+        )
+
+        let decision = resolvePromptCacheReuse(
+            enabled: true, hasMediaInput: false, modelName: modelName,
+            newTokens: priorTokens + [18, 3, 19], maxKVSize: 4096, store: store
+        )
+
+        guard case let .miss(reason) = decision else {
+            Issue.record("expected .miss, got \(decision)")
+            return
+        }
+        #expect(reason == .kvConfigChanged)
+    }
+
+    @Test func noSlotWhenModelHasNeverBeenSeen() {
+        let store = PromptCacheStore()
+        let decision = resolvePromptCacheReuse(
+            enabled: true, hasMediaInput: false, modelName: "never-seen",
+            newTokens: [1, 2, 3], maxKVSize: 4096, store: store
+        )
+        guard case let .miss(reason) = decision else {
+            Issue.record("expected .miss, got \(decision)")
+            return
+        }
+        #expect(reason == .noSlot)
+    }
+
+    @Test func disabledNeverTouchesTheStore() {
+        let store = PromptCacheStore()
+        let modelName = "model-disabled"
+        store.checkin(
+            modelName: modelName,
+            slot: PromptCacheSlot(
+                tokens: [1, 2], cache: makeSimpleCacheFedWithTokens([1, 2], layerCount: 1), maxKVSize: 100
+            )
+        )
+
+        let decision = resolvePromptCacheReuse(
+            enabled: false, hasMediaInput: false, modelName: modelName,
+            newTokens: [1, 2, 3], maxKVSize: 100, store: store
+        )
+        guard case let .miss(reason) = decision else {
+            Issue.record("expected .miss, got \(decision)")
+            return
+        }
+        #expect(reason == .disabled)
+        #expect(store.peek(modelName: modelName) != nil, "disabled must not disturb an existing slot")
+    }
+
+    @Test func multimodalNeverTouchesTheStore() {
+        let store = PromptCacheStore()
+        let modelName = "model-multimodal"
+        store.checkin(
+            modelName: modelName,
+            slot: PromptCacheSlot(
+                tokens: [1, 2], cache: makeSimpleCacheFedWithTokens([1, 2], layerCount: 1), maxKVSize: 100
+            )
+        )
+
+        let decision = resolvePromptCacheReuse(
+            enabled: true, hasMediaInput: true, modelName: modelName,
+            newTokens: [1, 2, 3], maxKVSize: 100, store: store
+        )
+        guard case let .miss(reason) = decision else {
+            Issue.record("expected .miss, got \(decision)")
+            return
+        }
+        #expect(reason == .multimodal)
+        #expect(store.peek(modelName: modelName) != nil, "multimodal must not disturb an existing slot")
+    }
+}
+
+// MARK: - PromptCacheStoreTests (slot lifecycle, pure)
+
+@Suite("Prompt cache: store lifecycle")
+struct PromptCacheStoreTests {
+    @Test func dropRemovesOneSlotAndDropAllClearsEverything() {
+        let store = PromptCacheStore()
+        store.checkin(
+            modelName: "a",
+            slot: PromptCacheSlot(tokens: [1, 2, 3], cache: [KVCacheSimple()], maxKVSize: 100)
+        )
+        store.checkin(
+            modelName: "b",
+            slot: PromptCacheSlot(tokens: [4, 5], cache: [KVCacheSimple()], maxKVSize: 100)
+        )
+
+        store.drop(modelName: "a")
+        #expect(store.peek(modelName: "a") == nil)
+        #expect(store.peek(modelName: "b") != nil)
+
+        store.dropAll()
+        #expect(store.peek(modelName: "b") == nil)
+    }
+
+    @Test func checkoutIsDestructiveButPeekIsNot() {
+        let store = PromptCacheStore()
+        store.checkin(
+            modelName: "m",
+            slot: PromptCacheSlot(tokens: [1, 2], cache: [KVCacheSimple()], maxKVSize: 100)
+        )
+
+        #expect(store.peek(modelName: "m") != nil)
+        #expect(store.peek(modelName: "m") != nil, "peek must not remove the slot")
+        #expect(store.checkout(modelName: "m") != nil)
+        #expect(store.peek(modelName: "m") == nil, "checkout must remove the slot")
+    }
+}
+
+// MARK: - PromptCacheEndToEndTests (blackbox: real ModelRunner.runChat round trips)
+
+@Suite("Prompt cache: end to end")
+struct PromptCacheEndToEndTests {
+    @Test func multiTurnEquivalenceWithRepetitionPenalty() async throws {
+        let (container, _) = makeTestContainer(period: 5)
+        // Small per-turn generations keep each turn's *suffix* (previous reply + new user
+        // message -- the only tokens a cache-hit turn actually prefills) short, while
+        // `repetitionContextSize` is set far larger than any single suffix but
+        // comfortably within the full conversation length. That makes this a real regression
+        // check rather than a vacuous one: a processor primed with only the suffix (the bug this
+        // wrapper exists to prevent) sees a materially smaller window than one primed with the
+        // full history, which changes which tokens get penalized enough to change the argmax --
+        // confirmed by deliberately breaking `FullHistoryLogitProcessor.prompt` locally and
+        // re-running this test, which fails as expected.
+        let parameters = GenerateParameters(
+            maxTokens: 3, maxKVSize: 4096, temperature: 0,
+            repetitionPenalty: 1.3, repetitionContextSize: 40
+        )
+
+        let userTurns = [[1, 2], [3, 4], [5, 6], [7, 8], [9, 10]] // >= 3 turns
+
+        let cachedRunner = ModelRunner(container: container, promptCacheStore: PromptCacheStore())
+        var cachedMessages: [MLXLMCommon.Chat.Message] = [.system(words([0]))]
+        var cachedOutputs: [String] = []
+        for turnWords in userTurns {
+            cachedMessages.append(.user(words(turnWords)))
+            let result = try await cachedRunner.runChat(
+                userInput: .init(chat: cachedMessages), parameters: parameters
+            )
+            cachedOutputs.append(result.output)
+            cachedMessages.append(.assistant(result.output))
+        }
+
+        var uncachedMessages: [MLXLMCommon.Chat.Message] = [.system(words([0]))]
+        var uncachedOutputs: [String] = []
+        for turnWords in userTurns {
+            uncachedMessages.append(.user(words(turnWords)))
+            let result = try await runUncached(
+                container: container, messages: uncachedMessages, parameters: parameters
+            )
+            uncachedOutputs.append(result.output)
+            uncachedMessages.append(.assistant(result.output))
+        }
+
+        #expect(cachedOutputs.count == userTurns.count)
+        #expect(cachedOutputs.allSatisfy { !$0.isEmpty })
+        #expect(cachedOutputs == uncachedOutputs, "cached and uncached generation must be tokenwise identical")
+    }
+
+    @Test func cacheHitAfterAppendingOneMessageReusesTheWholePreviousPrompt() async throws {
+        let (container, _) = makeTestContainer()
+        let modelName = await container.configuration.name
+        let parameters = GenerateParameters(maxTokens: 6, maxKVSize: 4096, temperature: 0)
+        let store = PromptCacheStore()
+        let runner = ModelRunner(container: container, promptCacheStore: store)
+
+        var messages: [MLXLMCommon.Chat.Message] = [.system(words([0])), .user(words([1, 2]))]
+        let turn1 = try await runner.runChat(userInput: .init(chat: messages), parameters: parameters)
+
+        guard let slotAfterTurn1 = store.peek(modelName: modelName) else {
+            Issue.record("expected a slot to be stored after a clean turn")
+            return
+        }
+        let turn1PromptTokenCount = slotAfterTurn1.tokens.count
+
+        messages.append(.assistant(turn1.output))
+        messages.append(.user(words([3, 4])))
+        let turn2 = try await runner.runChat(userInput: .init(chat: messages), parameters: parameters)
+
+        let baseline = try await runUncached(container: container, messages: messages, parameters: parameters)
+        #expect(turn2.output == baseline.output)
+
+        guard let slotAfterTurn2 = store.peek(modelName: modelName) else {
+            Issue.record("expected a slot to be stored after turn 2")
+            return
+        }
+        // The stored slot always holds exactly the prompt tokens for the last clean turn (no
+        // generated tokens); turn 2's prompt is turn 1's prompt plus the appended messages, so
+        // its stored length must be strictly greater than turn 1's.
+        #expect(slotAfterTurn2.tokens.count > turn1PromptTokenCount)
+        #expect(Array(slotAfterTurn2.tokens.prefix(turn1PromptTokenCount)) == slotAfterTurn1.tokens)
+    }
+
+    @Test func missOnMidHistoryEditStillProducesCorrectOutput() async throws {
+        let (container, _) = makeTestContainer()
+        let parameters = GenerateParameters(maxTokens: 5, maxKVSize: 4096, temperature: 0)
+        let store = PromptCacheStore()
+        let runner = ModelRunner(container: container, promptCacheStore: store)
+
+        _ = try await runner.runChat(
+            userInput: .init(chat: [.system(words([0])), .user(words([1, 2]))]), parameters: parameters
+        )
+
+        // Same system message (shared prefix), but the user content changed -- a mid-history
+        // edit relative to what's cached.
+        let editedMessages: [MLXLMCommon.Chat.Message] = [.system(words([0])), .user(words([9, 9, 9]))]
+        let edited = try await runner.runChat(userInput: .init(chat: editedMessages), parameters: parameters)
+        let baseline = try await runUncached(container: container, messages: editedMessages, parameters: parameters)
+
+        #expect(edited.output == baseline.output)
+    }
+
+    @Test func missOnSystemPromptChangeStillProducesCorrectOutput() async throws {
+        let (container, _) = makeTestContainer()
+        let parameters = GenerateParameters(maxTokens: 5, maxKVSize: 4096, temperature: 0)
+        let store = PromptCacheStore()
+        let runner = ModelRunner(container: container, promptCacheStore: store)
+
+        _ = try await runner.runChat(
+            userInput: .init(chat: [.system(words([0])), .user(words([1]))]), parameters: parameters
+        )
+
+        // No system message this time -- the sequence starts with a different role token, a
+        // mismatch at position 0.
+        let newMessages: [MLXLMCommon.Chat.Message] = [.user(words([2]))]
+        let missResult = try await runner.runChat(userInput: .init(chat: newMessages), parameters: parameters)
+        let baseline = try await runUncached(container: container, messages: newMessages, parameters: parameters)
+
+        #expect(missResult.output == baseline.output)
+    }
+
+    @Test func fullPrefixMatchTrimsToNMinusOneAndStillProducesCorrectOutput() async throws {
+        let (container, _) = makeTestContainer()
+        let parameters = GenerateParameters(maxTokens: 5, maxKVSize: 4096, temperature: 0)
+        let store = PromptCacheStore()
+        let runner = ModelRunner(container: container, promptCacheStore: store)
+
+        let messages: [MLXLMCommon.Chat.Message] = [.system(words([0])), .user(words([1, 2, 3]))]
+        let turn1 = try await runner.runChat(userInput: .init(chat: messages), parameters: parameters)
+
+        // Resend the exact same prompt verbatim: matched length == the entire cached prefix ==
+        // the entire new prompt, which the iterator-needs->=1-token cap must trim to N-1.
+        let turn2 = try await runner.runChat(userInput: .init(chat: messages), parameters: parameters)
+
+        let baseline = try await runUncached(container: container, messages: messages, parameters: parameters)
+        #expect(turn1.output == baseline.output)
+        #expect(turn2.output == baseline.output)
+    }
+
+    @Test func rotationFallbackProducesCorrectOutput() async throws {
+        let (container, tokenizer) = makeTestContainer()
+        let modelName = await container.configuration.name
+        let maxKVSize = 8
+        let store = PromptCacheStore()
+
+        let priorMessages: [MLXLMCommon.Chat.Message] = [.system(words([0])), .user(words([1, 2, 3, 4, 5]))]
+        let priorRawMessages = priorMessages.map { ["role": $0.role.rawValue, "content": $0.content] }
+        let priorTokens = try tokenizer.applyChatTemplate(
+            messages: priorRawMessages, tools: nil, additionalContext: nil
+        )
+
+        // Simulate "a slot was stored earlier and has since rotated past maxKVSize" directly,
+        // the same way `PromptCacheReuseClassificationTests.rotatedCacheRefusesReuseRegardlessOfMatchingPrefix`
+        // does, but wired into a real end-to-end run this time.
+        let cache = makeRotatedCache(tokens: priorTokens, layerCount: 2, maxKVSize: maxKVSize)
+        #expect(!promptCacheIsReusable(cache), "setup sanity: cache should have rotated")
+        store.checkin(
+            modelName: modelName,
+            slot: PromptCacheSlot(tokens: priorTokens, cache: cache, maxKVSize: maxKVSize)
+        )
+
+        let runner = ModelRunner(container: container, promptCacheStore: store)
+        var messages = priorMessages
+        messages.append(.user(words([6, 7])))
+        let parameters = GenerateParameters(maxTokens: 5, maxKVSize: maxKVSize, temperature: 0)
+
+        let result = try await runner.runChat(userInput: .init(chat: messages), parameters: parameters)
+        let baseline = try await runUncached(container: container, messages: messages, parameters: parameters)
+
+        #expect(result.output == baseline.output)
+    }
+
+    @Test func cancelMidGenerationThenNextRequestIsCleanAndCorrect() async throws {
+        let (container, _) = makeTestContainer()
+        let modelName = await container.configuration.name
+        let store = PromptCacheStore()
+        let runner = ModelRunner(container: container, promptCacheStore: store)
+        let parameters = GenerateParameters(maxTokens: 40, maxKVSize: 4096, temperature: 0)
+
+        // Rebuilt at each call site (rather than shared via one `let`) so the non-Sendable
+        // `[Chat.Message]` value doesn't get flagged as sent into the cancellable Task below
+        // while still "in use" by the follow-up calls afterward -- each call site owns its own
+        // independent value.
+        func buildMessages() -> [MLXLMCommon.Chat.Message] {
+            [.system(words([0])), .user(words([1, 2, 3]))]
+        }
+
+        let chunkCount = Counter()
+        // Run on its own Task (as production does via `runCancellingOnClose`) and cancel *that*
+        // task from within the callback -- deterministic, no scheduling race -- rather than
+        // cancelling whatever task happens to be running this test function itself, which would
+        // also derail the "clean next request" assertions below.
+        let cancellableTask = Task<ModelRunner.ChatRunResult, Error> {
+            try await runner.runChat(
+                userInput: .init(chat: buildMessages()),
+                parameters: parameters,
+                onToken: { _ in
+                    chunkCount.increment()
+                    if chunkCount.value == 3 {
+                        withUnsafeCurrentTask { $0?.cancel() }
+                    }
+                }
+            )
+        }
+        // runChat does not throw on cancellation; it returns whatever was accumulated so far.
+        _ = try await cancellableTask.value
+
+        #expect(store.peek(modelName: modelName) == nil, "an aborted generation must never be stored")
+
+        // The next request on the same model must be a clean run with correct output -- never
+        // corrupted state from the cancelled generation.
+        let followUp = try await runner.runChat(userInput: .init(chat: buildMessages()), parameters: parameters)
+        let baseline = try await runUncached(container: container, messages: buildMessages(), parameters: parameters)
+        #expect(followUp.output == baseline.output)
+    }
+
+    @Test func abortViaThrownErrorDuringStreamingNeverStoresAPartialSlot() async throws {
+        struct SimulatedDisconnect: Error {}
+
+        let (container, _) = makeTestContainer()
+        let modelName = await container.configuration.name
+        let store = PromptCacheStore()
+        let runner = ModelRunner(container: container, promptCacheStore: store)
+        let parameters = GenerateParameters(maxTokens: 40, maxKVSize: 4096, temperature: 0)
+        let messages: [MLXLMCommon.Chat.Message] = [.system(words([0])), .user(words([1, 2, 3]))]
+
+        let chunkCount = Counter()
+        do {
+            _ = try await runner.runChat(
+                userInput: .init(chat: messages),
+                parameters: parameters,
+                onToken: { _ in
+                    chunkCount.increment()
+                    if chunkCount.value == 3 {
+                        throw SimulatedDisconnect()
+                    }
+                }
+            )
+            Issue.record("expected runChat to rethrow the onToken failure")
+        }
+        catch is SimulatedDisconnect {
+            // expected
+        }
+
+        #expect(store.peek(modelName: modelName) == nil, "an aborted generation must never be stored")
+
+        let followUp = try await runner.runChat(userInput: .init(chat: messages), parameters: parameters)
+        let baseline = try await runUncached(container: container, messages: messages, parameters: parameters)
+        #expect(followUp.output == baseline.output)
+    }
+
+    @Test func storesOnCleanCompletionOnly() async throws {
+        let (container, _) = makeTestContainer()
+        let modelName = await container.configuration.name
+        let store = PromptCacheStore()
+        let runner = ModelRunner(container: container, promptCacheStore: store)
+        let parameters = GenerateParameters(maxTokens: 4, maxKVSize: 4096, temperature: 0)
+
+        #expect(store.peek(modelName: modelName) == nil)
+
+        let messages: [MLXLMCommon.Chat.Message] = [.system(words([0])), .user(words([1]))]
+        let result = try await runner.runChat(userInput: .init(chat: messages), parameters: parameters)
+
+        guard let slot = store.peek(modelName: modelName) else {
+            Issue.record("expected a slot after a clean completion")
+            return
+        }
+        #expect(slot.tokens.count > 0)
+        #expect(slot.maxKVSize == 4096)
+        // Precise store-side trim check: the cache must be trimmed back to *exactly* the
+        // request's prompt token count (discarding this turn's generated tokens), matching
+        // `ChatRunResult.promptTokens` -- not off by one in either direction. `next()` feeds
+        // exactly one token into the cache per yielded token, and none are fed beyond the last
+        // one yielded, so after `result.completionInfo!.generationTokenCount` tokens were
+        // generated, `offset == promptTokens + generationTokenCount`; trimming by
+        // `generationTokenCount` must land exactly back on `promptTokens`.
+        #expect(slot.tokens.count == result.promptTokens)
+        #expect(slot.cache[0].offset == result.promptTokens)
+        #expect(slot.cache.allSatisfy { $0.offset == result.promptTokens })
+    }
+}
+
+// MARK: - Counter
+
+/// A plain, unsynchronized mutable box for test callbacks that are invoked serially (as
+/// `runChat`'s `onToken` documents itself to be) but whose closure type is `@Sendable`.
+private final class Counter: @unchecked Sendable {
+    private(set) var value = 0
+
+    func increment() {
+        value += 1
+    }
+}

--- a/swama/Tests/SwamaKitTests/PromptCacheTests.swift
+++ b/swama/Tests/SwamaKitTests/PromptCacheTests.swift
@@ -45,15 +45,24 @@ private struct WordVocabTokenizer: MLXLMCommon.Tokenizer {
 
     let contentVocabSize: Int
 
-    var bosToken: String? { nil }
-    var eosToken: String? { nil }
-    var unknownToken: String? { nil }
+    var bosToken: String? {
+        nil
+    }
+
+    var eosToken: String? {
+        nil
+    }
+
+    var unknownToken: String? {
+        nil
+    }
 
     func encode(text: String, addSpecialTokens _: Bool) -> [Int] {
         text.split(separator: " ").compactMap { piece -> Int? in
             guard piece.hasPrefix("w"), let value = Int(piece.dropFirst()) else {
                 return nil
             }
+
             return ((value % contentVocabSize) + contentVocabSize) % contentVocabSize
         }
     }
@@ -61,14 +70,21 @@ private struct WordVocabTokenizer: MLXLMCommon.Tokenizer {
     func decode(tokenIds: [Int], skipSpecialTokens _: Bool) -> String {
         tokenIds.map { id in
             switch id {
-            case 0 ..< contentVocabSize: "w\(id) "
-            case Self.systemToken: "<sys> "
-            case Self.userToken: "<user> "
-            case Self.assistantToken: "<asst> "
-            case Self.sepToken: "<sep> "
-            default: "<unk\(id)> "
+            case 0 ..< contentVocabSize:
+                "w\(id) "
+            case Self.systemToken:
+                "<sys> "
+            case Self.userToken:
+                "<user> "
+            case Self.assistantToken:
+                "<asst> "
+            case Self.sepToken:
+                "<sep> "
+            default:
+                "<unk\(id)> "
             }
-        }.joined()
+        }
+        .joined()
     }
 
     func convertTokenToId(_ token: String) -> Int? {
@@ -76,11 +92,16 @@ private struct WordVocabTokenizer: MLXLMCommon.Tokenizer {
             return value
         }
         switch token {
-        case "<sys>": return Self.systemToken
-        case "<user>": return Self.userToken
-        case "<asst>": return Self.assistantToken
-        case "<sep>": return Self.sepToken
-        default: return nil
+        case "<sys>":
+            return Self.systemToken
+        case "<user>":
+            return Self.userToken
+        case "<asst>":
+            return Self.assistantToken
+        case "<sep>":
+            return Self.sepToken
+        default:
+            return nil
         }
     }
 
@@ -93,13 +114,16 @@ private struct WordVocabTokenizer: MLXLMCommon.Tokenizer {
         tools _: [[String: any Sendable]]?,
         additionalContext _: [String: any Sendable]?
     ) throws -> [Int] {
-        var tokens: [Int] = []
+        var tokens = [Int]()
         for message in messages {
             let role = message["role"] as? String ?? "user"
             switch role {
-            case "system": tokens.append(Self.systemToken)
-            case "assistant": tokens.append(Self.assistantToken)
-            default: tokens.append(Self.userToken)
+            case "system":
+                tokens.append(Self.systemToken)
+            case "assistant":
+                tokens.append(Self.assistantToken)
+            default:
+                tokens.append(Self.userToken)
             }
             if let content = message["content"] as? String {
                 tokens.append(contentsOf: encode(text: content, addSpecialTokens: false))
@@ -144,7 +168,9 @@ private final class WordEchoModel: MLXNN.Module, LLMModel, KVCacheDimensionProvi
     private let predictedLogit: Float
     private let alternativeLogit: Float
 
-    var loraLayers: [MLXNN.Module] { [] }
+    var loraLayers: [MLXNN.Module] {
+        []
+    }
 
     init(
         numLayers: Int,
@@ -167,8 +193,8 @@ private final class WordEchoModel: MLXNN.Module, LLMModel, KVCacheDimensionProvi
         let sequenceLength = inputs.dim(1)
         let keysIn = inputs.asType(.float32).reshaped([1, 1, sequenceLength, 1])
 
-        var history: [Float] = []
-        if let cache, !cache.isEmpty {
+        var history = [Float]()
+        if let cache, cache.isEmpty == false {
             for (index, layer) in cache.enumerated() {
                 let (k, _) = layer.update(keys: keysIn, values: keysIn)
                 if index == 0 {
@@ -190,7 +216,7 @@ private final class WordEchoModel: MLXNN.Module, LLMModel, KVCacheDimensionProvi
         row[predicted] = predictedLogit
         row[alternative] = max(row[alternative], alternativeLogit)
 
-        let flat = Array(repeating: row, count: sequenceLength).flatMap { $0 }
+        let flat = Array(repeating: row, count: sequenceLength).flatMap(\.self)
         return MLXArray(flat, [1, sequenceLength, outputVocabSize])
     }
 
@@ -198,6 +224,7 @@ private final class WordEchoModel: MLXNN.Module, LLMModel, KVCacheDimensionProvi
         guard history.count >= period else {
             return 0
         }
+
         let candidate = history[history.count - period]
         return ((candidate % contentVocabSize) + contentVocabSize) % contentVocabSize
     }
@@ -240,9 +267,10 @@ private func makeTestContainer(
 /// suitable for prefix-matching tests that aren't about rotation.
 private func makeSimpleCacheFedWithTokens(_ tokens: [Int], layerCount: Int) -> [KVCache] {
     let cache: [KVCache] = (0 ..< layerCount).map { _ in KVCacheSimple() }
-    guard !tokens.isEmpty else {
+    guard tokens.isEmpty == false else {
         return cache
     }
+
     let keys = MLXArray(tokens.map(Float.init), [1, 1, tokens.count, 1])
     for layer in cache {
         _ = layer.update(keys: keys, values: keys)
@@ -280,7 +308,7 @@ private func runUncached(
     )
 }
 
-// MARK: - PromptCacheReuseClassificationTests (whitebox)
+// MARK: - PromptCacheReuseClassificationTests
 
 @Suite("Prompt cache: reuse classification")
 struct PromptCacheReuseClassificationTests {
@@ -291,19 +319,21 @@ struct PromptCacheReuseClassificationTests {
         let cache = makeSimpleCacheFedWithTokens(previousTokens, layerCount: 2)
         store.checkin(
             modelName: modelName,
-            slot: PromptCacheSlot(tokens: previousTokens, cache: cache, maxKVSize: 4096)
+            slot: PromptCacheSlot(tokens: previousTokens, cache: cache, kvConfig: PromptCacheKVConfig(maxKVSize: 4096)),
+            epoch: store.currentEpoch(modelName: modelName)
         )
 
         let newTokens = previousTokens + [18, 5, 6, 19, 17, 7, 8, 19]
         let decision = resolvePromptCacheReuse(
             enabled: true, hasMediaInput: false, modelName: modelName,
-            newTokens: newTokens, maxKVSize: 4096, store: store
+            newTokens: newTokens, kvConfig: PromptCacheKVConfig(maxKVSize: 4096), store: store
         )
 
-        guard case let .reuse(matchedLength, reusedCache, reason) = decision else {
+        guard case let .reuse(matchedLength, reusedCache, reason, _) = decision else {
             Issue.record("expected .reuse, got \(decision)")
             return
         }
+
         #expect(matchedLength == previousTokens.count)
         #expect(reason == nil)
         #expect(reusedCache[0].offset == previousTokens.count)
@@ -317,7 +347,8 @@ struct PromptCacheReuseClassificationTests {
         let cache = makeSimpleCacheFedWithTokens(priorTokens, layerCount: 2)
         store.checkin(
             modelName: modelName,
-            slot: PromptCacheSlot(tokens: priorTokens, cache: cache, maxKVSize: 4096)
+            slot: PromptCacheSlot(tokens: priorTokens, cache: cache, kvConfig: PromptCacheKVConfig(maxKVSize: 4096)),
+            epoch: store.currentEpoch(modelName: modelName)
         )
 
         var editedTokens = priorTokens
@@ -326,13 +357,14 @@ struct PromptCacheReuseClassificationTests {
 
         let decision = resolvePromptCacheReuse(
             enabled: true, hasMediaInput: false, modelName: modelName,
-            newTokens: editedTokens, maxKVSize: 4096, store: store
+            newTokens: editedTokens, kvConfig: PromptCacheKVConfig(maxKVSize: 4096), store: store
         )
 
-        guard case let .reuse(matchedLength, _, reason) = decision else {
+        guard case let .reuse(matchedLength, _, reason, _) = decision else {
             Issue.record("expected .reuse (partial), got \(decision)")
             return
         }
+
         #expect(matchedLength == 4)
         #expect(reason == .partialMismatch)
     }
@@ -344,7 +376,8 @@ struct PromptCacheReuseClassificationTests {
         let cache = makeSimpleCacheFedWithTokens(priorTokens, layerCount: 2)
         store.checkin(
             modelName: modelName,
-            slot: PromptCacheSlot(tokens: priorTokens, cache: cache, maxKVSize: 4096)
+            slot: PromptCacheSlot(tokens: priorTokens, cache: cache, kvConfig: PromptCacheKVConfig(maxKVSize: 4096)),
+            epoch: store.currentEpoch(modelName: modelName)
         )
 
         // No system message this time: the sequence starts with the user-role token instead of
@@ -352,13 +385,14 @@ struct PromptCacheReuseClassificationTests {
         let newTokens = [17, 5, 19]
         let decision = resolvePromptCacheReuse(
             enabled: true, hasMediaInput: false, modelName: modelName,
-            newTokens: newTokens, maxKVSize: 4096, store: store
+            newTokens: newTokens, kvConfig: PromptCacheKVConfig(maxKVSize: 4096), store: store
         )
 
-        guard case let .miss(reason) = decision else {
+        guard case let .miss(reason, _) = decision else {
             Issue.record("expected .miss, got \(decision)")
             return
         }
+
         #expect(reason == .mismatchAtZero)
     }
 
@@ -369,19 +403,21 @@ struct PromptCacheReuseClassificationTests {
         let cache = makeSimpleCacheFedWithTokens(previousTokens, layerCount: 2)
         store.checkin(
             modelName: modelName,
-            slot: PromptCacheSlot(tokens: previousTokens, cache: cache, maxKVSize: 4096)
+            slot: PromptCacheSlot(tokens: previousTokens, cache: cache, kvConfig: PromptCacheKVConfig(maxKVSize: 4096)),
+            epoch: store.currentEpoch(modelName: modelName)
         )
 
         // The exact same prompt, resent verbatim.
         let decision = resolvePromptCacheReuse(
             enabled: true, hasMediaInput: false, modelName: modelName,
-            newTokens: previousTokens, maxKVSize: 4096, store: store
+            newTokens: previousTokens, kvConfig: PromptCacheKVConfig(maxKVSize: 4096), store: store
         )
 
-        guard case let .reuse(matchedLength, reusedCache, reason) = decision else {
+        guard case let .reuse(matchedLength, reusedCache, reason, _) = decision else {
             Issue.record("expected .reuse, got \(decision)")
             return
         }
+
         #expect(matchedLength == previousTokens.count - 1)
         #expect(reason == nil)
         #expect(reusedCache[0].offset == previousTokens.count - 1)
@@ -393,23 +429,29 @@ struct PromptCacheReuseClassificationTests {
         let maxKVSize = 6
         let priorTokens = Array(1 ... 10) // fed one at a time, exceeds maxKVSize -> rotates
         let cache = makeRotatedCache(tokens: priorTokens, layerCount: 2, maxKVSize: maxKVSize)
-        #expect(!promptCacheIsReusable(cache), "setup sanity: cache should have rotated")
+        #expect(promptCacheIsReusable(cache) == false, "setup sanity: cache should have rotated")
 
         store.checkin(
             modelName: modelName,
-            slot: PromptCacheSlot(tokens: priorTokens, cache: cache, maxKVSize: maxKVSize)
+            slot: PromptCacheSlot(
+                tokens: priorTokens,
+                cache: cache,
+                kvConfig: PromptCacheKVConfig(maxKVSize: maxKVSize)
+            ),
+            epoch: store.currentEpoch(modelName: modelName)
         )
 
         let newTokens = priorTokens + [11, 12] // would share a full prefix if reuse were attempted
         let decision = resolvePromptCacheReuse(
             enabled: true, hasMediaInput: false, modelName: modelName,
-            newTokens: newTokens, maxKVSize: maxKVSize, store: store
+            newTokens: newTokens, kvConfig: PromptCacheKVConfig(maxKVSize: maxKVSize), store: store
         )
 
-        guard case let .miss(reason) = decision else {
+        guard case let .miss(reason, _) = decision else {
             Issue.record("expected .miss, got \(decision)")
             return
         }
+
         #expect(reason == .rotated)
         #expect(store.checkout(modelName: modelName) == nil, "rotated slot must be dropped, not reused")
     }
@@ -421,31 +463,151 @@ struct PromptCacheReuseClassificationTests {
         let cache = makeSimpleCacheFedWithTokens(priorTokens, layerCount: 1)
         store.checkin(
             modelName: modelName,
-            slot: PromptCacheSlot(tokens: priorTokens, cache: cache, maxKVSize: 2048)
+            slot: PromptCacheSlot(tokens: priorTokens, cache: cache, kvConfig: PromptCacheKVConfig(maxKVSize: 2048)),
+            epoch: store.currentEpoch(modelName: modelName)
         )
 
         let decision = resolvePromptCacheReuse(
             enabled: true, hasMediaInput: false, modelName: modelName,
-            newTokens: priorTokens + [18, 3, 19], maxKVSize: 4096, store: store
+            newTokens: priorTokens + [18, 3, 19], kvConfig: PromptCacheKVConfig(maxKVSize: 4096), store: store
         )
 
-        guard case let .miss(reason) = decision else {
+        guard case let .miss(reason, _) = decision else {
             Issue.record("expected .miss, got \(decision)")
             return
         }
+
         #expect(reason == .kvConfigChanged)
+    }
+
+    // MARK: KV-config fingerprint (kvBits / kvGroupSize / quantizedKVStart)
+
+    /// Unlike their siblings above, the tests in this section build slots from a bare, never-fed
+    /// `KVCacheSimple()` instead of `makeSimpleCacheFedWithTokens`. `resolvePromptCacheReuse`'s
+    /// `PromptCacheKVConfig` comparison runs *before* anything touches `KVCache.update(keys:
+    /// values:)` (the real MLX tensor op that needs a Metal runtime this environment lacks -- see
+    /// the harness's hazard note), so a never-fed cache classifies identically for these purposes
+    /// while keeping these specific tests runnable without one.
+    @Test func kvBitsChangeIsAMiss() {
+        let store = PromptCacheStore()
+        let modelName = "model-kvbits-change"
+        let priorTokens = [16, 1, 19, 17, 2, 19]
+        store.checkin(
+            modelName: modelName,
+            slot: PromptCacheSlot(
+                tokens: priorTokens, cache: [KVCacheSimple()],
+                kvConfig: PromptCacheKVConfig(maxKVSize: 4096, kvBits: 8, kvGroupSize: 64, quantizedKVStart: 0)
+            ),
+            epoch: store.currentEpoch(modelName: modelName)
+        )
+
+        let decision = resolvePromptCacheReuse(
+            enabled: true, hasMediaInput: false, modelName: modelName,
+            newTokens: priorTokens + [18, 3, 19],
+            kvConfig: PromptCacheKVConfig(maxKVSize: 4096, kvBits: 4, kvGroupSize: 64, quantizedKVStart: 0),
+            store: store
+        )
+
+        guard case let .miss(reason, _) = decision else {
+            Issue.record("expected .miss, got \(decision)")
+            return
+        }
+
+        #expect(reason == .kvConfigChanged)
+    }
+
+    @Test func kvGroupSizeChangeIsAMiss() {
+        let store = PromptCacheStore()
+        let modelName = "model-kvgroupsize-change"
+        let priorTokens = [16, 1, 19, 17, 2, 19]
+        store.checkin(
+            modelName: modelName,
+            slot: PromptCacheSlot(
+                tokens: priorTokens, cache: [KVCacheSimple()],
+                kvConfig: PromptCacheKVConfig(maxKVSize: 4096, kvBits: 8, kvGroupSize: 64, quantizedKVStart: 0)
+            ),
+            epoch: store.currentEpoch(modelName: modelName)
+        )
+
+        // kvBits held fixed at 8 on both sides so kvGroupSize is the only field under test.
+        let decision = resolvePromptCacheReuse(
+            enabled: true, hasMediaInput: false, modelName: modelName,
+            newTokens: priorTokens + [18, 3, 19],
+            kvConfig: PromptCacheKVConfig(maxKVSize: 4096, kvBits: 8, kvGroupSize: 32, quantizedKVStart: 0),
+            store: store
+        )
+
+        guard case let .miss(reason, _) = decision else {
+            Issue.record("expected .miss, got \(decision)")
+            return
+        }
+
+        #expect(reason == .kvConfigChanged)
+    }
+
+    @Test func quantizedKVStartChangeIsAMiss() {
+        let store = PromptCacheStore()
+        let modelName = "model-quantizedkvstart-change"
+        let priorTokens = [16, 1, 19, 17, 2, 19]
+        store.checkin(
+            modelName: modelName,
+            slot: PromptCacheSlot(
+                tokens: priorTokens, cache: [KVCacheSimple()],
+                kvConfig: PromptCacheKVConfig(maxKVSize: 4096, kvBits: 8, kvGroupSize: 64, quantizedKVStart: 0)
+            ),
+            epoch: store.currentEpoch(modelName: modelName)
+        )
+
+        // kvBits/kvGroupSize held fixed on both sides so quantizedKVStart is the only field under
+        // test.
+        let decision = resolvePromptCacheReuse(
+            enabled: true, hasMediaInput: false, modelName: modelName,
+            newTokens: priorTokens + [18, 3, 19],
+            kvConfig: PromptCacheKVConfig(maxKVSize: 4096, kvBits: 8, kvGroupSize: 64, quantizedKVStart: 8),
+            store: store
+        )
+
+        guard case let .miss(reason, _) = decision else {
+            Issue.record("expected .miss, got \(decision)")
+            return
+        }
+
+        #expect(reason == .kvConfigChanged)
+    }
+
+    @Test func identicalKVConfigIncludingQuantizationSettingsStillHits() {
+        let store = PromptCacheStore()
+        let modelName = "model-kvconfig-match"
+        let priorTokens = [16, 1, 19, 17, 2, 19]
+        let config = PromptCacheKVConfig(maxKVSize: 4096, kvBits: 8, kvGroupSize: 32, quantizedKVStart: 4)
+        store.checkin(
+            modelName: modelName,
+            slot: PromptCacheSlot(tokens: priorTokens, cache: [KVCacheSimple()], kvConfig: config),
+            epoch: store.currentEpoch(modelName: modelName)
+        )
+
+        let decision = resolvePromptCacheReuse(
+            enabled: true, hasMediaInput: false, modelName: modelName,
+            newTokens: priorTokens + [18, 3, 19], kvConfig: config, store: store
+        )
+
+        guard case .reuse = decision else {
+            Issue.record("expected .reuse, got \(decision)")
+            return
+        }
     }
 
     @Test func noSlotWhenModelHasNeverBeenSeen() {
         let store = PromptCacheStore()
         let decision = resolvePromptCacheReuse(
             enabled: true, hasMediaInput: false, modelName: "never-seen",
-            newTokens: [1, 2, 3], maxKVSize: 4096, store: store
+            newTokens: [1, 2, 3], kvConfig: PromptCacheKVConfig(maxKVSize: 4096), store: store
         )
-        guard case let .miss(reason) = decision else {
+        guard case let .miss(reason, _) = decision else {
             Issue.record("expected .miss, got \(decision)")
             return
         }
+
         #expect(reason == .noSlot)
     }
 
@@ -455,18 +617,21 @@ struct PromptCacheReuseClassificationTests {
         store.checkin(
             modelName: modelName,
             slot: PromptCacheSlot(
-                tokens: [1, 2], cache: makeSimpleCacheFedWithTokens([1, 2], layerCount: 1), maxKVSize: 100
-            )
+                tokens: [1, 2], cache: makeSimpleCacheFedWithTokens([1, 2], layerCount: 1),
+                kvConfig: PromptCacheKVConfig(maxKVSize: 100)
+            ),
+            epoch: store.currentEpoch(modelName: modelName)
         )
 
         let decision = resolvePromptCacheReuse(
             enabled: false, hasMediaInput: false, modelName: modelName,
-            newTokens: [1, 2, 3], maxKVSize: 100, store: store
+            newTokens: [1, 2, 3], kvConfig: PromptCacheKVConfig(maxKVSize: 100), store: store
         )
-        guard case let .miss(reason) = decision else {
+        guard case let .miss(reason, _) = decision else {
             Issue.record("expected .miss, got \(decision)")
             return
         }
+
         #expect(reason == .disabled)
         #expect(store.peek(modelName: modelName) != nil, "disabled must not disturb an existing slot")
     }
@@ -477,24 +642,27 @@ struct PromptCacheReuseClassificationTests {
         store.checkin(
             modelName: modelName,
             slot: PromptCacheSlot(
-                tokens: [1, 2], cache: makeSimpleCacheFedWithTokens([1, 2], layerCount: 1), maxKVSize: 100
-            )
+                tokens: [1, 2], cache: makeSimpleCacheFedWithTokens([1, 2], layerCount: 1),
+                kvConfig: PromptCacheKVConfig(maxKVSize: 100)
+            ),
+            epoch: store.currentEpoch(modelName: modelName)
         )
 
         let decision = resolvePromptCacheReuse(
             enabled: true, hasMediaInput: true, modelName: modelName,
-            newTokens: [1, 2, 3], maxKVSize: 100, store: store
+            newTokens: [1, 2, 3], kvConfig: PromptCacheKVConfig(maxKVSize: 100), store: store
         )
-        guard case let .miss(reason) = decision else {
+        guard case let .miss(reason, _) = decision else {
             Issue.record("expected .miss, got \(decision)")
             return
         }
+
         #expect(reason == .multimodal)
         #expect(store.peek(modelName: modelName) != nil, "multimodal must not disturb an existing slot")
     }
 }
 
-// MARK: - PromptCacheStoreTests (slot lifecycle, pure)
+// MARK: - PromptCacheStoreTests
 
 @Suite("Prompt cache: store lifecycle")
 struct PromptCacheStoreTests {
@@ -502,11 +670,21 @@ struct PromptCacheStoreTests {
         let store = PromptCacheStore()
         store.checkin(
             modelName: "a",
-            slot: PromptCacheSlot(tokens: [1, 2, 3], cache: [KVCacheSimple()], maxKVSize: 100)
+            slot: PromptCacheSlot(
+                tokens: [1, 2, 3],
+                cache: [KVCacheSimple()],
+                kvConfig: PromptCacheKVConfig(maxKVSize: 100)
+            ),
+            epoch: store.currentEpoch(modelName: "a")
         )
         store.checkin(
             modelName: "b",
-            slot: PromptCacheSlot(tokens: [4, 5], cache: [KVCacheSimple()], maxKVSize: 100)
+            slot: PromptCacheSlot(
+                tokens: [4, 5],
+                cache: [KVCacheSimple()],
+                kvConfig: PromptCacheKVConfig(maxKVSize: 100)
+            ),
+            epoch: store.currentEpoch(modelName: "b")
         )
 
         store.drop(modelName: "a")
@@ -521,7 +699,12 @@ struct PromptCacheStoreTests {
         let store = PromptCacheStore()
         store.checkin(
             modelName: "m",
-            slot: PromptCacheSlot(tokens: [1, 2], cache: [KVCacheSimple()], maxKVSize: 100)
+            slot: PromptCacheSlot(
+                tokens: [1, 2],
+                cache: [KVCacheSimple()],
+                kvConfig: PromptCacheKVConfig(maxKVSize: 100)
+            ),
+            epoch: store.currentEpoch(modelName: "m")
         )
 
         #expect(store.peek(modelName: "m") != nil)
@@ -529,9 +712,223 @@ struct PromptCacheStoreTests {
         #expect(store.checkout(modelName: "m") != nil)
         #expect(store.peek(modelName: "m") == nil, "checkout must remove the slot")
     }
+
+    @Test func dropBumpsThatModelsEpochEvenWithNoLiveSlotAndLeavesOtherModelsAlone() {
+        let store = PromptCacheStore()
+        let epochBefore = store.currentEpoch(modelName: "never-had-a-slot")
+
+        // `drop` must invalidate a future write-back for this model even though no slot exists
+        // to remove right now -- see `PromptCacheStore.modelEpochs`'s "never cleared" note.
+        store.drop(modelName: "never-had-a-slot")
+        let epochAfter = store.currentEpoch(modelName: "never-had-a-slot")
+        #expect(epochAfter != epochBefore, "drop must bump the per-model epoch even with no live slot")
+
+        let untouchedBefore = store.currentEpoch(modelName: "untouched")
+        store.drop(modelName: "never-had-a-slot")
+        let untouchedAfter = store.currentEpoch(modelName: "untouched")
+        #expect(untouchedAfter == untouchedBefore, "dropping one model must not bump another model's epoch")
+    }
+
+    @Test func dropAllBumpsTheGlobalEpochForEveryModelIncludingOnesNeverSeen() {
+        let store = PromptCacheStore()
+        let neverSeenBefore = store.currentEpoch(modelName: "never-seen")
+        let seededBefore = store.currentEpoch(modelName: "seeded")
+
+        store.dropAll()
+
+        #expect(
+            store.currentEpoch(modelName: "never-seen") != neverSeenBefore,
+            "dropAll must invalidate even a model with no slot and no prior per-model drop"
+        )
+        #expect(store.currentEpoch(modelName: "seeded") != seededBefore)
+    }
 }
 
-// MARK: - PromptCacheEndToEndTests (blackbox: real ModelRunner.runChat round trips)
+// MARK: - PromptCacheEpochInvalidationTests
+
+/// Covers the callout on `ModelPool.clearCache()`'s `PromptCacheStore.shared.dropAll()` call:
+/// `ModelPool.run` suspends while an inference is in flight, so `clearCache()`/`remove(modelName:)`
+/// can mutate the store while a still-running `ModelRunner` already holds (or is about to build) a
+/// slot for the model being cleared, and its eventual `checkin` must not resurrect what was just
+/// invalidated. `ModelPool` itself is never constructed here (see the harness's hazard note) --
+/// every test drives `PromptCacheStore` directly, exactly as `ModelPool.clearCache()`/
+/// `remove(modelName:)` do via their own `dropAll()`/`drop(modelName:)` calls.
+@Suite("Prompt cache: epoch invalidation")
+struct PromptCacheEpochInvalidationTests {
+    @Test func checkinIsRejectedAfterDropAllEvenWithTheTokenCapturedAtCheckout() {
+        let store = PromptCacheStore()
+        let modelName = "model-dropall-race"
+        let slot = PromptCacheSlot(
+            tokens: [1, 2, 3],
+            cache: [KVCacheSimple()],
+            kvConfig: PromptCacheKVConfig(maxKVSize: 100)
+        )
+        store.checkin(modelName: modelName, slot: slot, epoch: store.currentEpoch(modelName: modelName))
+
+        guard let (checkedOutSlot, epoch) = store.checkout(modelName: modelName) else {
+            Issue.record("expected a slot to check out")
+            return
+        }
+
+        // Simulates `ModelPool.run` being suspended awaiting an in-flight inference's operation
+        // while `clearCache()` runs on the actor and calls `dropAll()`.
+        store.dropAll()
+
+        let accepted = store.checkin(modelName: modelName, slot: checkedOutSlot, epoch: epoch)
+        #expect(accepted == false, "checkin must be rejected once the global epoch has moved on")
+        #expect(store.peek(modelName: modelName) == nil, "a stale check-in must not resurrect a slot")
+    }
+
+    @Test func checkinIsRejectedAfterDropOfThatModelButNotAfterDroppingAnotherModel() {
+        let store = PromptCacheStore()
+        let droppedModel = "model-dropped"
+        let otherModel = "model-untouched"
+        let droppedSlot = PromptCacheSlot(
+            tokens: [1, 2],
+            cache: [KVCacheSimple()],
+            kvConfig: PromptCacheKVConfig(maxKVSize: 100)
+        )
+        let otherSlot = PromptCacheSlot(
+            tokens: [3, 4],
+            cache: [KVCacheSimple()],
+            kvConfig: PromptCacheKVConfig(maxKVSize: 100)
+        )
+        store.checkin(modelName: droppedModel, slot: droppedSlot, epoch: store.currentEpoch(modelName: droppedModel))
+        store.checkin(modelName: otherModel, slot: otherSlot, epoch: store.currentEpoch(modelName: otherModel))
+
+        guard let (checkedOutDropped, droppedEpoch) = store.checkout(modelName: droppedModel) else {
+            Issue.record("expected \(droppedModel)'s slot to check out")
+            return
+        }
+        guard let (checkedOutOther, otherEpoch) = store.checkout(modelName: otherModel) else {
+            Issue.record("expected \(otherModel)'s slot to check out")
+            return
+        }
+
+        // Simulates `ModelPool.remove(modelName:)` racing with just `droppedModel`'s in-flight
+        // inference -- `otherModel`'s concurrently in-flight inference must be unaffected.
+        store.drop(modelName: droppedModel)
+
+        let droppedAccepted = store.checkin(modelName: droppedModel, slot: checkedOutDropped, epoch: droppedEpoch)
+        #expect(droppedAccepted == false, "checkin for the dropped model must be rejected")
+        #expect(store.peek(modelName: droppedModel) == nil)
+
+        // Control: an unrelated model's checkin must still succeed -- proves the rejection above
+        // is targeted at `droppedModel`'s epoch, not some global side effect of calling `drop`.
+        let otherAccepted = store.checkin(modelName: otherModel, slot: checkedOutOther, epoch: otherEpoch)
+        #expect(otherAccepted, "checkin for an untouched model must still succeed")
+        #expect(store.peek(modelName: otherModel) != nil)
+    }
+
+    @Test func currentEpochCapturedOnTheMissPathIsInvalidatedByADropAllBeforeCheckin() {
+        let store = PromptCacheStore()
+        let modelName = "model-never-seen-yet"
+
+        // Mirrors `resolvePromptCacheReuse`'s `.noSlot` branch: no slot exists yet, so the caller
+        // captures `currentEpoch` up front, intending to write a freshly-built cache back at the
+        // end of generation.
+        let epoch = store.currentEpoch(modelName: modelName)
+
+        store.dropAll()
+
+        let freshSlot = PromptCacheSlot(
+            tokens: [1, 2, 3],
+            cache: [KVCacheSimple()],
+            kvConfig: PromptCacheKVConfig(maxKVSize: 100)
+        )
+        let accepted = store.checkin(modelName: modelName, slot: freshSlot, epoch: epoch)
+        #expect(accepted == false, "a global epoch bump before checkin must reject even a miss-path write-back")
+        #expect(store.peek(modelName: modelName) == nil)
+    }
+
+    @Test func ordinaryCheckoutCheckinRoundTripWithNoInterveningDropStillStores() {
+        // Guards against the epoch check rejecting everything -- that failure mode would look
+        // like a passing suite sitting on top of a cache that never actually stores anything.
+        let store = PromptCacheStore()
+        let modelName = "model-clean-path"
+        let slot = PromptCacheSlot(
+            tokens: [1, 2],
+            cache: [KVCacheSimple()],
+            kvConfig: PromptCacheKVConfig(maxKVSize: 100)
+        )
+        store.checkin(modelName: modelName, slot: slot, epoch: store.currentEpoch(modelName: modelName))
+
+        guard let (checkedOut, epoch) = store.checkout(modelName: modelName) else {
+            Issue.record("expected a slot to check out")
+            return
+        }
+
+        let accepted = store.checkin(modelName: modelName, slot: checkedOut, epoch: epoch)
+        #expect(accepted, "an ordinary checkout/checkin round trip with no intervening drop must still store")
+        #expect(store.peek(modelName: modelName) != nil)
+    }
+}
+
+// MARK: - PromptCacheIteratorStrategyTests
+
+/// `promptCacheIteratorStrategy` is a pure function over three plain values (no `KVCache`,
+/// `MLXArray`, or `TokenIterator` involved), so these tests exercise the initializer-selection
+/// decision directly rather than trying to assert on a constructed `TokenIterator` (whose
+/// `kvBits`/`kvGroupSize`/`quantizedKVStart` are internal `let`s SwamaKit cannot read back out).
+/// Also useful in this sandbox specifically: unlike almost everything else in this file, none of
+/// these tests can ever hit the missing-metallib crash, since nothing here touches MLX.
+@Suite("Prompt cache: iterator strategy")
+struct PromptCacheIteratorStrategyTests {
+    @Test func missPathAlwaysUsesParametersRegardlessOfProcessorOrKVBits() {
+        // needsFullHistoryWrapper: false covers every cacheable-miss path -- `iterInput` already
+        // is the full prompt there, so there is never anything to wrap, independent of whether a
+        // penalty processor or KV quantization is configured.
+        #expect(
+            promptCacheIteratorStrategy(needsFullHistoryWrapper: false, hasPenaltyProcessor: false, kvBits: nil)
+                == .parameters
+        )
+        #expect(
+            promptCacheIteratorStrategy(needsFullHistoryWrapper: false, hasPenaltyProcessor: true, kvBits: nil)
+                == .parameters
+        )
+        #expect(
+            promptCacheIteratorStrategy(needsFullHistoryWrapper: false, hasPenaltyProcessor: true, kvBits: 4)
+                == .parameters
+        )
+    }
+
+    @Test func cacheHitWithNoPenaltyProcessorUsesParameters() {
+        // A cache hit with nothing to wrap: no reason to give up the `parameters:` initializer's
+        // full KV-config fidelity just because this is a suffix-only prefill.
+        #expect(
+            promptCacheIteratorStrategy(needsFullHistoryWrapper: true, hasPenaltyProcessor: false, kvBits: nil)
+                == .parameters
+        )
+        #expect(
+            promptCacheIteratorStrategy(needsFullHistoryWrapper: true, hasPenaltyProcessor: false, kvBits: 8)
+                == .parameters
+        )
+    }
+
+    @Test func cacheHitWithPenaltyProcessorAndNoKVQuantizationUsesProcessorWrapper() {
+        #expect(
+            promptCacheIteratorStrategy(needsFullHistoryWrapper: true, hasPenaltyProcessor: true, kvBits: nil)
+                == .processorWrapper
+        )
+    }
+
+    @Test func cacheHitWithPenaltyProcessorAndKVQuantizationBypasses() {
+        // The one combination neither upstream initializer can serve correctly: a full-history
+        // wrapper is needed (drops to the processor:sampler: overload) but the caller also wants
+        // KV quantization (which that overload's hardcoded kvBits: nil would silently disable).
+        #expect(
+            promptCacheIteratorStrategy(needsFullHistoryWrapper: true, hasPenaltyProcessor: true, kvBits: 8)
+                == .bypass
+        )
+        #expect(
+            promptCacheIteratorStrategy(needsFullHistoryWrapper: true, hasPenaltyProcessor: true, kvBits: 0)
+                == .bypass,
+            "kvBits: 0 is still non-nil -- a caller asking for 0-bit quantization must not be treated as unset"
+        )
+    }
+}
+
+// MARK: - PromptCacheEndToEndTests
 
 @Suite("Prompt cache: end to end")
 struct PromptCacheEndToEndTests {
@@ -555,7 +952,7 @@ struct PromptCacheEndToEndTests {
 
         let cachedRunner = ModelRunner(container: container, promptCacheStore: PromptCacheStore())
         var cachedMessages: [MLXLMCommon.Chat.Message] = [.system(words([0]))]
-        var cachedOutputs: [String] = []
+        var cachedOutputs = [String]()
         for turnWords in userTurns {
             cachedMessages.append(.user(words(turnWords)))
             let result = try await cachedRunner.runChat(
@@ -566,7 +963,7 @@ struct PromptCacheEndToEndTests {
         }
 
         var uncachedMessages: [MLXLMCommon.Chat.Message] = [.system(words([0]))]
-        var uncachedOutputs: [String] = []
+        var uncachedOutputs = [String]()
         for turnWords in userTurns {
             uncachedMessages.append(.user(words(turnWords)))
             let result = try await runUncached(
@@ -577,7 +974,7 @@ struct PromptCacheEndToEndTests {
         }
 
         #expect(cachedOutputs.count == userTurns.count)
-        #expect(cachedOutputs.allSatisfy { !$0.isEmpty })
+        #expect(cachedOutputs.allSatisfy { $0.isEmpty == false })
         #expect(cachedOutputs == uncachedOutputs, "cached and uncached generation must be tokenwise identical")
     }
 
@@ -591,10 +988,11 @@ struct PromptCacheEndToEndTests {
         var messages: [MLXLMCommon.Chat.Message] = [.system(words([0])), .user(words([1, 2]))]
         let turn1 = try await runner.runChat(userInput: .init(chat: messages), parameters: parameters)
 
-        guard let slotAfterTurn1 = store.peek(modelName: modelName) else {
-            Issue.record("expected a slot to be stored after a clean turn")
-            return
-        }
+        let slotAfterTurn1 = try #require(
+            store.peek(modelName: modelName),
+            "expected a slot to be stored after a clean turn"
+        )
+
         let turn1PromptTokenCount = slotAfterTurn1.tokens.count
 
         messages.append(.assistant(turn1.output))
@@ -604,10 +1002,8 @@ struct PromptCacheEndToEndTests {
         let baseline = try await runUncached(container: container, messages: messages, parameters: parameters)
         #expect(turn2.output == baseline.output)
 
-        guard let slotAfterTurn2 = store.peek(modelName: modelName) else {
-            Issue.record("expected a slot to be stored after turn 2")
-            return
-        }
+        let slotAfterTurn2 = try #require(store.peek(modelName: modelName), "expected a slot to be stored after turn 2")
+
         // The stored slot always holds exactly the prompt tokens for the last clean turn (no
         // generated tokens); turn 2's prompt is turn 1's prompt plus the appended messages, so
         // its stored length must be strictly greater than turn 1's.
@@ -687,10 +1083,15 @@ struct PromptCacheEndToEndTests {
         // the same way `PromptCacheReuseClassificationTests.rotatedCacheRefusesReuseRegardlessOfMatchingPrefix`
         // does, but wired into a real end-to-end run this time.
         let cache = makeRotatedCache(tokens: priorTokens, layerCount: 2, maxKVSize: maxKVSize)
-        #expect(!promptCacheIsReusable(cache), "setup sanity: cache should have rotated")
+        #expect(promptCacheIsReusable(cache) == false, "setup sanity: cache should have rotated")
         store.checkin(
             modelName: modelName,
-            slot: PromptCacheSlot(tokens: priorTokens, cache: cache, maxKVSize: maxKVSize)
+            slot: PromptCacheSlot(
+                tokens: priorTokens,
+                cache: cache,
+                kvConfig: PromptCacheKVConfig(maxKVSize: maxKVSize)
+            ),
+            epoch: store.currentEpoch(modelName: modelName)
         )
 
         let runner = ModelRunner(container: container, promptCacheStore: store)
@@ -704,6 +1105,56 @@ struct PromptCacheEndToEndTests {
         #expect(result.output == baseline.output)
     }
 
+    /// Covers the callout on `ModelRunner.swift`'s `buildPromptCacheGenerationRun`: a cache hit
+    /// whose `GenerateParameters` configure both a penalty processor (forcing the
+    /// `FullHistoryLogitProcessor` wrapper) *and* KV quantization (`kvBits != nil`) must not
+    /// silently reuse the slot through the wrapper's hardcoded `kvBits: nil` -- see
+    /// `PromptCacheIteratorStrategy.bypass`.
+    ///
+    /// Unlike this suite's other tests, this one cannot be distinguished from the pre-fix
+    /// behavior by a compile error: it only calls upstream's own, pre-existing
+    /// `GenerateParameters(kvBits:)`, not any new SwamaKit symbol. The only way to observe the
+    /// difference is behaviorally -- turn 2 must decline the cache hit `resolvePromptCacheReuse`
+    /// found and store nothing back, where the pre-fix code would have silently reused it via the
+    /// processor:sampler: overload (dropping kvBits) and stored the result. That requires
+    /// actually running this test, which this sandbox cannot do for any test that reaches a real
+    /// MLXArray tensor op (see the harness's hazard note) -- turn 1's prefill alone is already
+    /// enough to trigger `maybeQuantizeKVCache`'s real quantization math once `kvBits` is
+    /// non-nil, on top of the pre-existing missing-metallib limitation every other blackbox test
+    /// in this file already has.
+    @Test func kvBitsWithPenaltyProcessorOnCacheHitBypassesReuseAndProducesCorrectOutput() async throws {
+        let (container, _) = makeTestContainer(period: 5)
+        let modelName = await container.configuration.name
+        let store = PromptCacheStore()
+        let runner = ModelRunner(container: container, promptCacheStore: store)
+        let parameters = GenerateParameters(
+            maxTokens: 4, maxKVSize: 4096, kvBits: 8, temperature: 0,
+            repetitionPenalty: 1.3, repetitionContextSize: 40
+        )
+
+        var messages: [MLXLMCommon.Chat.Message] = [.system(words([0])), .user(words([1, 2]))]
+        let turn1 = try await runner.runChat(userInput: .init(chat: messages), parameters: parameters)
+        #expect(store.peek(modelName: modelName) != nil, "setup sanity: turn 1 must have primed a slot")
+
+        messages.append(.assistant(turn1.output))
+        messages.append(.user(words([3, 4, 5])))
+
+        // Turn 2 shares turn 1's exact kvConfig and appends onto its token sequence, so
+        // `resolvePromptCacheReuse` would ordinarily report `.reuse` here -- the bypass must
+        // intercept that decision before any `TokenIterator` gets built for it.
+        let turn2 = try await runner.runChat(userInput: .init(chat: messages), parameters: parameters)
+        let baseline = try await runUncached(container: container, messages: messages, parameters: parameters)
+
+        #expect(turn2.output == baseline.output)
+        #expect(
+            store.peek(modelName: modelName) == nil,
+            """
+            a bypassed cache hit must neither resurrect the slot resolvePromptCacheReuse already \
+            checked out nor store a new one -- run.cache is nil on the .kvQuantizationUnsupported path
+            """
+        )
+    }
+
     @Test func cancelMidGenerationThenNextRequestIsCleanAndCorrect() async throws {
         let (container, _) = makeTestContainer()
         let modelName = await container.configuration.name
@@ -711,10 +1162,10 @@ struct PromptCacheEndToEndTests {
         let runner = ModelRunner(container: container, promptCacheStore: store)
         let parameters = GenerateParameters(maxTokens: 40, maxKVSize: 4096, temperature: 0)
 
-        // Rebuilt at each call site (rather than shared via one `let`) so the non-Sendable
-        // `[Chat.Message]` value doesn't get flagged as sent into the cancellable Task below
-        // while still "in use" by the follow-up calls afterward -- each call site owns its own
-        // independent value.
+        /// Rebuilt at each call site (rather than shared via one `let`) so the non-Sendable
+        /// `[Chat.Message]` value doesn't get flagged as sent into the cancellable Task below
+        /// while still "in use" by the follow-up calls afterward -- each call site owns its own
+        /// independent value.
         func buildMessages() -> [MLXLMCommon.Chat.Message] {
             [.system(words([0])), .user(words([1, 2, 3]))]
         }
@@ -746,6 +1197,90 @@ struct PromptCacheEndToEndTests {
         let followUp = try await runner.runChat(userInput: .init(chat: buildMessages()), parameters: parameters)
         let baseline = try await runUncached(container: container, messages: buildMessages(), parameters: parameters)
         #expect(followUp.output == baseline.output)
+    }
+
+    @Test func dropAllMidGenerationDoesNotResurrectAStaleSlotAndNextRequestIsCorrect() async throws {
+        let (container, _) = makeTestContainer()
+        let modelName = await container.configuration.name
+        let store = PromptCacheStore()
+        let runner = ModelRunner(container: container, promptCacheStore: store)
+        let parameters = GenerateParameters(maxTokens: 40, maxKVSize: 4096, temperature: 0)
+
+        // Prime a slot with a first, ordinary turn so turn 2 below is a genuine cache *hit*
+        // (checkout, not just `currentEpoch` on a miss) -- the exact shape of the callout: an
+        // in-flight inference that has already checked a slot out for reuse.
+        var messages: [MLXLMCommon.Chat.Message] = [.system(words([0])), .user(words([1, 2]))]
+        let turn1 = try await runner.runChat(userInput: .init(chat: messages), parameters: parameters)
+        #expect(store.peek(modelName: modelName) != nil, "setup sanity: turn 1 must have primed a slot")
+
+        messages.append(.assistant(turn1.output))
+        messages.append(.user(words([3, 4, 5])))
+
+        let chunkCount = Counter()
+        let turn2 = try await runner.runChat(
+            userInput: .init(chat: messages),
+            parameters: parameters,
+            onToken: { _ in
+                chunkCount.increment()
+                if chunkCount.value == 3 {
+                    // Simulates `ModelPool.run` suspended awaiting turn 2's still-in-flight
+                    // operation while `clearCache()` runs on the actor and calls `dropAll()` --
+                    // the callout this fix addresses.
+                    store.dropAll()
+                }
+            }
+        )
+
+        #expect(turn2.output.isEmpty == false)
+        #expect(
+            store.peek(modelName: modelName) == nil,
+            "turn 2's check-in must not resurrect a slot dropAll() already cleared"
+        )
+
+        // The next request must still be a clean, correct run -- never stale/corrupted state
+        // left over from the invalidated (but still-completed) turn 2.
+        let turn3 = try await runner.runChat(userInput: .init(chat: messages), parameters: parameters)
+        let baseline = try await runUncached(container: container, messages: messages, parameters: parameters)
+        #expect(turn3.output == baseline.output)
+    }
+
+    @Test func dropModelNameMidGenerationDoesNotResurrectAStaleSlotAndNextRequestIsCorrect() async throws {
+        let (container, _) = makeTestContainer()
+        let modelName = await container.configuration.name
+        let store = PromptCacheStore()
+        let runner = ModelRunner(container: container, promptCacheStore: store)
+        let parameters = GenerateParameters(maxTokens: 40, maxKVSize: 4096, temperature: 0)
+
+        var messages: [MLXLMCommon.Chat.Message] = [.system(words([0])), .user(words([1, 2]))]
+        let turn1 = try await runner.runChat(userInput: .init(chat: messages), parameters: parameters)
+        #expect(store.peek(modelName: modelName) != nil, "setup sanity: turn 1 must have primed a slot")
+
+        messages.append(.assistant(turn1.output))
+        messages.append(.user(words([3, 4, 5])))
+
+        let chunkCount = Counter()
+        let turn2 = try await runner.runChat(
+            userInput: .init(chat: messages),
+            parameters: parameters,
+            onToken: { _ in
+                chunkCount.increment()
+                if chunkCount.value == 3 {
+                    // Sibling of the `dropAll` test above, but for the targeted
+                    // `ModelPool.remove(modelName:)` path via `drop(modelName:)`.
+                    store.drop(modelName: modelName)
+                }
+            }
+        )
+
+        #expect(turn2.output.isEmpty == false)
+        #expect(
+            store.peek(modelName: modelName) == nil,
+            "turn 2's check-in must not resurrect a slot drop(modelName:) already cleared"
+        )
+
+        let turn3 = try await runner.runChat(userInput: .init(chat: messages), parameters: parameters)
+        let baseline = try await runUncached(container: container, messages: messages, parameters: parameters)
+        #expect(turn3.output == baseline.output)
     }
 
     @Test func abortViaThrownErrorDuringStreamingNeverStoresAPartialSlot() async throws {
@@ -795,12 +1330,10 @@ struct PromptCacheEndToEndTests {
         let messages: [MLXLMCommon.Chat.Message] = [.system(words([0])), .user(words([1]))]
         let result = try await runner.runChat(userInput: .init(chat: messages), parameters: parameters)
 
-        guard let slot = store.peek(modelName: modelName) else {
-            Issue.record("expected a slot after a clean completion")
-            return
-        }
-        #expect(slot.tokens.count > 0)
-        #expect(slot.maxKVSize == 4096)
+        let slot = try #require(store.peek(modelName: modelName), "expected a slot after a clean completion")
+
+        #expect(slot.tokens.isEmpty == false)
+        #expect(slot.kvConfig.maxKVSize == 4096)
         // Precise store-side trim check: the cache must be trimmed back to *exactly* the
         // request's prompt token count (discarding this turn's generated tokens), matching
         // `ChatRunResult.promptTokens` -- not off by one in either direction. `next()` feeds


### PR DESCRIPTION
Closes the gap described in #122. A request whose post-template token sequence shares a prefix with the previous request on the same model now prefills only the suffix.

**Measured on this branch** (Qwen3-4B-4bit, 13-turn realistic chat corpus, temp 0, method as described in #122): median **90.2%** token-level prefill reduction on warm turns (range 78–94%, growing with conversation length), **12/12** warm-turn hit rate with `cached_prefix` exactly equal to the previous turn's prompt length every time, median warm prefill **~185ms** vs multi-second cold prefill (client-side median TTFT 0.68s warm vs 2.24s cold on the same corpus).

## Design

- `PromptCacheStore`: one resident slot per model `(tokens, cache, maxKVSize)` with **checkout semantics** — the slot is removed from the store while a request uses it and only checked back in after `await task.value` on clean completion. Cancellation, errors, or an unusable resulting cache (rotated) simply never check in: no half-written state is representable. Piggybacks on the existing per-model inference serialization in `ModelPool.run`; slots are dropped on model eviction and memory pressure.
- Longest-common-prefix match on the **post-template token sequence**; cache trimmed to `min(match, N-1)` (the iterator needs ≥1 prompt token); suffix-only `LMInput` + injected cache. The full-prefill path is byte-for-byte the pre-existing code when there is no usable slot.
- `FullHistoryLogitProcessor` wrapper primes repetition-penalty processors with the full token history on hits, so windowed penalty state matches the uncached path instead of silently seeing only the suffix.
- Reuse refused (with a logged reason) for: multimodal input, rotated `RotatingKVCache` (`offset >= maxSize`), `maxKVSize` change, no slot. `SWAMA_PROMPT_CACHE=0` disables the feature entirely.
- Per-request OSLog metrics: `prompt_tokens`, `cached_prefix`, `prefilled_suffix`, `prefill_ms`, `reason` — a cache that silently never hits is diagnosable, not invisible (lesson from llama.cpp #23030).
- Concurrency: single slot per model, guarded by the existing per-model serialization — v1 is deliberately simple; a multi-slot LRU is a straightforward extension if demand appears.

## Correctness

- 20 tests (against a deterministic in-test `LanguageModel` exercising the real `KVCacheSimple`/`RotatingKVCache` + `TokenIterator`): multi-turn cached-vs-uncached equivalence with repetition penalty active, hit-on-append, mid-history-edit and system-change misses, full-prefix trim, rotation fallback, cancel-mid-generation, abort-via-throw, store lifecycle.
- **The determinism bar, stated plainly:** each path is deterministic — cache-off runs are identical run-to-run, and warm (cache-hit) runs are identical run-to-run — but warm output is **not guaranteed bitwise-identical to cold output at temp 0**. Suffix-shaped prefill takes different Metal kernel paths than full prefill, and fp non-associativity can flip the last bit of a logit, occasionally flipping a near-tie argmax. This is the same documented property as llama.cpp and vLLM prefix caching (measurement details in #122). Per-path determinism is what the regression tests assert.

## Memory

The resident slot is the same KV state the request already allocated — reuse extends its lifetime between turns rather than adding a copy (~144 KiB/token fp16 on Qwen3-4B ≈ 0.6 GB at 4k tokens). Dropped under memory pressure and on model eviction.

Independent of #119 and #121 — this touches only the model-runner layer, not the server handlers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
