### PR TITLE
Update MLX audio support and bump version to 2.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,12 @@ swama list
 | `parakeet` | `mlx-community/parakeet-tdt-0.6b-v3` | - | Parakeet TDT 0.6B |
 | `voxtral` | `mlx-community/Voxtral-Mini-4B-Realtime-2602-fp16` | - | Voxtral Mini 4B (realtime) |
 | `cohere-transcribe` | `beshkenadze/cohere-transcribe-03-2026-mlx-fp16` | - | Cohere Transcribe |
+| `whisper-base` | `mlx-community/whisper-base-4bit` | - | Native Whisper (4/8-bit and fp16 aliases available) |
+| `moss-transcribe-diarize` | `OpenMOSS-Team/MOSS-Transcribe-Diarize` | - | Transcription with speaker diarization |
+| `nemotron-asr` | `mlx-community/nemotron-3.5-asr-streaming-0.6b-8bit` | - | Nemotron 3.5 streaming ASR |
+| `canary` | `Mediform/canary-1b-v2-mlx-q8` | - | Canary 1B v2 |
+| `moonshine` | `UsefulSensors/moonshine-tiny` | - | Moonshine Tiny |
+| `wav2vec2` | `facebook/wav2vec2-base-960h` | - | Wav2Vec2 CTC |
 
 > FireRedASR2 is also supported — pass its full HuggingFace repo id as the model name.
 
@@ -173,7 +179,13 @@ swama list
 | `soprano` | `mlx-community/Soprano-80M-bf16` | - | Soprano 80M |
 | `pocket-tts` | `mlx-community/pocket-tts` | - | Pocket-TTS |
 | `moss-tts` | `OpenMOSS-Team/MOSS-TTS` | - | MOSS-TTS |
+| `moss-ttsd` | `OpenMOSS-Team/MOSS-TTSD-v1.0` | - | MOSS dialogue TTS |
+| `moss-tts-local` | `OpenMOSS-Team/MOSS-TTS-Local-Transformer` | - | MOSS local-transformer TTS |
 | `echo-tts` | `mlx-community/echo-tts-base` | - | Echo-TTS |
+| `kokoro` | `mlx-community/Kokoro-82M-bf16` | - | Kokoro multilingual 82M |
+| `kitten-tts` | `mlx-community/kitten-tts-mini-0.8` | - | KittenTTS Mini |
+| `irodori-tts` | `mlx-community/Irodori-TTS-600M-v3-VoiceDesign-8bit` | - | Japanese VoiceDesign TTS |
+| `omnivoice` | `mlx-community/OmniVoice-bf16` | - | Multilingual voice-design TTS |
 
 ### 3. Start API Service
 
@@ -241,11 +253,12 @@ curl -X POST http://localhost:28100/v1/audio/speech \
     "response_format": "wav"
   }' --output speech.wav
 
-# TTS models: qwen3-tts, orpheus, marvis, chatterbox, vyvo, fish-speech, soprano, pocket-tts, moss-tts, echo-tts
-# Voice-supported models: orpheus, marvis, qwen3-tts, vyvo
+# TTS models: qwen3-tts, orpheus, marvis, chatterbox, vyvo, fish-speech, soprano, pocket-tts, moss-tts, echo-tts, kokoro, kitten-tts, irodori-tts, omnivoice, moss-ttsd, moss-tts-local
+# Voice-supported models: orpheus, marvis, qwen3-tts, vyvo, kokoro, kitten-tts, irodori-tts, omnivoice
 # Orpheus voices: dan, jess, leo, mia, tara, zac, zoe
 # Marvis voices: conversational_a, conversational_b
 # Qwen3-TTS / VyvoTTS voice: en-us-1
+# Kokoro default voice: af_heart; KittenTTS default voice: Bella
 
 # Tool calling (function calling)
 curl -X POST http://localhost:28100/v1/chat/completions \

--- a/README_CN.md
+++ b/README_CN.md
@@ -157,6 +157,12 @@ swama list
 | `parakeet` | `mlx-community/parakeet-tdt-0.6b-v3` | - | Parakeet TDT 0.6B |
 | `voxtral` | `mlx-community/Voxtral-Mini-4B-Realtime-2602-fp16` | - | Voxtral Mini 4B（实时） |
 | `cohere-transcribe` | `beshkenadze/cohere-transcribe-03-2026-mlx-fp16` | - | Cohere Transcribe |
+| `whisper-base` | `mlx-community/whisper-base-4bit` | - | 原生 Whisper（另有 4/8-bit 和 fp16 别名） |
+| `moss-transcribe-diarize` | `OpenMOSS-Team/MOSS-Transcribe-Diarize` | - | 转录与说话人分离 |
+| `nemotron-asr` | `mlx-community/nemotron-3.5-asr-streaming-0.6b-8bit` | - | Nemotron 3.5 流式 ASR |
+| `canary` | `Mediform/canary-1b-v2-mlx-q8` | - | Canary 1B v2 |
+| `moonshine` | `UsefulSensors/moonshine-tiny` | - | Moonshine Tiny |
+| `wav2vec2` | `facebook/wav2vec2-base-960h` | - | Wav2Vec2 CTC |
 
 > 同时支持 FireRedASR2 —— 用完整的 HuggingFace repo id 作为模型名即可。
 
@@ -173,7 +179,13 @@ swama list
 | `soprano` | `mlx-community/Soprano-80M-bf16` | - | Soprano 80M |
 | `pocket-tts` | `mlx-community/pocket-tts` | - | Pocket-TTS |
 | `moss-tts` | `OpenMOSS-Team/MOSS-TTS` | - | MOSS-TTS |
+| `moss-ttsd` | `OpenMOSS-Team/MOSS-TTSD-v1.0` | - | MOSS 对话 TTS |
+| `moss-tts-local` | `OpenMOSS-Team/MOSS-TTS-Local-Transformer` | - | MOSS Local Transformer TTS |
 | `echo-tts` | `mlx-community/echo-tts-base` | - | Echo-TTS |
+| `kokoro` | `mlx-community/Kokoro-82M-bf16` | - | Kokoro 多语言 82M |
+| `kitten-tts` | `mlx-community/kitten-tts-mini-0.8` | - | KittenTTS Mini |
+| `irodori-tts` | `mlx-community/Irodori-TTS-600M-v3-VoiceDesign-8bit` | - | 日语 VoiceDesign TTS |
+| `omnivoice` | `mlx-community/OmniVoice-bf16` | - | 多语言音色设计 TTS |
 
 ### 3. 启动 API 服务
 
@@ -241,11 +253,12 @@ curl -X POST http://localhost:28100/v1/audio/speech \
     "response_format": "wav"
   }' --output speech.wav
 
-# TTS 模型：qwen3-tts, orpheus, marvis, chatterbox, vyvo, fish-speech, soprano, pocket-tts, moss-tts, echo-tts
-# 支持音色的模型：orpheus, marvis, qwen3-tts, vyvo
+# TTS 模型：qwen3-tts, orpheus, marvis, chatterbox, vyvo, fish-speech, soprano, pocket-tts, moss-tts, echo-tts, kokoro, kitten-tts, irodori-tts, omnivoice, moss-ttsd, moss-tts-local
+# 支持音色的模型：orpheus, marvis, qwen3-tts, vyvo, kokoro, kitten-tts, irodori-tts, omnivoice
 # Orpheus 音色：dan, jess, leo, mia, tara, zac, zoe
 # Marvis 音色：conversational_a, conversational_b
 # Qwen3-TTS / VyvoTTS 音色：en-us-1
+# Kokoro 默认音色：af_heart；KittenTTS 默认音色：Bella
 
 # 工具调用（函数调用）
 curl -X POST http://localhost:28100/v1/chat/completions \

--- a/README_JA.md
+++ b/README_JA.md
@@ -157,6 +157,12 @@ swama list
 | `parakeet` | `mlx-community/parakeet-tdt-0.6b-v3` | - | Parakeet TDT 0.6B |
 | `voxtral` | `mlx-community/Voxtral-Mini-4B-Realtime-2602-fp16` | - | Voxtral Mini 4B（リアルタイム） |
 | `cohere-transcribe` | `beshkenadze/cohere-transcribe-03-2026-mlx-fp16` | - | Cohere Transcribe |
+| `whisper-base` | `mlx-community/whisper-base-4bit` | - | ネイティブ Whisper（4/8-bit、fp16 エイリアスあり） |
+| `moss-transcribe-diarize` | `OpenMOSS-Team/MOSS-Transcribe-Diarize` | - | 文字起こしと話者分離 |
+| `nemotron-asr` | `mlx-community/nemotron-3.5-asr-streaming-0.6b-8bit` | - | Nemotron 3.5 ストリーミング ASR |
+| `canary` | `Mediform/canary-1b-v2-mlx-q8` | - | Canary 1B v2 |
+| `moonshine` | `UsefulSensors/moonshine-tiny` | - | Moonshine Tiny |
+| `wav2vec2` | `facebook/wav2vec2-base-960h` | - | Wav2Vec2 CTC |
 
 > FireRedASR2 もサポート —— 完全な HuggingFace repo id をモデル名として指定してください。
 
@@ -173,7 +179,13 @@ swama list
 | `soprano` | `mlx-community/Soprano-80M-bf16` | - | Soprano 80M |
 | `pocket-tts` | `mlx-community/pocket-tts` | - | Pocket-TTS |
 | `moss-tts` | `OpenMOSS-Team/MOSS-TTS` | - | MOSS-TTS |
+| `moss-ttsd` | `OpenMOSS-Team/MOSS-TTSD-v1.0` | - | MOSS 対話 TTS |
+| `moss-tts-local` | `OpenMOSS-Team/MOSS-TTS-Local-Transformer` | - | MOSS Local Transformer TTS |
 | `echo-tts` | `mlx-community/echo-tts-base` | - | Echo-TTS |
+| `kokoro` | `mlx-community/Kokoro-82M-bf16` | - | Kokoro 多言語 82M |
+| `kitten-tts` | `mlx-community/kitten-tts-mini-0.8` | - | KittenTTS Mini |
+| `irodori-tts` | `mlx-community/Irodori-TTS-600M-v3-VoiceDesign-8bit` | - | 日本語 VoiceDesign TTS |
+| `omnivoice` | `mlx-community/OmniVoice-bf16` | - | 多言語ボイスデザイン TTS |
 
 ### 3. APIサービスの開始
 
@@ -241,11 +253,12 @@ curl -X POST http://localhost:28100/v1/audio/speech \
     "response_format": "wav"
   }' --output speech.wav
 
-# TTSモデル: qwen3-tts, orpheus, marvis, chatterbox, vyvo, fish-speech, soprano, pocket-tts, moss-tts, echo-tts
-# 音色対応モデル: orpheus, marvis, qwen3-tts, vyvo
+# TTSモデル: qwen3-tts, orpheus, marvis, chatterbox, vyvo, fish-speech, soprano, pocket-tts, moss-tts, echo-tts, kokoro, kitten-tts, irodori-tts, omnivoice, moss-ttsd, moss-tts-local
+# 音色対応モデル: orpheus, marvis, qwen3-tts, vyvo, kokoro, kitten-tts, irodori-tts, omnivoice
 # Orpheus音色: dan, jess, leo, mia, tara, zac, zoe
 # Marvis音色: conversational_a, conversational_b
 # Qwen3-TTS / VyvoTTS 音色: en-us-1
+# Kokoroデフォルト音色: af_heart、KittenTTSデフォルト音色: Bella
 
 # ツール呼び出し（関数呼び出し）
 curl -X POST http://localhost:28100/v1/chat/completions \

--- a/swama-macos/Swama/Swama.xcodeproj/project.pbxproj
+++ b/swama-macos/Swama/Swama.xcodeproj/project.pbxproj
@@ -448,7 +448,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.6;
-				MARKETING_VERSION = 2.2.0;
+				MARKETING_VERSION = 2.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "trans-n.ai.Swama";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -479,7 +479,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 15.6;
-				MARKETING_VERSION = 2.2.0;
+				MARKETING_VERSION = 2.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "trans-n.ai.Swama";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;

--- a/swama-macos/Swama/Swama.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/swama-macos/Swama/Swama.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -30,10 +30,9 @@
     {
       "identity" : "mlx-swift-lm",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ml-explore/mlx-swift-lm.git",
+      "location" : "https://github.com/ml-explore/mlx-swift-lm",
       "state" : {
-        "revision" : "bd4b7434e6bdb588c7ef55706ff8904cb7fd4c57",
-        "version" : "3.31.4"
+        "revision" : "10e0cb7442920d3f67a08e067d6670334e9dadef"
       }
     },
     {

--- a/swama-macos/Swama/Swama.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/swama-macos/Swama/Swama.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mattt/EventSource.git",
       "state" : {
-        "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
-        "version" : "1.4.1"
+        "revision" : "86b5096ac59ab46e66bd1f6377c604bc1dab0bc2",
+        "version" : "1.5.1"
       }
     },
     {
@@ -15,25 +15,25 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Blaizzy/mlx-audio-swift.git",
       "state" : {
-        "revision" : "856e04afb3c6eb931d92bb0d6ae7bbfbdfa89b15"
+        "revision" : "cae704f53bc32a3d0b606823828fbc5bedaaf388"
       }
     },
     {
       "identity" : "mlx-swift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ml-explore/mlx-swift",
+      "location" : "https://github.com/ml-explore/mlx-swift.git",
       "state" : {
-        "revision" : "dc43e62d7055353c7f99fa071a4e71d29dfddc44",
-        "version" : "0.31.4"
+        "revision" : "0bb916c67f4b9e5c682cbe02a42c701c93ab5021",
+        "version" : "0.31.6"
       }
     },
     {
       "identity" : "mlx-swift-lm",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ml-explore/mlx-swift-lm",
+      "location" : "https://github.com/ml-explore/mlx-swift-lm.git",
       "state" : {
-        "revision" : "1c05248bb0899e2a7a4962b84d319cf12f4e12aa",
-        "version" : "3.31.3"
+        "revision" : "bd4b7434e6bdb588c7ef55706ff8904cb7fd4c57",
+        "version" : "3.31.4"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
-        "revision" : "c5d11a805e765f52ba34ec7284bd4fcd6ba68615",
-        "version" : "1.7.0"
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
-        "version" : "1.7.0"
+        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
+        "version" : "1.7.1"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
       "state" : {
-        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
-        "version" : "1.3.0"
+        "revision" : "0442cb5a3f98ab802acb777929fdb446bda11a34",
+        "version" : "1.3.1"
       }
     },
     {
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
-        "version" : "1.3.0"
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
       }
     },
     {
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
-        "version" : "4.5.0"
+        "revision" : "47d3869a7291f085c1fb9fb1e6d3b97a793f45c6",
+        "version" : "4.5.1"
       }
     },
     {
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-jinja.git",
       "state" : {
-        "revision" : "0b67ecb79139f6addef8699eff3622808aa6c7dc",
-        "version" : "2.3.6"
+        "revision" : "7d0b8880ef8e567dd4e0089f8b99fb354129017c",
+        "version" : "2.4.2"
       }
     },
     {
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "5e72fc102906ebe75a3487595a653e6f43725552",
-        "version" : "2.94.0"
+        "revision" : "0b18836bd8b0162e7e17a995a3fbee20ed8f3b2b",
+        "version" : "2.101.3"
       }
     },
     {
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
-        "revision" : "0687f71944021d616d34d922343dcef086855920",
-        "version" : "600.0.1"
+        "revision" : "79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1",
+        "version" : "603.0.2"
       }
     },
     {
@@ -131,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system.git",
       "state" : {
-        "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
-        "version" : "1.6.4"
+        "revision" : "869129b7bf4ecc57b97d0193ad29690ca2134750",
+        "version" : "1.8.1"
       }
     },
     {

--- a/swama/Package.resolved
+++ b/swama/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3af75e3a6ef12785ad9452d3d27685fca2b5b79ebee538fb58321cbe31a18902",
+  "originHash" : "2071f1a349327569fac13a780e36c897392e4d153a2107cccc39f1125bf102ce",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -30,10 +30,9 @@
     {
       "identity" : "mlx-swift-lm",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ml-explore/mlx-swift-lm.git",
+      "location" : "https://github.com/ml-explore/mlx-swift-lm",
       "state" : {
-        "revision" : "bd4b7434e6bdb588c7ef55706ff8904cb7fd4c57",
-        "version" : "3.31.4"
+        "revision" : "10e0cb7442920d3f67a08e067d6670334e9dadef"
       }
     },
     {

--- a/swama/Package.resolved
+++ b/swama/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "73e69c14d8898078b3fc6c5b06a3c0bb5371dcaef6e55f29d9756feebf540abf",
+  "originHash" : "3af75e3a6ef12785ad9452d3d27685fca2b5b79ebee538fb58321cbe31a18902",
   "pins" : [
     {
       "identity" : "eventsource",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mattt/EventSource.git",
       "state" : {
-        "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
-        "version" : "1.4.1"
+        "revision" : "86b5096ac59ab46e66bd1f6377c604bc1dab0bc2",
+        "version" : "1.5.1"
       }
     },
     {
@@ -15,25 +15,25 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Blaizzy/mlx-audio-swift.git",
       "state" : {
-        "revision" : "856e04afb3c6eb931d92bb0d6ae7bbfbdfa89b15"
+        "revision" : "cae704f53bc32a3d0b606823828fbc5bedaaf388"
       }
     },
     {
       "identity" : "mlx-swift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ml-explore/mlx-swift",
+      "location" : "https://github.com/ml-explore/mlx-swift.git",
       "state" : {
-        "revision" : "dc43e62d7055353c7f99fa071a4e71d29dfddc44",
-        "version" : "0.31.4"
+        "revision" : "0bb916c67f4b9e5c682cbe02a42c701c93ab5021",
+        "version" : "0.31.6"
       }
     },
     {
       "identity" : "mlx-swift-lm",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ml-explore/mlx-swift-lm",
+      "location" : "https://github.com/ml-explore/mlx-swift-lm.git",
       "state" : {
-        "revision" : "1c05248bb0899e2a7a4962b84d319cf12f4e12aa",
-        "version" : "3.31.3"
+        "revision" : "bd4b7434e6bdb588c7ef55706ff8904cb7fd4c57",
+        "version" : "3.31.4"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
-        "revision" : "c5d11a805e765f52ba34ec7284bd4fcd6ba68615",
-        "version" : "1.7.0"
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
-        "version" : "1.7.0"
+        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
+        "version" : "1.7.1"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
       "state" : {
-        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
-        "version" : "1.3.0"
+        "revision" : "0442cb5a3f98ab802acb777929fdb446bda11a34",
+        "version" : "1.3.1"
       }
     },
     {
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
-        "version" : "1.3.0"
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
       }
     },
     {
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
-        "version" : "4.5.0"
+        "revision" : "47d3869a7291f085c1fb9fb1e6d3b97a793f45c6",
+        "version" : "4.5.1"
       }
     },
     {
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-jinja.git",
       "state" : {
-        "revision" : "0b67ecb79139f6addef8699eff3622808aa6c7dc",
-        "version" : "2.3.6"
+        "revision" : "7d0b8880ef8e567dd4e0089f8b99fb354129017c",
+        "version" : "2.4.2"
       }
     },
     {
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "5e72fc102906ebe75a3487595a653e6f43725552",
-        "version" : "2.94.0"
+        "revision" : "0b18836bd8b0162e7e17a995a3fbee20ed8f3b2b",
+        "version" : "2.101.3"
       }
     },
     {
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
-        "revision" : "0687f71944021d616d34d922343dcef086855920",
-        "version" : "600.0.1"
+        "revision" : "79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1",
+        "version" : "603.0.2"
       }
     },
     {
@@ -131,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system.git",
       "state" : {
-        "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
-        "version" : "1.6.4"
+        "revision" : "869129b7bf4ecc57b97d0193ad29690ca2134750",
+        "version" : "1.8.1"
       }
     },
     {

--- a/swama/Package.swift
+++ b/swama/Package.swift
@@ -19,7 +19,12 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
-        .package(url: "https://github.com/ml-explore/mlx-swift-lm", .upToNextMajor(from: "3.31.4")),
+        // Last revision before FoundationModelsIntegration became a default trait;
+        // newer commits require a newer Xcode 27 FoundationModels SDK.
+        .package(
+            url: "https://github.com/ml-explore/mlx-swift-lm",
+            revision: "10e0cb7442920d3f67a08e067d6670334e9dadef"
+        ),
         .package(url: "https://github.com/ml-explore/mlx-swift", .upToNextMajor(from: "0.31.4")),
         .package(
             url: "https://github.com/Blaizzy/mlx-audio-swift.git",

--- a/swama/Package.swift
+++ b/swama/Package.swift
@@ -19,11 +19,11 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
-        .package(url: "https://github.com/ml-explore/mlx-swift-lm", .upToNextMajor(from: "3.31.3")),
-        .package(url: "https://github.com/ml-explore/mlx-swift", .upToNextMajor(from: "0.31.3")),
+        .package(url: "https://github.com/ml-explore/mlx-swift-lm", .upToNextMajor(from: "3.31.4")),
+        .package(url: "https://github.com/ml-explore/mlx-swift", .upToNextMajor(from: "0.31.4")),
         .package(
             url: "https://github.com/Blaizzy/mlx-audio-swift.git",
-            revision: "856e04afb3c6eb931d92bb0d6ae7bbfbdfa89b15"
+            revision: "cae704f53bc32a3d0b606823828fbc5bedaaf388"
         ),
     ],
     targets: [

--- a/swama/Sources/Swama/CLI/Command.swift
+++ b/swama/Sources/Swama/CLI/Command.swift
@@ -10,7 +10,7 @@ struct Swama: AsyncParsableCommand {
     static let configuration: CommandConfiguration = .init(
         commandName: "swama",
         abstract: "Swama - The Swift-native LLM runtime for macOS",
-        version: "2.2.0",
+        version: "2.3.0",
         subcommands: [
             Serve.self,
             Pull.self,

--- a/swama/Sources/Swama/CLI/Remove.swift
+++ b/swama/Sources/Swama/CLI/Remove.swift
@@ -19,7 +19,7 @@ struct Remove: AsyncParsableCommand {
     func run() async throws {
         let resolvedModelName: String =
             if let ttsModel = TTSModelResolver.resolve(model) {
-                ttsModel.kind.rawValue
+                ttsModel.repository
             }
             else {
                 // Resolve model name using the same logic as other commands

--- a/swama/Sources/SwamaKit/Model/ModelAliases.swift
+++ b/swama/Sources/SwamaKit/Model/ModelAliases.swift
@@ -44,15 +44,7 @@ public enum ModelAliasResolver {
         let lowercasedName = modelName.lowercased()
         return lowercasedName.hasPrefix("whisper-") ||
             lowercasedName.hasPrefix("funasr-") ||
-            lowercasedName.contains("qwen3-asr") ||
-            lowercasedName.contains("glm-asr") ||
-            lowercasedName.contains("glmasr") ||
-            lowercasedName.contains("sensevoice") ||
-            lowercasedName.contains("voxtral") ||
-            lowercasedName.contains("cohere") ||
-            lowercasedName.contains("parakeet") ||
-            lowercasedName.contains("firered") ||
-            lowercasedName.contains("fire-red") ||
+            sttModelMarkers.contains(where: lowercasedName.contains) ||
             sttAliases.keys.contains(lowercasedName) ||
             sttAliases.values.contains(where: { $0.lowercased() == lowercasedName })
     }
@@ -164,21 +156,38 @@ public enum ModelAliasResolver {
     /// STT model aliases for MLXAudio.
     /// All keys should be lowercase for case-insensitive matching.
     static let sttAliases: [String: String] = [
-        // Legacy Whisper/FunASR API names are preserved and mapped to the new ASR backend.
-        "whisper-tiny": "mlx-community/Qwen3-ASR-0.6B-4bit",
-        "whisper-base": "mlx-community/Qwen3-ASR-0.6B-4bit",
-        "whisper-small": "mlx-community/Qwen3-ASR-0.6B-4bit",
-        "whisper-medium": "mlx-community/Qwen3-ASR-0.6B-4bit",
-        "whisper-large": "mlx-community/Qwen3-ASR-0.6B-4bit",
-        "whisper-large-v3": "mlx-community/Qwen3-ASR-0.6B-4bit",
-        "whisper-large-turbo": "mlx-community/Qwen3-ASR-0.6B-4bit",
-        "whisper": "mlx-community/Qwen3-ASR-0.6B-4bit",
-
-        // English-only variants
-        "whisper-tiny-en": "mlx-community/Qwen3-ASR-0.6B-4bit",
-        "whisper-base-en": "mlx-community/Qwen3-ASR-0.6B-4bit",
-        "whisper-small-en": "mlx-community/Qwen3-ASR-0.6B-4bit",
-        "whisper-medium-en": "mlx-community/Qwen3-ASR-0.6B-4bit",
+        // Whisper is native again in mlx-audio-swift. Keep aliases quantized by default.
+        "whisper": "mlx-community/whisper-large-v3-turbo-4bit",
+        "whisper-tiny": "mlx-community/whisper-tiny-4bit",
+        "whisper-tiny-4bit": "mlx-community/whisper-tiny-4bit",
+        "whisper-tiny-8bit": "mlx-community/whisper-tiny-8bit",
+        "whisper-tiny-fp16": "mlx-community/whisper-tiny-fp16",
+        "whisper-base": "mlx-community/whisper-base-4bit",
+        "whisper-base-4bit": "mlx-community/whisper-base-4bit",
+        "whisper-base-8bit": "mlx-community/whisper-base-8bit",
+        "whisper-base-fp16": "mlx-community/whisper-base-fp16",
+        "whisper-small": "mlx-community/whisper-small-4bit",
+        "whisper-small-4bit": "mlx-community/whisper-small-4bit",
+        "whisper-small-8bit": "mlx-community/whisper-small-8bit",
+        "whisper-small-fp16": "mlx-community/whisper-small-fp16",
+        "whisper-medium": "mlx-community/whisper-medium-4bit",
+        "whisper-medium-4bit": "mlx-community/whisper-medium-4bit",
+        "whisper-medium-8bit": "mlx-community/whisper-medium-8bit",
+        "whisper-medium-fp16": "mlx-community/whisper-medium-fp16",
+        "whisper-large": "mlx-community/whisper-large-v3-4bit",
+        "whisper-large-v3": "mlx-community/whisper-large-v3-4bit",
+        "whisper-large-v3-4bit": "mlx-community/whisper-large-v3-4bit",
+        "whisper-large-v3-8bit": "mlx-community/whisper-large-v3-8bit",
+        "whisper-large-v3-fp16": "mlx-community/whisper-large-v3-fp16",
+        "whisper-large-turbo": "mlx-community/whisper-large-v3-turbo-4bit",
+        "whisper-large-v3-turbo": "mlx-community/whisper-large-v3-turbo-4bit",
+        "whisper-large-v3-turbo-4bit": "mlx-community/whisper-large-v3-turbo-4bit",
+        "whisper-large-v3-turbo-8bit": "mlx-community/whisper-large-v3-turbo-8bit",
+        "whisper-large-v3-turbo-fp16": "mlx-community/whisper-large-v3-turbo-fp16",
+        "whisper-tiny-en": "mlx-community/whisper-tiny.en-4bit",
+        "whisper-base-en": "mlx-community/whisper-base.en-4bit",
+        "whisper-small-en": "mlx-community/whisper-small.en-4bit",
+        "whisper-medium-en": "mlx-community/whisper-medium.en-4bit",
 
         // FunASR models
         "funasr": "mlx-community/Qwen3-ASR-0.6B-4bit",
@@ -194,6 +203,14 @@ public enum ModelAliasResolver {
         "parakeet": "mlx-community/parakeet-tdt-0.6b-v3",
         "voxtral": "mlx-community/Voxtral-Mini-4B-Realtime-2602-fp16",
         "cohere-transcribe": "beshkenadze/cohere-transcribe-03-2026-mlx-fp16",
+        "moss-transcribe": "OpenMOSS-Team/MOSS-Transcribe-Diarize",
+        "moss-transcribe-diarize": "OpenMOSS-Team/MOSS-Transcribe-Diarize",
+        "nemotron-asr": "mlx-community/nemotron-3.5-asr-streaming-0.6b-8bit",
+        "nemotron-asr-en": "animaslabs/nemotron-speech-streaming-en-0.6b-mlx-8bit",
+        "canary": "Mediform/canary-1b-v2-mlx-q8",
+        "moonshine": "UsefulSensors/moonshine-tiny",
+        "wav2vec2": "facebook/wav2vec2-base-960h",
+        "mms-asr": "facebook/mms-1b-fl102",
     ]
 
     /// TTS (Text-to-Speech) model aliases
@@ -218,6 +235,12 @@ public enum ModelAliasResolver {
         "pocket-tts": "mlx-community/pocket-tts",
         "moss-tts": "OpenMOSS-Team/MOSS-TTS",
         "echo-tts": "mlx-community/echo-tts-base",
+        "kokoro": "mlx-community/Kokoro-82M-bf16",
+        "kitten-tts": "mlx-community/kitten-tts-mini-0.8",
+        "irodori-tts": "mlx-community/Irodori-TTS-600M-v3-VoiceDesign-8bit",
+        "omnivoice": "mlx-community/OmniVoice-bf16",
+        "moss-ttsd": "OpenMOSS-Team/MOSS-TTSD-v1.0",
+        "moss-tts-local": "OpenMOSS-Team/MOSS-TTS-Local-Transformer",
 
         // Legacy names mapped to Qwen3-TTS to keep request compatibility.
         "outetts": "mlx-community/Qwen3-TTS-12Hz-0.6B-Base-8bit",
@@ -225,5 +248,26 @@ public enum ModelAliasResolver {
         // CosyVoice models
         "cosyvoice2": "mlx-community/Qwen3-TTS-12Hz-0.6B-Base-8bit",
         "cosyvoice3": "mlx-community/Qwen3-TTS-12Hz-0.6B-Base-8bit",
+    ]
+
+    private static let sttModelMarkers = [
+        "whisper",
+        "qwen3-asr",
+        "glm-asr",
+        "glmasr",
+        "sensevoice",
+        "voxtral",
+        "cohere",
+        "parakeet",
+        "firered",
+        "fire-red",
+        "moss-transcribe-diarize",
+        "nemotron",
+        "canary",
+        "moonshine",
+        "wav2vec",
+        "mms-",
+        "lasr",
+        "granite-speech",
     ]
 }

--- a/swama/Sources/SwamaKit/Model/ModelDownloader.swift
+++ b/swama/Sources/SwamaKit/Model/ModelDownloader.swift
@@ -140,7 +140,7 @@ public enum ModelDownloader {
 
     private static func resolveRepoIDs(resolvedName: String) -> [String] {
         if let ttsModel = TTSModelResolver.resolve(resolvedName) {
-            return TTSModelResolver.repoIDs(for: ttsModel.kind)
+            return [ttsModel.repository]
         }
         return [resolvedName]
     }

--- a/swama/Sources/SwamaKit/Model/ModelPaths.swift
+++ b/swama/Sources/SwamaKit/Model/ModelPaths.swift
@@ -60,7 +60,7 @@ public enum ModelPaths {
     /// for its on-disk directory; otherwise `nil` (i.e. it's a regular LLM/VLM model).
     static func audioRepo(for modelName: String) -> String? {
         if let tts = TTSModelResolver.resolve(modelName) {
-            return TTSModelResolver.repository(for: tts.kind)
+            return tts.repository
         }
         if ModelAliasResolver.isAudioModel(modelName) {
             return ModelAliasResolver.resolve(name: modelName)

--- a/swama/Sources/SwamaKit/Model/ModelPool.swift
+++ b/swama/Sources/SwamaKit/Model/ModelPool.swift
@@ -129,6 +129,7 @@ public actor ModelPool {
     public func runTTS<T: Sendable>(
         modelKey: String,
         kind: TTSModelKind,
+        repository: String? = nil,
         operation: @Sendable @escaping (TTSRunner) async throws -> T
     ) async throws -> T {
         while runningInferences >= maxConcurrentInferences || runningModels.contains(modelKey) {
@@ -139,7 +140,11 @@ public actor ModelPool {
         runningModels.insert(modelKey)
 
         do {
-            let runner = try await getTTSRunner(modelKey: modelKey, kind: kind)
+            let runner = try await getTTSRunner(
+                modelKey: modelKey,
+                kind: kind,
+                repository: repository
+            )
             let result = try await operation(runner)
 
             runningInferences = max(0, runningInferences - 1)
@@ -193,7 +198,11 @@ public actor ModelPool {
     }
 
     /// Gets or loads a TTS runner for the given model key
-    private func getTTSRunner(modelKey: String, kind: TTSModelKind) async throws -> TTSRunner {
+    private func getTTSRunner(
+        modelKey: String,
+        kind: TTSModelKind,
+        repository: String?
+    ) async throws -> TTSRunner {
         ensureMemoryManagementStarted()
 
         if let runner = ttsRunnerCache[modelKey] {
@@ -210,7 +219,8 @@ public actor ModelPool {
         await performMemoryPressureCheck()
 
         let task = Task {
-            let runner = TTSRunner(kind: kind)
+            let runner = repository.map { TTSRunner(kind: kind, repository: $0) }
+                ?? TTSRunner(kind: kind)
             try await runner.loadModel()
             self.setTTSRunner(runner, forKey: modelKey)
             return runner

--- a/swama/Sources/SwamaKit/Model/SpeechToTextRunner.swift
+++ b/swama/Sources/SwamaKit/Model/SpeechToTextRunner.swift
@@ -118,7 +118,10 @@ public class SpeechToTextRunner: @unchecked Sendable {
                 chunkDuration: params.chunkDuration,
                 minChunkDuration: params.minChunkDuration,
                 repetitionPenalty: params.repetitionPenalty,
-                repetitionContextSize: params.repetitionContextSize
+                repetitionContextSize: params.repetitionContextSize,
+                kvBits: params.kvBits,
+                kvGroupSize: params.kvGroupSize,
+                quantizedKVStart: params.quantizedKVStart
             )
 
             let output = stt.generate(audio: audio, generationParameters: params)
@@ -183,50 +186,20 @@ public enum AudioError: Error, LocalizedError {
 private extension SpeechToTextRunner {
     func createSTT(for modelName: String) async throws -> any STTGenerationModel {
         let repo = resolveSTTRepo(modelName)
-        let normalized = repo.lowercased()
         let cache = HubCache(cacheDirectory: ModelPaths.activeModelsDirectory)
 
-        if normalized.contains("glmasr") || normalized.contains("glm-asr") {
-            return try await GLMASRModel.fromPretrained(repo, cache: cache)
+        do {
+            return try await STT.loadModel(modelRepo: repo, cache: cache)
         }
-        if normalized.contains("voxtral") {
-            // Voxtral/Cohere fromPretrained in mlx-audio-swift do not accept a cache
-            // override yet, so they fall back to the library's default HF cache.
-            return try await VoxtralRealtimeModel.fromPretrained(repo)
+        catch {
+            throw AudioError.modelLoadFailed(
+                "Unable to load STT model '\(repo)': \(error.localizedDescription)"
+            )
         }
-        if normalized.contains("cohere") {
-            return try await CohereTranscribeModel.fromPretrained(repo)
-        }
-        if normalized.contains("parakeet") {
-            return try await ParakeetModel.fromPretrained(repo, cache: cache)
-        }
-        if normalized.contains("firered") || normalized.contains("fire-red") {
-            return try await FireRedASR2Model.fromPretrained(repo, cache: cache)
-        }
-        if normalized.contains("sensevoice") {
-            return try await SenseVoiceModel.fromPretrained(repo, cache: cache)
-        }
-        if normalized.contains("qwen3-asr") || normalized.contains("qwen3_asr") {
-            return try await Qwen3ASRModel.fromPretrained(repo, cache: cache)
-        }
-
-        throw AudioError.modelNotFound("Unsupported STT model: \(modelName)")
     }
 
     func resolveSTTRepo(_ modelName: String) -> String {
-        let resolved = ModelAliasResolver.resolve(name: modelName)
-        let normalized = resolved.lowercased()
-
-        if normalized.hasPrefix("whisper-") ||
-            normalized.hasPrefix("mlx-community/whisper") ||
-            normalized.hasPrefix("funasr") ||
-            normalized.hasPrefix("fun-asr") ||
-            normalized.hasPrefix("mlx-community/fun-asr")
-        {
-            return "mlx-community/Qwen3-ASR-0.6B-4bit"
-        }
-
-        return resolved
+        ModelAliasResolver.resolve(name: modelName)
     }
 
     func normalizeLanguage(_ language: String?) -> String? {

--- a/swama/Sources/SwamaKit/Model/TTSRunner.swift
+++ b/swama/Sources/SwamaKit/Model/TTSRunner.swift
@@ -61,7 +61,13 @@ public enum TTSModelKind: String, CaseIterable, Sendable {
     case soprano
     case pocketTTS = "pocket-tts"
     case mossTTS = "moss-tts"
+    case mossTTSD = "moss-ttsd"
+    case mossTTSLocal = "moss-tts-local"
     case echoTTS = "echo-tts"
+    case kokoro
+    case kittenTTS = "kitten-tts"
+    case irodoriTTS = "irodori-tts"
+    case omniVoice = "omnivoice"
 
     // Legacy aliases kept so existing API model names continue resolving.
     case cosyVoice2 = "cosyvoice2"
@@ -74,6 +80,7 @@ public enum TTSModelKind: String, CaseIterable, Sendable {
 public struct TTSModelResolution: Sendable {
     public let kind: TTSModelKind
     public let cacheKey: String
+    public let repository: String
 }
 
 // MARK: - TTSModelResolver
@@ -92,14 +99,21 @@ public enum TTSModelResolver {
         "soprano",
         "pocket-tts",
         "moss-tts",
+        "moss-ttsd",
+        "moss-tts-local",
         "echo-tts",
+        "kokoro",
+        "kitten-tts",
+        "irodori-tts",
+        "omnivoice",
         "cosyvoice2",
         "cosyvoice3",
         "outetts",
     ]
 
     public static func resolve(_ modelName: String) -> TTSModelResolution? {
-        let normalized = modelName.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let requested = modelName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalized = requested.lowercased()
 
         switch normalized {
         case "mlx-community/orpheus-3b-0.1-ft-4bit",
@@ -119,9 +133,10 @@ public enum TTSModelResolver {
              "mlx-community/chatterbox-turbo-tts-q4":
             return resolution(.chatterboxTurbo)
         case "qwen3-tts",
-             "qwen3tts",
-             qwen3TTSRepo.lowercased():
+             "qwen3tts":
             return resolution(.qwen3TTS)
+        case qwen3TTSRepo.lowercased():
+            return resolution(.qwen3TTS, repository: requested)
         case "mlx-community/vyvotts-en-beta-4bit",
              "vyvo",
              "vyvotts":
@@ -142,10 +157,33 @@ public enum TTSModelResolver {
              "moss-tts",
              "openmoss-team/moss-tts":
             return resolution(.mossTTS)
+        case "moss-ttsd",
+             "openmoss-team/moss-ttsd-v1.0":
+            return resolution(.mossTTSD)
+        case "moss-tts-local",
+             "openmoss-team/moss-tts-local-transformer":
+            return resolution(.mossTTSLocal)
         case "echo",
              "echo-tts",
              "mlx-community/echo-tts-base":
             return resolution(.echoTTS)
+        case "kokoro":
+            return resolution(.kokoro)
+        case "hexgrad/kokoro-82m",
+             "mlx-community/kokoro-82m-bf16":
+            return resolution(.kokoro, repository: requested)
+        case "kitten-tts",
+             "mlx-community/kitten-tts-mini-0.8":
+            return resolution(.kittenTTS)
+        case "irodori",
+             "irodori-tts",
+             "mlx-community/irodori-tts-600m-v3-voicedesign-8bit":
+            return resolution(.irodoriTTS)
+        case "omnivoice",
+             "mlx-community/omnivoice-bf16":
+            return resolution(.omniVoice)
+        case "mlx-community/omnivoice":
+            return resolution(.omniVoice, repository: requested)
         case "cosy-voice2",
              "cosyvoice2",
              "mlx-community/cosyvoice2-0.5b-4bit":
@@ -158,7 +196,7 @@ public enum TTSModelResolver {
              "outetts":
             return resolution(.outetts)
         default:
-            return resolveRepository(normalized)
+            return resolveRepository(requested: requested, normalized: normalized)
         }
     }
 
@@ -171,13 +209,21 @@ public enum TTSModelResolver {
         case .qwen3TTS,
              .vyvo:
             ["en-us-1"]
+        case .kokoro:
+            ["af_heart", "af_bella", "am_adam", "bf_emma", "jf_alpha", "zf_xiaobei"]
+        case .kittenTTS:
+            ["Bella", "Jasper", "Luna", "Bruno", "Rosie", "Hugo", "Kiki", "Leo"]
         case .chatterbox,
              .chatterboxTurbo,
              .cosyVoice2,
              .cosyVoice3,
              .echoTTS,
              .fishSpeech,
+             .irodoriTTS,
              .mossTTS,
+             .mossTTSD,
+             .mossTTSLocal,
+             .omniVoice,
              .outetts,
              .pocketTTS,
              .soprano:
@@ -213,18 +259,41 @@ public enum TTSModelResolver {
             "mlx-community/pocket-tts"
         case .mossTTS:
             "OpenMOSS-Team/MOSS-TTS"
+        case .mossTTSD:
+            "OpenMOSS-Team/MOSS-TTSD-v1.0"
+        case .mossTTSLocal:
+            "OpenMOSS-Team/MOSS-TTS-Local-Transformer"
         case .echoTTS:
             "mlx-community/echo-tts-base"
+        case .kokoro:
+            "mlx-community/Kokoro-82M-bf16"
+        case .kittenTTS:
+            "mlx-community/kitten-tts-mini-0.8"
+        case .irodoriTTS:
+            "mlx-community/Irodori-TTS-600M-v3-VoiceDesign-8bit"
+        case .omniVoice:
+            "mlx-community/OmniVoice-bf16"
         }
     }
 
-    private static func resolution(_ kind: TTSModelKind) -> TTSModelResolution {
-        TTSModelResolution(kind: kind, cacheKey: kind.rawValue)
+    private static func resolution(
+        _ kind: TTSModelKind,
+        repository: String? = nil
+    ) -> TTSModelResolution {
+        let repository = repository ?? self.repository(for: kind)
+        return TTSModelResolution(
+            kind: kind,
+            cacheKey: repository.lowercased(),
+            repository: repository
+        )
     }
 
-    private static func resolveRepository(_ normalized: String) -> TTSModelResolution? {
+    private static func resolveRepository(
+        requested: String,
+        normalized: String
+    ) -> TTSModelResolution? {
         if normalized.contains("qwen3-tts") {
-            return resolution(.qwen3TTS)
+            return resolution(.qwen3TTS, repository: requested)
         }
         if normalized.contains("vyvotts") {
             return resolution(.vyvo)
@@ -248,10 +317,28 @@ public enum TTSModelResolver {
             return resolution(.pocketTTS)
         }
         if normalized.contains("moss") {
-            return resolution(.mossTTS)
+            if normalized.contains("ttsd") {
+                return resolution(.mossTTSD, repository: requested)
+            }
+            if normalized.contains("local-transformer") {
+                return resolution(.mossTTSLocal, repository: requested)
+            }
+            return resolution(.mossTTS, repository: requested)
         }
         if normalized.contains("echo") {
             return resolution(.echoTTS)
+        }
+        if normalized.contains("kokoro") {
+            return resolution(.kokoro, repository: requested)
+        }
+        if normalized.contains("kitten") {
+            return resolution(.kittenTTS, repository: requested)
+        }
+        if normalized.contains("irodori") {
+            return resolution(.irodoriTTS, repository: requested)
+        }
+        if normalized.contains("omnivoice") {
+            return resolution(.omniVoice, repository: requested)
         }
         return nil
     }
@@ -261,10 +348,17 @@ public enum TTSModelResolver {
 
 public final class TTSRunner: @unchecked Sendable {
     private let kind: TTSModelKind
+    private let repository: String
     private var model: (any SpeechGenerationModel)?
 
     public init(kind: TTSModelKind) {
         self.kind = kind
+        self.repository = TTSModelResolver.repository(for: kind)
+    }
+
+    public init(kind: TTSModelKind, repository: String) {
+        self.kind = kind
+        self.repository = repository
     }
 
     public func loadModel() async throws {
@@ -277,7 +371,7 @@ public final class TTSRunner: @unchecked Sendable {
             // loaded weights resolve to the same place (see ModelPaths.audioModelDirectory).
             let cache = HubCache(cacheDirectory: ModelPaths.activeModelsDirectory)
             model = try await TTS.loadModel(
-                modelRepo: TTSModelResolver.repository(for: kind),
+                modelRepo: repository,
                 cache: cache
             )
         }
@@ -340,6 +434,10 @@ public final class TTSRunner: @unchecked Sendable {
                 return "conversational_a"
             case .vyvo:
                 return "en-us-1"
+            case .kokoro:
+                return "af_heart"
+            case .kittenTTS:
+                return "Bella"
             default:
                 return nil
             }

--- a/swama/Sources/SwamaKit/Server/TextToSpeechHandler.swift
+++ b/swama/Sources/SwamaKit/Server/TextToSpeechHandler.swift
@@ -58,7 +58,8 @@ public enum TextToSpeechHandler {
 
             let result = try await ModelPool.shared.runTTS(
                 modelKey: modelResolution.cacheKey,
-                kind: modelResolution.kind
+                kind: modelResolution.kind,
+                repository: modelResolution.repository
             ) { runner in
                 try await runner.generate(
                     text: trimmedInput,

--- a/swama/Tests/SwamaKitTests/AudioModelResolverTests.swift
+++ b/swama/Tests/SwamaKitTests/AudioModelResolverTests.swift
@@ -1,0 +1,57 @@
+@testable import SwamaKit
+import Testing
+
+@Suite("Audio Model Resolution")
+struct AudioModelResolverTests {
+    @Test func resolvesNativeWhisperAliases() {
+        #expect(
+            ModelAliasResolver.resolve(name: "whisper-base")
+                == "mlx-community/whisper-base-4bit"
+        )
+        #expect(
+            ModelAliasResolver.resolve(name: "whisper-large-v3-turbo-8bit")
+                == "mlx-community/whisper-large-v3-turbo-8bit"
+        )
+    }
+
+    @Test func recognizesNewSTTModelFamilies() {
+        #expect(ModelAliasResolver.isAudioModel("moss-transcribe-diarize"))
+        #expect(ModelAliasResolver.isAudioModel("openai/whisper-large-v3-turbo"))
+        #expect(ModelAliasResolver.isAudioModel("mlx-community/nemotron-3.5-asr-streaming-0.6b-8bit"))
+        #expect(ModelAliasResolver.isAudioModel("Mediform/canary-1b-v2-mlx-q8"))
+        #expect(ModelAliasResolver.isAudioModel("facebook/wav2vec2-base-960h"))
+    }
+
+    @Test func resolvesNewTTSAliases() throws {
+        let kokoro = try #require(TTSModelResolver.resolve("kokoro"))
+        #expect(kokoro.kind == .kokoro)
+        #expect(kokoro.repository == "mlx-community/Kokoro-82M-bf16")
+
+        let irodori = try #require(TTSModelResolver.resolve("irodori-tts"))
+        #expect(irodori.kind == .irodoriTTS)
+        #expect(irodori.repository == "mlx-community/Irodori-TTS-600M-v3-VoiceDesign-8bit")
+
+        let omniVoice = try #require(TTSModelResolver.resolve("omnivoice"))
+        #expect(omniVoice.kind == .omniVoice)
+        #expect(omniVoice.repository == "mlx-community/OmniVoice-bf16")
+    }
+
+    @Test func preservesQwenTTSVariantRepository() throws {
+        let repository = "mlx-community/Qwen3-TTS-12Hz-1.7B-VoiceDesign-bf16"
+        let resolution = try #require(TTSModelResolver.resolve(repository))
+
+        #expect(resolution.kind == .qwen3TTS)
+        #expect(resolution.repository == repository)
+        #expect(resolution.cacheKey == repository.lowercased())
+    }
+
+    @Test func distinguishesMOSSVariants() throws {
+        let dialogue = try #require(TTSModelResolver.resolve("moss-ttsd"))
+        let local = try #require(TTSModelResolver.resolve("moss-tts-local"))
+
+        #expect(dialogue.kind == .mossTTSD)
+        #expect(dialogue.repository == "OpenMOSS-Team/MOSS-TTSD-v1.0")
+        #expect(local.kind == .mossTTSLocal)
+        #expect(local.repository == "OpenMOSS-Team/MOSS-TTS-Local-Transformer")
+    }
+}


### PR DESCRIPTION
## Summary

- update `mlx-audio-swift` from `856e04a` to `cae704f`
- update `mlx-swift-lm` from tag 3.31.4 to reproducible revision `10e0cb74` (2026-07-14, 19 commits newer than the tag)
- keep `mlx-swift` at the compatible 0.31.6 release
- route STT loading through the upstream unified `STT.loadModel` factory
- restore native Whisper aliases and add MOSS Transcribe, Nemotron, Canary, Moonshine, Wav2Vec2/MMS detection
- add Kokoro, KittenTTS, Irodori, OmniVoice, and MOSS TTS variants
- preserve explicitly requested Qwen3-TTS VoiceDesign/CustomVoice repositories
- keep the existing transcription and speech HTTP request interfaces unchanged
- update English, Chinese, and Japanese model documentation
- bump CLI and macOS app version to 2.3.0
- merge the latest `main` prompt-cache, cancellation, and models-handler changes

## Verification

- full clean `swift build`
- full merged test bundle: 106 tests across 15 suites
- direct local Metal inference with SmolLM
- cached Soprano TTS -> Qwen3-ASR transcription round trip
- macOS and CLI SwiftPM lock files resolve to the same revisions
- GitHub reports the PR as mergeable

## mlx-swift-lm revision choice

Current `mlx-swift-lm` HEAD (`92195087`, 2026-08-24) enables `FoundationModelsIntegration` as a default SwiftPM trait. The transitive dependency from `mlx-audio-swift` therefore enables that product even though Swama does not use it. HEAD requires a newer Xcode 27 FoundationModels SDK than the current build environment and fails inside `MLXFoundationModels`.

`10e0cb74` is the latest revision immediately before that default trait was introduced. It includes 19 post-3.31.4 fixes, including cancellation fixes, Qwen3.5/3.6 warm continuation, safetensors-index loading, Qwen3 embedder attention masks, Gemma fixes, and tool round-trip fixes.

## Toolchain note

Xcode 27 beta / Swift 6.4 currently crashes in the optimizer while compiling the enlarged upstream `MLXAudioTTS` target. A release build succeeds with:

```bash
swift build -c release --product swama --jobs 4 -Xswiftc -Onone
```
