### PR TITLE
test: add Swift-native refactor acceptance harness

### DIFF
--- a/Tests/AcceptanceFixture/Package.resolved
+++ b/Tests/AcceptanceFixture/Package.resolved
@@ -1,0 +1,157 @@
+{
+  "originHash" : "77f73a11ede3b2b05d5371516ec723532fd164a4cee168a96c232d105bc85970",
+  "pins" : [
+    {
+      "identity" : "eventsource",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattt/EventSource.git",
+      "state" : {
+        "revision" : "86b5096ac59ab46e66bd1f6377c604bc1dab0bc2",
+        "version" : "1.5.1"
+      }
+    },
+    {
+      "identity" : "mlx-audio-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Blaizzy/mlx-audio-swift.git",
+      "state" : {
+        "revision" : "cae704f53bc32a3d0b606823828fbc5bedaaf388"
+      }
+    },
+    {
+      "identity" : "mlx-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ml-explore/mlx-swift.git",
+      "state" : {
+        "revision" : "0bb916c67f4b9e5c682cbe02a42c701c93ab5021",
+        "version" : "0.31.6"
+      }
+    },
+    {
+      "identity" : "mlx-swift-lm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ml-explore/mlx-swift-lm",
+      "state" : {
+        "revision" : "10e0cb7442920d3f67a08e067d6670334e9dadef"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
+        "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "0442cb5a3f98ab802acb777929fdb446bda11a34",
+        "version" : "1.3.1"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "47d3869a7291f085c1fb9fb1e6d3b97a793f45c6",
+        "version" : "4.5.1"
+      }
+    },
+    {
+      "identity" : "swift-huggingface",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-huggingface.git",
+      "state" : {
+        "revision" : "b721959445b617d0bf03910b2b4aced345fd93bf",
+        "version" : "0.9.0"
+      }
+    },
+    {
+      "identity" : "swift-jinja",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-jinja.git",
+      "state" : {
+        "revision" : "7d0b8880ef8e567dd4e0089f8b99fb354129017c",
+        "version" : "2.4.2"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "0b18836bd8b0162e7e17a995a3fbee20ed8f3b2b",
+        "version" : "2.101.3"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
+      "state" : {
+        "revision" : "79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1",
+        "version" : "603.0.2"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "869129b7bf4ecc57b97d0193ad29690ca2134750",
+        "version" : "1.8.1"
+      }
+    },
+    {
+      "identity" : "swift-transformers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-transformers.git",
+      "state" : {
+        "revision" : "2fa33e1f5e7131a7fc64c28e6d161dcec0d24820",
+        "version" : "1.3.3"
+      }
+    },
+    {
+      "identity" : "yyjson",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ibireme/yyjson.git",
+      "state" : {
+        "revision" : "8b4a38dc994a110abaec8a400615567bd996105f",
+        "version" : "0.12.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Tests/AcceptanceFixture/Package.swift
+++ b/Tests/AcceptanceFixture/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version: 6.2
+import PackageDescription
+
+let package = Package(
+    name: "SwamaAcceptanceFixture",
+    platforms: [.macOS("15.4")],
+    dependencies: [
+        .package(path: "../../swama"),
+        .package(
+            url: "https://github.com/ml-explore/mlx-swift-lm",
+            revision: "10e0cb7442920d3f67a08e067d6670334e9dadef"
+        )
+    ],
+    targets: [
+        .executableTarget(
+            name: "SwamaAcceptanceProbe",
+            dependencies: [
+                .product(name: "SwamaKit", package: "swama"),
+                .product(name: "MLXLMCommon", package: "mlx-swift-lm")
+            ],
+            path: "Sources/SwamaAcceptanceProbe"
+        )
+    ]
+)

--- a/Tests/AcceptanceFixture/Sources/SwamaAcceptanceProbe/main.swift
+++ b/Tests/AcceptanceFixture/Sources/SwamaAcceptanceProbe/main.swift
@@ -1,0 +1,446 @@
+import Darwin
+import Foundation
+import MLXLMCommon
+import SwamaKit
+
+// MARK: - ProbeError
+
+private enum ProbeError: Error, LocalizedError {
+    case invalidArguments(String)
+    case cancellationDidNotStart
+
+    var errorDescription: String? {
+        switch self {
+        case let .invalidArguments(message):
+            message
+        case .cancellationDidNotStart:
+            "generation completed before the cancellation witness observed two tokens"
+        }
+    }
+}
+
+// MARK: - RunRecord
+
+private struct RunRecord: Codable, Sendable {
+    let route: String
+    let model: String
+    let round: Int
+    let promptTokens: Int
+    let generatedTokens: Int
+    let ttftMilliseconds: Double?
+    let totalMilliseconds: Double
+    let tokensPerSecond: Double?
+    let output: String
+    let peakResidentBytes: UInt64
+}
+
+// MARK: - CancelRecord
+
+private struct CancelRecord: Codable, Sendable {
+    let route: String
+    let model: String
+    let observedTokensBeforeCancel: Int
+    let cancellationMilliseconds: Double
+    let cancelledOutput: String
+    let followupOutput: String
+    let followupGeneratedTokens: Int
+    let peakResidentBytes: UInt64
+}
+
+// MARK: - ConcurrentRecord
+
+private struct ConcurrentRecord: Codable, Sendable {
+    let route: String
+    let model: String
+    let requestCount: Int
+    let totalMilliseconds: Double
+    let outputs: [String]
+    let peakResidentBytes: UInt64
+}
+
+// MARK: - SwitchRecord
+
+private struct SwitchRecord: Codable, Sendable {
+    let route: String
+    let models: [String]
+    let cycles: Int
+    let runs: [RunRecord]
+    let residentBytesAfterClear: [UInt64]
+    let peakResidentBytes: UInt64
+}
+
+// MARK: - TokenRecorder
+
+private final class TokenRecorder: @unchecked Sendable {
+    private let lock: NSLock = .init()
+    private var firstTokenUptime: UInt64?
+    private var pieces: [String] = []
+    private var waiters: [(threshold: Int, continuation: CheckedContinuation<Void, Never>)] = []
+
+    func append(_ token: String) {
+        let now = DispatchTime.now().uptimeNanoseconds
+        var ready: [CheckedContinuation<Void, Never>] = []
+
+        lock.lock()
+        if firstTokenUptime == nil {
+            firstTokenUptime = now
+        }
+        pieces.append(token)
+        let count = pieces.count
+        waiters.removeAll { waiter in
+            if count >= waiter.threshold {
+                ready.append(waiter.continuation)
+                return true
+            }
+            return false
+        }
+        lock.unlock()
+
+        for continuation in ready {
+            continuation.resume()
+        }
+    }
+
+    func wait(untilCount threshold: Int) async {
+        await withCheckedContinuation { continuation in
+            lock.lock()
+            if pieces.count >= threshold {
+                lock.unlock()
+                continuation.resume()
+            }
+            else {
+                waiters.append((threshold, continuation))
+                lock.unlock()
+            }
+        }
+    }
+
+    func snapshot() -> (firstTokenUptime: UInt64?, count: Int, output: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        return (firstTokenUptime, pieces.count, pieces.joined())
+    }
+}
+
+private func peakResidentBytes() -> UInt64 {
+    var usage = rusage()
+    guard getrusage(RUSAGE_SELF, &usage) == 0 else {
+        return 0
+    }
+
+    // ru_maxrss is bytes on Darwin (kilobytes on Linux).
+    return UInt64(max(0, usage.ru_maxrss))
+}
+
+private func currentResidentBytes() -> UInt64 {
+    let process = Process()
+    let pipe = Pipe()
+    process.executableURL = URL(fileURLWithPath: "/bin/ps")
+    process.arguments = ["-o", "rss=", "-p", String(getpid())]
+    process.standardOutput = pipe
+    process.standardError = FileHandle.nullDevice
+
+    do {
+        try process.run()
+        process.waitUntilExit()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        guard process.terminationStatus == 0,
+              let text = String(data: data, encoding: .utf8),
+              let kibibytes = UInt64(text.trimmingCharacters(in: .whitespacesAndNewlines))
+        else {
+            return 0
+        }
+
+        return kibibytes * 1024
+    }
+    catch {
+        return 0
+    }
+}
+
+private func parameters(maxTokens: Int) -> GenerateParameters {
+    GenerateParameters(
+        maxTokens: maxTokens,
+        temperature: 0,
+        topP: 1,
+        seed: 1
+    )
+}
+
+private func runOnce(
+    model: String,
+    prompt: String,
+    maxTokens: Int,
+    round: Int
+) async throws -> RunRecord {
+    let recorder = TokenRecorder()
+    let start = DispatchTime.now().uptimeNanoseconds
+    let result = try await ModelPool.shared.run(modelName: model) { runner in
+        try await runner.runChat(
+            userInput: UserInput(chat: [.user(prompt)]),
+            parameters: parameters(maxTokens: maxTokens),
+            onToken: { token in recorder.append(token) }
+        )
+    }
+    let end = DispatchTime.now().uptimeNanoseconds
+    let snapshot = recorder.snapshot()
+    let info = result.completionInfo
+
+    return RunRecord(
+        route: "core",
+        model: model,
+        round: round,
+        promptTokens: result.promptTokens,
+        generatedTokens: info?.generationTokenCount ?? snapshot.count,
+        ttftMilliseconds: snapshot.firstTokenUptime.map { Double($0 - start) / 1_000_000 },
+        totalMilliseconds: Double(end - start) / 1_000_000,
+        tokensPerSecond: info?.tokensPerSecond,
+        output: snapshot.output.isEmpty ? result.output : snapshot.output,
+        peakResidentBytes: peakResidentBytes()
+    )
+}
+
+private func runCancellation(
+    model: String,
+    prompt: String,
+    maxTokens: Int
+) async throws -> CancelRecord {
+    // Warm the model first so the cancellation arm exercises generation, not
+    // dependency resolution or model loading.
+    _ = try await runOnce(model: model, prompt: "Warm up.", maxTokens: 8, round: 0)
+
+    let recorder = TokenRecorder()
+    let task = Task {
+        try await ModelPool.shared.run(modelName: model) { runner in
+            try await runner.runChat(
+                userInput: UserInput(chat: [.user(prompt)]),
+                parameters: parameters(maxTokens: maxTokens),
+                onToken: { token in recorder.append(token) }
+            )
+        }
+    }
+
+    await recorder.wait(untilCount: 2)
+    guard !task.isCancelled else {
+        throw ProbeError.cancellationDidNotStart
+    }
+
+    let cancelStart = DispatchTime.now().uptimeNanoseconds
+    task.cancel()
+    let cancelledResult = try await task.value
+    let cancelEnd = DispatchTime.now().uptimeNanoseconds
+    let cancelledSnapshot = recorder.snapshot()
+
+    let followup = try await runOnce(
+        model: model,
+        prompt: "Reply with exactly: AFTER_CANCEL_OK",
+        maxTokens: 24,
+        round: 1
+    )
+
+    return CancelRecord(
+        route: "core-cancel",
+        model: model,
+        observedTokensBeforeCancel: cancelledSnapshot.count,
+        cancellationMilliseconds: Double(cancelEnd - cancelStart) / 1_000_000,
+        cancelledOutput: cancelledSnapshot.output.isEmpty ? cancelledResult.output : cancelledSnapshot.output,
+        followupOutput: followup.output,
+        followupGeneratedTokens: followup.generatedTokens,
+        peakResidentBytes: peakResidentBytes()
+    )
+}
+
+private func runConcurrent(
+    model: String,
+    prompt: String,
+    maxTokens: Int,
+    requestCount: Int
+) async throws -> ConcurrentRecord {
+    _ = try await runOnce(model: model, prompt: "Warm up.", maxTokens: 8, round: 0)
+    let start = DispatchTime.now().uptimeNanoseconds
+    let outputs = try await withThrowingTaskGroup(of: String.self) { group in
+        for request in 0 ..< requestCount {
+            group.addTask {
+                let record = try await runOnce(
+                    model: model,
+                    prompt: "\(prompt) Request \(request).",
+                    maxTokens: maxTokens,
+                    round: request
+                )
+                return record.output
+            }
+        }
+
+        var values: [String] = []
+        for try await value in group {
+            values.append(value)
+        }
+        return values.sorted()
+    }
+    let end = DispatchTime.now().uptimeNanoseconds
+
+    return ConcurrentRecord(
+        route: "core-concurrent",
+        model: model,
+        requestCount: requestCount,
+        totalMilliseconds: Double(end - start) / 1_000_000,
+        outputs: outputs,
+        peakResidentBytes: peakResidentBytes()
+    )
+}
+
+private func runSwitching(
+    models: [String],
+    prompt: String,
+    maxTokens: Int,
+    cycles: Int,
+    settleMilliseconds: Int
+) async throws -> SwitchRecord {
+    var runs: [RunRecord] = []
+    var residentBytesAfterClear: [UInt64] = []
+
+    for cycle in 0 ..< cycles {
+        for (index, model) in models.enumerated() {
+            try await runs.append(
+                runOnce(
+                    model: model,
+                    prompt: "\(prompt) Cycle \(cycle), model \(index).",
+                    maxTokens: maxTokens,
+                    round: cycle * models.count + index
+                )
+            )
+            await ModelPool.shared.clearCache()
+            try await Task.sleep(nanoseconds: UInt64(settleMilliseconds) * 1_000_000)
+            residentBytesAfterClear.append(currentResidentBytes())
+        }
+    }
+
+    return SwitchRecord(
+        route: "core-model-switch",
+        models: models,
+        cycles: cycles,
+        runs: runs,
+        residentBytesAfterClear: residentBytesAfterClear,
+        peakResidentBytes: peakResidentBytes()
+    )
+}
+
+private func encode(_ value: some Encodable) throws {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+    let data = try encoder.encode(value)
+    FileHandle.standardOutput.write(data)
+    FileHandle.standardOutput.write(Data([0x0A]))
+}
+
+// MARK: - SwamaAcceptanceProbe
+
+@main
+private struct SwamaAcceptanceProbe {
+    static func main() async throws {
+        let arguments = Array(CommandLine.arguments.dropFirst())
+        guard let command = arguments.first else {
+            throw ProbeError.invalidArguments("expected generate, cancel, concurrent, or switch")
+        }
+
+        switch command {
+        case "generate":
+            guard arguments.count >= 5,
+                  let maxTokens = Int(arguments[2]),
+                  let rounds = Int(arguments[3]),
+                  maxTokens > 0,
+                  rounds > 0
+            else {
+                throw ProbeError.invalidArguments(
+                    "usage: SwamaAcceptanceProbe generate MODEL MAX_TOKENS ROUNDS PROMPT"
+                )
+            }
+
+            let model = arguments[1]
+            let prompt = arguments.dropFirst(4).joined(separator: " ")
+            var records: [RunRecord] = []
+            for round in 0 ..< rounds {
+                try await records.append(
+                    runOnce(
+                        model: model,
+                        prompt: prompt,
+                        maxTokens: maxTokens,
+                        round: round
+                    )
+                )
+            }
+            try encode(records)
+
+        case "cancel":
+            guard arguments.count >= 4,
+                  let maxTokens = Int(arguments[2]),
+                  maxTokens > 2
+            else {
+                throw ProbeError.invalidArguments(
+                    "usage: SwamaAcceptanceProbe cancel MODEL MAX_TOKENS PROMPT"
+                )
+            }
+
+            try await encode(
+                runCancellation(
+                    model: arguments[1],
+                    prompt: arguments.dropFirst(3).joined(separator: " "),
+                    maxTokens: maxTokens
+                )
+            )
+
+        case "concurrent":
+            guard arguments.count >= 5,
+                  let maxTokens = Int(arguments[2]),
+                  let requests = Int(arguments[3]),
+                  maxTokens > 0,
+                  requests > 1
+            else {
+                throw ProbeError.invalidArguments(
+                    "usage: SwamaAcceptanceProbe concurrent MODEL MAX_TOKENS REQUESTS PROMPT"
+                )
+            }
+
+            try await encode(
+                runConcurrent(
+                    model: arguments[1],
+                    prompt: arguments.dropFirst(4).joined(separator: " "),
+                    maxTokens: maxTokens,
+                    requestCount: requests
+                )
+            )
+
+        case "switch":
+            guard arguments.count >= 6,
+                  let maxTokens = Int(arguments[2]),
+                  let cycles = Int(arguments[3]),
+                  let settleMilliseconds = Int(arguments[4]),
+                  maxTokens > 0,
+                  cycles > 0,
+                  settleMilliseconds >= 0
+            else {
+                throw ProbeError.invalidArguments(
+                    "usage: SwamaAcceptanceProbe switch MODEL_A,MODEL_B MAX_TOKENS CYCLES SETTLE_MS PROMPT"
+                )
+            }
+
+            let models = arguments[1].split(separator: ",").map(String.init)
+            guard models.count >= 2 else {
+                throw ProbeError.invalidArguments("switch requires at least two comma-separated models")
+            }
+
+            try await encode(
+                runSwitching(
+                    models: models,
+                    prompt: arguments.dropFirst(5).joined(separator: " "),
+                    maxTokens: maxTokens,
+                    cycles: cycles,
+                    settleMilliseconds: settleMilliseconds
+                )
+            )
+
+        default:
+            throw ProbeError.invalidArguments("unknown command: \(command)")
+        }
+    }
+}

--- a/Tools/SwamaAcceptance/Package.swift
+++ b/Tools/SwamaAcceptance/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version: 6.2
+import PackageDescription
+
+let package = Package(
+    name: "SwamaAcceptance",
+    platforms: [.macOS("15.4")],
+    products: [
+        .executable(name: "swama-acceptance", targets: ["SwamaAcceptance"])
+    ],
+    targets: [
+        .target(
+            name: "SwamaAcceptanceKit",
+            path: "Sources/SwamaAcceptanceKit"
+        ),
+        .executableTarget(
+            name: "SwamaAcceptance",
+            dependencies: ["SwamaAcceptanceKit"],
+            path: "Sources/SwamaAcceptance"
+        ),
+        .testTarget(
+            name: "SwamaAcceptanceTests",
+            dependencies: ["SwamaAcceptanceKit"],
+            path: "Tests/SwamaAcceptanceTests"
+        )
+    ]
+)

--- a/Tools/SwamaAcceptance/README.md
+++ b/Tools/SwamaAcceptance/README.md
@@ -1,0 +1,66 @@
+# Swama acceptance harness
+
+This directory is a standalone Swift package that measures Swama from outside
+the product package. It does not import or depend on `SwamaKit`.
+
+The companion `Tests/AcceptanceFixture` package is the library consumer. It
+depends on `../../swama` exactly as another Swift package would and exposes the
+small `SwamaAcceptanceProbe` executable used by the harness.
+
+This split is deliberate:
+
+- candidate Swift compilation or runtime failure cannot take down an already
+  built harness;
+- the probe cannot use `internal` or `package` Swama APIs;
+- the production `swama/Package.swift` contains no acceptance-only target;
+- all process control, HTTP streaming, RSS sampling, hashing, report sealing,
+  architecture checks and comparisons remain Swift-native.
+
+## Build the referee first
+
+```bash
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
+  xcrun swift build \
+  --package-path Tools/SwamaAcceptance \
+  --configuration release
+
+HARNESS="$(DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
+  xcrun swift build \
+  --package-path Tools/SwamaAcceptance \
+  --configuration release \
+  --show-bin-path)/swama-acceptance"
+```
+
+Run the resulting binary directly. Do not use `swift run` for a candidate: the
+binary identity is part of every report and must already be frozen before the
+candidate build starts.
+
+## Commands
+
+```bash
+"$HARNESS" architecture --repo-root "$PWD"
+
+"$HARNESS" baseline \
+  --repo-root "$PWD" \
+  --output /tmp/swama-baseline.json
+
+"$HARNESS" compare \
+  --repo-root "$PWD" \
+  --baseline /path/held-by-reviewer.json \
+  --candidate /tmp/swama-candidate.json
+```
+
+The default Swift/Xcode build path is `/Applications/Xcode.app`. The default
+Metal compiler path is `/Applications/Xcode-beta.app`; they can be overridden
+independently with `--developer-dir` and `--metal-developer-dir`.
+
+The harness builds the current resolved `mlx-swift` Metal sources into a new
+temporary directory and copies only that just-produced library beside each
+executable. It never searches old build directories for a metallib.
+
+## Report trust boundary
+
+Reports contain a canonical JSON self-hash. This detects accidental edits and
+truncation; it is not authentication because anyone can edit and reseal a
+report. The baseline of record must therefore be generated and retained by an
+independent reviewer. An author-generated baseline cannot replace it.

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptance/Main.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptance/Main.swift
@@ -1,0 +1,9 @@
+import Darwin
+import SwamaAcceptanceKit
+
+@main
+struct SwamaAcceptanceMain {
+    static func main() async {
+        await exit(AcceptanceCLI.run(Array(CommandLine.arguments.dropFirst())))
+    }
+}

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Architecture.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Architecture.swift
@@ -1,0 +1,159 @@
+import Foundation
+
+// MARK: - ArchitectureStage
+
+enum ArchitectureStage: String, Sendable {
+    case legacyRatchet = "legacy-ratchet"
+    case coreBoundary = "core-boundary"
+}
+
+func architectureReport(
+    contract: ArchitectureContract,
+    stage: ArchitectureStage,
+    paths: WorkspacePaths
+) throws -> JSONObject {
+    let packageManifest = try String(contentsOf: paths.package.appendingPathComponent("Package.swift"), encoding: .utf8)
+    let swamaKit = paths.package.appendingPathComponent("Sources/SwamaKit")
+    let forbidden = Set(contract.goalForbiddenImports)
+    let legacyImports = try imports(in: swamaKit, forbidden: forbidden, repository: paths.repository)
+    let legacyLeaks = try publicMLXLeaks(in: swamaKit, repository: paths.repository)
+    var report: JSONObject = [
+        "stage": stage.rawValue,
+        "legacy_forbidden_imports": legacyImports,
+        "legacy_public_mlx_leaks": legacyLeaks
+    ]
+
+    switch stage {
+    case .legacyRatchet:
+        let actualImports = Set(legacyImports.compactMap { item -> String? in
+            guard let file = item["file"] as? String, let module = item["module"] as? String else { return nil }
+
+            return "\(file):\(module)"
+        })
+        let allowedImports = Set(contract.legacyForbiddenImportAllowlist)
+        let actualLeaks = Set(legacyLeaks.compactMap { item -> String? in
+            guard let file = item["file"] as? String, let text = item["text"] as? String else { return nil }
+
+            return "\(file):\(text)"
+        })
+        let allowedLeaks = Set(contract.legacyPublicMLXLeakAllowlist)
+        let newImports = Array(actualImports.subtracting(allowedImports)).sorted()
+        let removedImports = Array(allowedImports.subtracting(actualImports)).sorted()
+        let newLeaks = Array(actualLeaks.subtracting(allowedLeaks)).sorted()
+        let removedLeaks = Array(allowedLeaks.subtracting(actualLeaks)).sorted()
+        report["new_forbidden_imports"] = newImports
+        report["removed_forbidden_imports"] = removedImports
+        report["new_public_mlx_leaks"] = newLeaks
+        report["removed_public_mlx_leaks"] = removedLeaks
+        report["passed"] = newImports.isEmpty && newLeaks.isEmpty
+
+    case .coreBoundary:
+        let coreRoot = paths.package.appendingPathComponent("Sources/\(contract.goalCoreTarget)")
+        let coreImports = try imports(in: coreRoot, forbidden: forbidden, repository: paths.repository)
+        let coreLeaks = try publicMLXLeaks(in: coreRoot, repository: paths.repository)
+        let targetPresent = packageManifest.contains("name: \"\(contract.goalCoreTarget)\"")
+            && FileManager.default.fileExists(atPath: coreRoot.path)
+        report["core_target_present"] = targetPresent
+        report["core_forbidden_imports"] = coreImports
+        report["core_public_mlx_leaks"] = coreLeaks
+        report["passed"] = targetPresent && coreImports.isEmpty && coreLeaks.isEmpty
+    }
+    return report
+}
+
+private func imports(
+    in root: URL,
+    forbidden: Set<String>,
+    repository: URL
+) throws -> [JSONObject] {
+    guard FileManager.default.fileExists(atPath: root.path) else {
+        return []
+    }
+
+    let expression = try NSRegularExpression(pattern: #"^\s*(?:@preconcurrency\s+)?import\s+([A-Za-z0-9_]+)"#)
+    var hits: [JSONObject] = []
+
+    for file in try regularFiles(in: root, extensions: ["swift"]).sorted(by: { $0.path < $1.path }) {
+        let text = try String(contentsOf: file, encoding: .utf8)
+        for (index, line) in text.split(separator: "\n", omittingEmptySubsequences: false).enumerated() {
+            let value = String(line)
+            let range = NSRange(value.startIndex ..< value.endIndex, in: value)
+            guard let match = expression.firstMatch(in: value, range: range),
+                  let moduleRange = Range(match.range(at: 1), in: value)
+            else {
+                continue
+            }
+
+            let module = String(value[moduleRange])
+            if forbidden.contains(module) {
+                hits.append([
+                    "file": relativePath(file, to: repository),
+                    "line": index + 1,
+                    "module": module
+                ])
+            }
+        }
+    }
+    return hits
+}
+
+private func publicMLXLeaks(in root: URL, repository: URL) throws -> [JSONObject] {
+    guard FileManager.default.fileExists(atPath: root.path) else {
+        return []
+    }
+
+    let declaration = try NSRegularExpression(
+        pattern: #"\bpublic\s+(?:(?:nonisolated|static|final|class|mutating|nonmutating)\s+)*(func|init|let|var|subscript|typealias)\b"#
+    )
+    let mlxToken = try NSRegularExpression(
+        pattern: #"\b(?:MLX[A-Za-z0-9_]*|ModelContainer|GenerateParameters|GenerateCompletionInfo|UserInput|ToolCall)\b"#
+    )
+    var hits: [JSONObject] = []
+
+    for file in try regularFiles(in: root, extensions: ["swift"]).sorted(by: { $0.path < $1.path }) {
+        let lines = try String(contentsOf: file, encoding: .utf8)
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map(String.init)
+        var index = 0
+        while index < lines.count {
+            let line = lines[index]
+            let lineRange = NSRange(line.startIndex ..< line.endIndex, in: line)
+            guard let match = declaration.firstMatch(in: line, range: lineRange),
+                  let kindRange = Range(match.range(at: 1), in: line)
+            else {
+                index += 1
+                continue
+            }
+
+            let kind = String(line[kindRange])
+            var block = [line.trimmingCharacters(in: .whitespaces)]
+            var end = index
+            if ["func", "init", "subscript"].contains(kind), !line.contains("{") {
+                while end + 1 < lines.count, end - index < 30 {
+                    end += 1
+                    block.append(lines[end].trimmingCharacters(in: .whitespaces))
+                    if lines[end].contains("{") { break }
+                }
+            }
+
+            let normalized = block.filter { !$0.isEmpty }.joined(separator: " ")
+            let normalizedRange = NSRange(normalized.startIndex ..< normalized.endIndex, in: normalized)
+            if mlxToken.firstMatch(in: normalized, range: normalizedRange) != nil {
+                hits.append([
+                    "file": relativePath(file, to: repository),
+                    "line": index + 1,
+                    "text": normalized
+                ])
+            }
+            index = end + 1
+        }
+    }
+    return hits
+}
+
+private func relativePath(_ file: URL, to root: URL) -> String {
+    file.resolvingSymlinksInPath().path.replacingOccurrences(
+        of: root.resolvingSymlinksInPath().path + "/",
+        with: ""
+    )
+}

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Baseline.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Baseline.swift
@@ -1,0 +1,378 @@
+import Foundation
+
+func runBaseline(
+    contract: AcceptanceContract,
+    contractURL: URL,
+    developerDirectory: URL,
+    metalDeveloperDirectory: URL,
+    architectureStage: ArchitectureStage,
+    paths: WorkspacePaths
+) async throws -> JSONObject {
+    var environment = try developerEnvironment(developerDirectory)
+    environment["SWAMA_PROMPT_CACHE"] = "0"
+    let architecture = try architectureReport(
+        contract: contract.architecture,
+        stage: architectureStage,
+        paths: paths
+    )
+    guard architecture["passed"] as? Bool == true else {
+        throw AcceptanceFailure.failed("architecture gate failed")
+    }
+
+    let build = try buildProducts(
+        developerDirectory: developerDirectory,
+        metalDeveloperDirectory: metalDeveloperDirectory,
+        paths: paths
+    )
+    let timeout = contract.reliability.timeoutSeconds
+    var benchmarks: JSONObject = [:]
+    var surfaces: JSONObject = [:]
+
+    for model in contract.models where model.benchmark {
+        var core = try coreBenchmark(
+            probe: build.probe,
+            model: model.id,
+            prompt: contract.benchmark.prompt,
+            maxTokens: contract.benchmark.maxTokens,
+            rounds: contract.benchmark.rounds,
+            environment: environment,
+            timeout: timeout,
+            paths: paths
+        )
+        let coreRecords = try core.array("records").compactMap { $0 as? JSONObject }
+        core["summary"] = try summarizeCore(
+            coreRecords,
+            warmups: contract.benchmark.warmupRounds,
+            minimumMeasured: contract.benchmark.minimumMeasuredRounds
+        )
+        surfaces[model.id] = try [
+            "cli": cliContract(
+                swama: build.swama,
+                model: model.id,
+                prompt: contract.benchmark.prompt,
+                maxTokens: 32,
+                environment: environment,
+                timeout: timeout,
+                paths: paths
+            )
+        ]
+
+        let serverRun = try await withServer(
+            executable: build.swama,
+            environment: environment,
+            paths: paths
+        ) { port in
+            var records: [JSONObject] = []
+            for _ in 0 ..< contract.benchmark.rounds {
+                try await records.append(httpStream(
+                    port: port,
+                    model: model.id,
+                    prompt: contract.benchmark.prompt,
+                    maxTokens: contract.benchmark.maxTokens
+                ))
+            }
+            return records
+        }
+        let httpRecords = serverRun.value.map { record -> JSONObject in
+            var value = record
+            value["external_peak_resident_bytes"] = serverRun.peakResidentBytes
+            return value
+        }
+        let http: JSONObject = try [
+            "records": httpRecords,
+            "summary": summarizeHTTP(
+                httpRecords,
+                warmups: contract.benchmark.warmupRounds,
+                minimumMeasured: contract.benchmark.minimumMeasuredRounds
+            )
+        ]
+        benchmarks[model.id] = ["core": core, "http": http]
+    }
+
+    guard let reliabilityModel = contract.models.first(where: { $0.role == "reliability" })?.id else {
+        throw AcceptanceFailure.unknown("contract has no reliability model")
+    }
+
+    var reliability: JSONObject = [:]
+
+    let cancelResult = try runCommand(
+        [
+            build.probe.path, "cancel", reliabilityModel,
+            String(contract.reliability.cancelMaxTokens),
+            "Write a long numbered list so generation continues until cancelled."
+        ],
+        currentDirectory: paths.fixture,
+        environment: environment,
+        timeout: timeout
+    )
+    guard cancelResult.returnCode == 0 else {
+        throw AcceptanceFailure.failed("cancellation contract failed: \(cancelResult.stderr.suffix(2000))")
+    }
+
+    reliability["cancel_then_recover"] = try jsonObjectFromProcess(cancelResult)
+
+    let concurrentResult = try runCommand(
+        [
+            build.probe.path, "concurrent", reliabilityModel,
+            String(contract.reliability.concurrentMaxTokens),
+            String(contract.reliability.concurrentRequests),
+            "Return a short deterministic sentence."
+        ],
+        currentDirectory: paths.fixture,
+        environment: environment,
+        timeout: timeout
+    )
+    guard concurrentResult.returnCode == 0 else {
+        throw AcceptanceFailure.failed("concurrency contract failed: \(concurrentResult.stderr.suffix(2000))")
+    }
+
+    reliability["same_model_concurrency"] = try jsonObjectFromProcess(concurrentResult)
+
+    let repeatResult = try coreBenchmark(
+        probe: build.probe,
+        model: reliabilityModel,
+        prompt: "Return the marker REPEAT_OK and one integer.",
+        maxTokens: contract.reliability.repeatMaxTokens,
+        rounds: contract.reliability.repeatRounds,
+        environment: environment,
+        timeout: timeout,
+        paths: paths
+    )
+    let repeatRecords = try repeatResult.array("records").compactMap { $0 as? JSONObject }
+    reliability["repeat_generation"] = [
+        "completed_rounds": repeatRecords.count,
+        "outputs_nonempty": repeatRecords.allSatisfy { ($0["output"] as? String)?.isEmpty == false }
+    ]
+
+    let switchModels = contract.models.map(\.id)
+    let switchResult = try runCommand(
+        [
+            build.probe.path, "switch", switchModels.joined(separator: ","),
+            String(contract.reliability.switchMaxTokens),
+            String(contract.reliability.switchCycles),
+            String(contract.reliability.releaseSettleMilliseconds),
+            "Return a short marker for the model-switch test."
+        ],
+        currentDirectory: paths.fixture,
+        environment: environment,
+        timeout: timeout * 2
+    )
+    guard switchResult.returnCode == 0 else {
+        throw AcceptanceFailure.failed("model-switch contract failed: \(switchResult.stderr.suffix(2000))")
+    }
+
+    var switchRecord = try jsonObjectFromProcess(switchResult)
+    let rssValues = try switchRecord.array("residentBytesAfterClear").compactMap { ($0 as? NSNumber)?.uint64Value }
+    let expectedSwitchRuns = switchModels.count * contract.reliability.switchCycles
+    guard rssValues.count == expectedSwitchRuns, let firstSmallRSS = rssValues.first,
+          let finalRSS = rssValues.last
+    else {
+        throw AcceptanceFailure.unknown("model-switch probe omitted post-clear RSS readings")
+    }
+
+    let releaseLimit = max(
+        Double(firstSmallRSS) * contract.reliability.releaseRSSRatioMax,
+        Double(firstSmallRSS + contract.reliability.releaseRSSAbsoluteSlackBytes)
+    )
+    switchRecord["release_limit_bytes"] = releaseLimit
+    switchRecord["release_gate_passed"] = Double(finalRSS) <= releaseLimit
+    reliability["model_switch_and_release"] = switchRecord
+
+    let disconnectRun = try await withServer(
+        executable: build.swama,
+        environment: environment,
+        paths: paths
+    ) { port -> JSONObject in
+        let disconnected = try await httpStream(
+            port: port,
+            model: reliabilityModel,
+            prompt: "Write a long essay that will be interrupted.",
+            maxTokens: 512,
+            disconnectAfterFirst: true
+        )
+        try await Task.sleep(for: .milliseconds(500))
+        let followup = try await httpStream(
+            port: port,
+            model: reliabilityModel,
+            prompt: "Reply with RECOVERED.",
+            maxTokens: 24
+        )
+        return ["disconnect": disconnected, "followup": followup]
+    }
+    var disconnect = disconnectRun.value
+    disconnect["server_peak_resident_bytes"] = disconnectRun.peakResidentBytes
+    reliability["http_disconnect_then_recover"] = disconnect
+
+    let reliabilityGates = try reliabilityGateStatus(reliability, contract: contract.reliability)
+    return try [
+        "schema_version": contract.schemaVersion,
+        "contract_sha256": sha256File(contractURL),
+        "instrument": currentInstrumentIdentity(paths: paths),
+        "provenance": captureProvenance(
+            developerDirectory: developerDirectory,
+            models: contract.models.map(\.id),
+            paths: paths
+        ),
+        "architecture": architecture,
+        "build": build.report,
+        "benchmarks": benchmarks,
+        "surface_contracts": surfaces,
+        "reliability": reliability,
+        "reliability_gates": reliabilityGates,
+        "passed": reliabilityGates.values.allSatisfy(\.self)
+    ]
+}
+
+private func coreBenchmark(
+    probe: URL,
+    model: String,
+    prompt: String,
+    maxTokens: Int,
+    rounds: Int,
+    environment: [String: String],
+    timeout: Double,
+    paths: WorkspacePaths
+) throws -> JSONObject {
+    let result = try runCommand(
+        [probe.path, "generate", model, String(maxTokens), String(rounds), prompt],
+        currentDirectory: paths.fixture,
+        environment: environment,
+        timeout: timeout
+    )
+    guard result.returnCode == 0 else {
+        throw AcceptanceFailure.failed("core benchmark failed for \(model): \(result.stderr.suffix(2000))")
+    }
+    guard var records = try lastJSONValue(result.stdout) as? [JSONObject], records.count == rounds else {
+        throw AcceptanceFailure.unknown("core benchmark returned incomplete records for \(model)")
+    }
+
+    for index in records.indices {
+        records[index]["external_peak_resident_bytes"] = result.peakResidentBytes
+    }
+    return ["records": records, "stderr": result.stderr]
+}
+
+private func cliContract(
+    swama: URL,
+    model: String,
+    prompt: String,
+    maxTokens: Int,
+    environment: [String: String],
+    timeout: Double,
+    paths: WorkspacePaths
+) throws -> JSONObject {
+    let result = try runCommand(
+        [
+            swama.path, "run", model, prompt, "--direct", "--no-stream",
+            "--temperature", "0", "--max-tokens", String(maxTokens)
+        ],
+        currentDirectory: paths.package,
+        environment: environment,
+        timeout: timeout
+    )
+    guard result.returnCode == 0, result.stdout.contains("Generation completed") else {
+        throw AcceptanceFailure.failed("CLI contract failed for \(model)")
+    }
+
+    return [
+        "returncode": result.returnCode,
+        "duration_ms": result.durationMilliseconds,
+        "peak_resident_bytes": result.peakResidentBytes,
+        "output_sha256": sha256(Data(result.stdout.utf8)),
+        "completed": true
+    ]
+}
+
+private func summarizeCore(
+    _ records: [JSONObject],
+    warmups: Int,
+    minimumMeasured: Int
+) throws -> JSONObject {
+    let measured = Array(records.dropFirst(warmups))
+    guard measured.count >= minimumMeasured else {
+        throw AcceptanceFailure.unknown("core benchmark has too few measured rounds")
+    }
+
+    let ttft = try measured.map { try $0.double("ttftMilliseconds") }
+    let speed = try measured.map { try $0.double("tokensPerSecond") }
+    let total = try measured.map { try $0.double("totalMilliseconds") }
+    let peak = measured.map {
+        max(
+            ($0["peakResidentBytes"] as? NSNumber)?.uint64Value ?? 0,
+            ($0["external_peak_resident_bytes"] as? NSNumber)?.uint64Value ?? 0
+        )
+    }
+    .max() ?? 0
+    return [
+        "rounds": measured.count,
+        "ttft_median_ms": median(ttft),
+        "tokens_per_second_median": median(speed),
+        "total_median_ms": median(total),
+        "peak_resident_bytes": peak
+    ]
+}
+
+private func summarizeHTTP(
+    _ records: [JSONObject],
+    warmups: Int,
+    minimumMeasured: Int
+) throws -> JSONObject {
+    let measured = Array(records.dropFirst(warmups))
+    guard measured.count >= minimumMeasured else {
+        throw AcceptanceFailure.unknown("HTTP benchmark has too few measured rounds")
+    }
+
+    let speed = try measured.map { try $0.object("usage").double("response_token/s") }
+    return try [
+        "rounds": measured.count,
+        "ttft_median_ms": median(measured.map { try $0.double("ttft_ms") }),
+        "tokens_per_second_median": median(speed),
+        "total_median_ms": median(measured.map { try $0.double("total_ms") }),
+        "peak_resident_bytes": measured.compactMap {
+            ($0["external_peak_resident_bytes"] as? NSNumber)?.uint64Value
+        }
+        .max() ?? 0
+    ]
+}
+
+func reliabilityGateStatus(
+    _ report: JSONObject,
+    contract: ReliabilityContract
+) throws -> [String: Bool] {
+    let cancel = try report.object("cancel_then_recover")
+    let concurrent = try report.object("same_model_concurrency")
+    let repeatGeneration = try report.object("repeat_generation")
+    let switchReport = try report.object("model_switch_and_release")
+    let disconnect = try report.object("http_disconnect_then_recover")
+    let followup = try disconnect.object("followup")
+    return try [
+        "cancel_then_recover": cancel.integer("observedTokensBeforeCancel") <= contract.cancelObservedTokenCeiling
+            && cancel.double("cancellationMilliseconds") <= contract.cancellationLatencyMillisecondsMax
+            && !cancel.string("followupOutput").isEmpty,
+        "same_model_concurrency": concurrent.array("outputs").count == contract.concurrentRequests,
+        "repeat_generation": repeatGeneration.boolean("outputs_nonempty"),
+        "model_switch_and_release": switchReport.boolean("release_gate_passed"),
+        "http_disconnect_then_recover": !followup.string("output").isEmpty
+            && followup.double("ttft_ms") <= contract.disconnectRecoveryTTFTMillisecondsMax
+    ]
+}
+
+private func jsonObjectFromProcess(_ result: CommandResult) throws -> JSONObject {
+    guard let object = try lastJSONValue(result.stdout) as? JSONObject else {
+        throw AcceptanceFailure.unknown("probe did not return a JSON object")
+    }
+
+    return object
+}
+
+func median(_ values: [Double]) -> Double {
+    let sorted = values.sorted()
+    guard !sorted.isEmpty else {
+        return .nan
+    }
+
+    let middle = sorted.count / 2
+    return sorted.count.isMultiple(of: 2)
+        ? (sorted[middle - 1] + sorted[middle]) / 2
+        : sorted[middle]
+}

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Baseline.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Baseline.swift
@@ -8,6 +8,7 @@ func runBaseline(
     architectureStage: ArchitectureStage,
     paths: WorkspacePaths
 ) async throws -> JSONObject {
+    try requireCleanWorktree(paths: paths)
     var environment = try developerEnvironment(developerDirectory)
     environment["SWAMA_PROMPT_CACHE"] = "0"
     let architecture = try architectureReport(

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Build.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Build.swift
@@ -1,0 +1,199 @@
+import Foundation
+
+// MARK: - BuildProducts
+
+struct BuildProducts {
+    let swama: URL
+    let probe: URL
+    let report: JSONObject
+}
+
+func buildProducts(
+    developerDirectory: URL,
+    metalDeveloperDirectory: URL,
+    paths: WorkspacePaths
+) throws -> BuildProducts {
+    let environment = try developerEnvironment(developerDirectory)
+    let releaseBuild = try runCommand(
+        [
+            "xcrun",
+            "swift",
+            "build",
+            "--package-path",
+            paths.package.path,
+            "--force-resolved-versions",
+            "-c",
+            "release",
+            "-j",
+            "4"
+        ],
+        currentDirectory: paths.repository,
+        environment: environment,
+        timeout: 1200,
+        sampleMemory: false
+    )
+    guard releaseBuild.returnCode == 0 else {
+        throw AcceptanceFailure.failed("Swama release build failed:\n\(releaseBuild.stderr.suffix(4000))")
+    }
+
+    let fixtureBuild = try runCommand(
+        [
+            "xcrun",
+            "swift",
+            "build",
+            "--package-path",
+            paths.fixture.path,
+            "--force-resolved-versions",
+            "-c",
+            "release",
+            "-j",
+            "4"
+        ],
+        currentDirectory: paths.repository,
+        environment: environment,
+        timeout: 1200,
+        sampleMemory: false
+    )
+    guard fixtureBuild.returnCode == 0 else {
+        throw AcceptanceFailure.failed("external consumer fixture build failed:\n\(fixtureBuild.stderr.suffix(4000))")
+    }
+
+    let testBuild = try runCommand(
+        [
+            "xcrun",
+            "swift",
+            "build",
+            "--package-path",
+            paths.package.path,
+            "--force-resolved-versions",
+            "--build-tests",
+            "-j",
+            "4"
+        ],
+        currentDirectory: paths.repository,
+        environment: environment,
+        timeout: 1200,
+        sampleMemory: false
+    )
+    guard testBuild.returnCode == 0 else {
+        throw AcceptanceFailure.failed("Swama test build failed:\n\(testBuild.stderr.suffix(4000))")
+    }
+
+    let releaseBin = try URL(fileURLWithPath: commandOutput(
+        [
+            "xcrun",
+            "swift",
+            "build",
+            "--package-path",
+            paths.package.path,
+            "--force-resolved-versions",
+            "-c",
+            "release",
+            "--show-bin-path"
+        ],
+        currentDirectory: paths.repository,
+        environment: environment
+    ))
+    let fixtureBin = try URL(fileURLWithPath: commandOutput(
+        [
+            "xcrun",
+            "swift",
+            "build",
+            "--package-path",
+            paths.fixture.path,
+            "--force-resolved-versions",
+            "-c",
+            "release",
+            "--show-bin-path"
+        ],
+        currentDirectory: paths.repository,
+        environment: environment
+    ))
+    let debugBin = try URL(fileURLWithPath: commandOutput(
+        [
+            "xcrun",
+            "swift",
+            "build",
+            "--package-path",
+            paths.package.path,
+            "--force-resolved-versions",
+            "-c",
+            "debug",
+            "--show-bin-path"
+        ],
+        currentDirectory: paths.repository,
+        environment: environment
+    ))
+    let swama = releaseBin.appendingPathComponent("swama")
+    let probe = fixtureBin.appendingPathComponent("SwamaAcceptanceProbe")
+    let testExecutable = debugBin
+        .appendingPathComponent("swamaPackageTests.xctest/Contents/MacOS/swamaPackageTests")
+    for required in [swama, probe, testExecutable] where !FileManager.default.fileExists(atPath: required.path) {
+        throw AcceptanceFailure.unknown("expected build product is missing: \(required.path)")
+    }
+
+    let metal = try buildMetallib(metalDeveloperDirectory: metalDeveloperDirectory, paths: paths)
+    defer { metal.remove() }
+    let swamaMetal = try installMetallib(metal.library, nextTo: swama)
+    let probeMetal = try installMetallib(metal.library, nextTo: probe)
+    let testMetal = try installMetallib(metal.library, nextTo: testExecutable)
+
+    let tests = try runCommand(
+        [
+            "xcrun",
+            "swift",
+            "test",
+            "--package-path",
+            paths.package.path,
+            "--force-resolved-versions",
+            "--skip-build",
+            "-j",
+            "4"
+        ],
+        currentDirectory: paths.repository,
+        environment: environment,
+        timeout: 600,
+        sampleMemory: false
+    )
+    guard tests.returnCode == 0 else {
+        throw AcceptanceFailure.failed(
+            "Swift tests failed:\n\(tests.stdout.suffix(2000))\n\(tests.stderr.suffix(2000))"
+        )
+    }
+
+    let testCount = firstCapture(#"Test run with (\d+) tests"#, in: tests.stdout).flatMap(Int.init) ?? -1
+
+    return .init(
+        swama: swama,
+        probe: probe,
+        report: [
+            "duration_ms": releaseBuild.durationMilliseconds + fixtureBuild.durationMilliseconds,
+            "swama": swama.path,
+            "probe": probe.path,
+            "metal_build": metal.provenance,
+            "metallib": swamaMetal,
+            "probe_metallib": probeMetal,
+            "swift_tests": [
+                "count": testCount,
+                "duration_ms": tests.durationMilliseconds,
+                "metallib": testMetal
+            ]
+        ]
+    )
+}
+
+func firstCapture(_ pattern: String, in text: String) -> String? {
+    guard let expression = try? NSRegularExpression(pattern: pattern) else {
+        return nil
+    }
+
+    let range = NSRange(text.startIndex ..< text.endIndex, in: text)
+    guard let match = expression.firstMatch(in: text, range: range),
+          match.numberOfRanges > 1,
+          let capture = Range(match.range(at: 1), in: text)
+    else {
+        return nil
+    }
+
+    return String(text[capture])
+}

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Build.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Build.swift
@@ -33,7 +33,7 @@ func buildProducts(
         sampleMemory: false
     )
     guard releaseBuild.returnCode == 0 else {
-        throw AcceptanceFailure.failed("Swama release build failed:\n\(releaseBuild.stderr.suffix(4000))")
+        throw AcceptanceFailure.failed("Swama release build failed:\n\(commandFailureSummary(releaseBuild))")
     }
 
     let fixtureBuild = try runCommand(
@@ -55,7 +55,8 @@ func buildProducts(
         sampleMemory: false
     )
     guard fixtureBuild.returnCode == 0 else {
-        throw AcceptanceFailure.failed("external consumer fixture build failed:\n\(fixtureBuild.stderr.suffix(4000))")
+        throw AcceptanceFailure
+            .failed("external consumer fixture build failed:\n\(commandFailureSummary(fixtureBuild))")
     }
 
     let testBuild = try runCommand(
@@ -76,7 +77,7 @@ func buildProducts(
         sampleMemory: false
     )
     guard testBuild.returnCode == 0 else {
-        throw AcceptanceFailure.failed("Swama test build failed:\n\(testBuild.stderr.suffix(4000))")
+        throw AcceptanceFailure.failed("Swama test build failed:\n\(commandFailureSummary(testBuild))")
     }
 
     let releaseBin = try URL(fileURLWithPath: commandOutput(
@@ -157,7 +158,7 @@ func buildProducts(
     )
     guard tests.returnCode == 0 else {
         throw AcceptanceFailure.failed(
-            "Swift tests failed:\n\(tests.stdout.suffix(2000))\n\(tests.stderr.suffix(2000))"
+            "Swift tests failed:\n\(commandFailureSummary(tests))"
         )
     }
 
@@ -180,6 +181,20 @@ func buildProducts(
             ]
         ]
     )
+}
+
+func commandFailureSummary(_ result: CommandResult, maximumCharacters: Int = 4000) -> String {
+    let combined = result.stdout + "\n" + result.stderr
+    let errorLines = combined.split(separator: "\n")
+        .filter { $0.localizedCaseInsensitiveContains("error:") }
+        .suffix(20)
+        .joined(separator: "\n")
+    let tail = String(combined.suffix(maximumCharacters))
+    guard !errorLines.isEmpty else {
+        return tail
+    }
+
+    return "error lines:\n\(errorLines)\noutput tail:\n\(tail)"
 }
 
 func firstCapture(_ pattern: String, in text: String) -> String? {

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/CLI.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/CLI.swift
@@ -1,0 +1,143 @@
+import Foundation
+
+// MARK: - AcceptanceCLI
+
+public enum AcceptanceCLI {
+    public static func run(_ rawArguments: [String]) async -> Int32 {
+        do {
+            let arguments = try Arguments.parse(rawArguments)
+            let paths = try WorkspacePaths.discover(explicit: arguments.repoRoot)
+            let contractURL = arguments.contract.map { URL(fileURLWithPath: $0) } ?? paths.contract
+            let contract = try AcceptanceContract.load(from: contractURL)
+
+            switch arguments.command {
+            case .architecture:
+                let report = try architectureReport(
+                    contract: contract.architecture,
+                    stage: arguments.stage,
+                    paths: paths
+                )
+                try writeStandardOutput(report)
+                return report["passed"] as? Bool == true ? 0 : 1
+
+            case .baseline:
+                guard let output = arguments.output else {
+                    throw AcceptanceFailure.unknown("baseline requires --output")
+                }
+
+                var report = try await runBaseline(
+                    contract: contract,
+                    contractURL: contractURL,
+                    developerDirectory: URL(fileURLWithPath: arguments.developerDirectory),
+                    metalDeveloperDirectory: URL(fileURLWithPath: arguments.metalDeveloperDirectory),
+                    architectureStage: arguments.stage,
+                    paths: paths
+                )
+                try sealReport(&report)
+                try prettyJSONData(report).write(to: URL(fileURLWithPath: output), options: .atomic)
+                try writeStandardOutput(report)
+                return report["passed"] as? Bool == true ? 0 : 1
+
+            case .compare:
+                guard let baseline = arguments.baseline, let candidate = arguments.candidate else {
+                    throw AcceptanceFailure.unknown("compare requires --baseline and --candidate")
+                }
+
+                var report = try compareReports(
+                    baseline: loadJSONObject(URL(fileURLWithPath: baseline)),
+                    candidate: loadJSONObject(URL(fileURLWithPath: candidate)),
+                    contract: contract,
+                    contractURL: contractURL,
+                    paths: paths
+                )
+                if let output = arguments.output {
+                    try sealReport(&report)
+                    try prettyJSONData(report).write(to: URL(fileURLWithPath: output), options: .atomic)
+                }
+                try writeStandardOutput(report)
+                return report["passed"] as? Bool == true ? 0 : 1
+            }
+        }
+        catch let error as AcceptanceFailure {
+            let status = error.kind == .unknown ? "UNKNOWN" : "FAIL"
+            try? writeStandardError(["status": status, "error": error.message])
+            return error.kind == .unknown ? 2 : 1
+        }
+        catch {
+            try? writeStandardError(["status": "UNKNOWN", "error": String(describing: error)])
+            return 2
+        }
+    }
+}
+
+// MARK: - Command
+
+private enum Command: String {
+    case architecture
+    case baseline
+    case compare
+}
+
+// MARK: - Arguments
+
+private struct Arguments {
+    let command: Command
+    let repoRoot: String?
+    let contract: String?
+    let developerDirectory: String
+    let metalDeveloperDirectory: String
+    let stage: ArchitectureStage
+    let output: String?
+    let baseline: String?
+    let candidate: String?
+
+    static func parse(_ raw: [String]) throws -> Self {
+        var values: [String: String] = [:]
+        var positionals: [String] = []
+        var index = 0
+        while index < raw.count {
+            let argument = raw[index]
+            if argument.hasPrefix("--") {
+                guard index + 1 < raw.count else {
+                    throw AcceptanceFailure.unknown("missing value for \(argument)")
+                }
+
+                values[argument] = raw[index + 1]
+                index += 2
+            }
+            else {
+                positionals.append(argument)
+                index += 1
+            }
+        }
+        guard positionals.count == 1, let command = Command(rawValue: positionals[0]) else {
+            throw AcceptanceFailure.unknown("usage: swama-acceptance [options] architecture|baseline|compare")
+        }
+
+        let stageText = values["--stage"] ?? values["--architecture-stage"] ?? "legacy-ratchet"
+        guard let stage = ArchitectureStage(rawValue: stageText) else {
+            throw AcceptanceFailure.unknown("unknown architecture stage: \(stageText)")
+        }
+
+        return .init(
+            command: command,
+            repoRoot: values["--repo-root"],
+            contract: values["--contract"],
+            developerDirectory: values["--developer-dir"] ?? "/Applications/Xcode.app/Contents/Developer",
+            metalDeveloperDirectory: values["--metal-developer-dir"] ??
+                "/Applications/Xcode-beta.app/Contents/Developer",
+            stage: stage,
+            output: values["--output"],
+            baseline: values["--baseline"],
+            candidate: values["--candidate"]
+        )
+    }
+}
+
+private func writeStandardOutput(_ object: Any) throws {
+    try FileHandle.standardOutput.write(prettyJSONData(object))
+}
+
+private func writeStandardError(_ object: Any) throws {
+    try FileHandle.standardError.write(prettyJSONData(object))
+}

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Compare.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Compare.swift
@@ -1,0 +1,185 @@
+import Foundation
+
+func compareReports(
+    baseline: JSONObject,
+    candidate: JSONObject,
+    contract: AcceptanceContract,
+    contractURL: URL,
+    paths: WorkspacePaths
+) throws -> JSONObject {
+    try verifyReport(baseline)
+    try verifyReport(candidate)
+    let currentContractHash = try sha256File(contractURL)
+    guard baseline["contract_sha256"] as? String == currentContractHash else {
+        throw AcceptanceFailure.unknown("baseline contract hash does not match current --contract")
+    }
+    guard candidate["contract_sha256"] as? String == currentContractHash else {
+        throw AcceptanceFailure.unknown("candidate contract hash does not match current --contract")
+    }
+
+    let currentInstrument = try currentInstrumentIdentity(paths: paths)
+    let baselineInstrument = try baseline.object("instrument")
+    let candidateInstrument = try candidate.object("instrument")
+    let immutableInstrumentKeys = [
+        "harness_binary_sha256",
+        "harness_sources_sha256",
+        "harness_tests_sha256",
+        "core_probe_sha256",
+        "fixture_manifest_sha256"
+    ]
+    for key in immutableInstrumentKeys {
+        let current = try currentInstrument.string(key)
+        guard baselineInstrument[key] as? String == current else {
+            throw AcceptanceFailure.unknown("baseline instrument hash does not match current \(key)")
+        }
+        guard candidateInstrument[key] as? String == current else {
+            throw AcceptanceFailure.unknown("candidate instrument hash does not match current \(key)")
+        }
+    }
+
+    let baselineProvenance = try baseline.object("provenance")
+    let candidateProvenance = try candidate.object("provenance")
+    var comparable: JSONObject = try [
+        "platform": jsonEqual(baselineProvenance["platform"], candidateProvenance["platform"]),
+        "toolchain": jsonEqual(baselineProvenance["toolchain"], candidateProvenance["toolchain"]),
+        "models": jsonEqual(baselineProvenance["models"], candidateProvenance["models"]),
+        "contract": baseline["contract_sha256"] as? String == candidate["contract_sha256"] as? String,
+        "instrument": Dictionary(uniqueKeysWithValues: immutableInstrumentKeys.map { key in
+            (key, baselineInstrument[key] as? String == candidateInstrument[key] as? String)
+        })
+    ]
+
+    let baselineMetal = try baseline.object("build").object("metal_build")
+    let candidateMetal = try candidate.object("build").object("metal_build")
+    let metalKeys = [
+        "metal_version",
+        "metallib_version",
+        "metal_executable_sha256",
+        "metallib_executable_sha256",
+        "mlx_swift_revision",
+        "sha256"
+    ]
+    var metalComparable = Dictionary(uniqueKeysWithValues: metalKeys.map { key in
+        (key, baselineMetal[key] as? String == candidateMetal[key] as? String && baselineMetal[key] != nil)
+    })
+    metalComparable["source_inputs"] = try metalSourceIdentities(baselineMetal) == metalSourceIdentities(candidateMetal)
+        && !metalSourceIdentities(baselineMetal).isEmpty
+    comparable["metal_toolchain"] = metalComparable
+
+    guard try allJSONBooleansTrue(comparable) else {
+        throw try AcceptanceFailure
+            .unknown("reports are not comparable: \(String(decoding: compactJSONData(comparable), as: UTF8.self))")
+    }
+
+    var findings: [JSONObject] = []
+    let baselineBenchmarks = try baseline.object("benchmarks")
+    let candidateBenchmarks = try candidate.object("benchmarks")
+    for model in baselineBenchmarks.keys.sorted() {
+        guard let baselineRoutes = baselineBenchmarks[model] as? JSONObject,
+              let candidateRoutes = candidateBenchmarks[model] as? JSONObject
+        else {
+            throw AcceptanceFailure.unknown("candidate is missing benchmark model: \(model)")
+        }
+
+        for route in ["core", "http"] {
+            let baselineSummary = try baselineRoutes.object(route).object("summary")
+            let candidateSummary = try candidateRoutes.object(route).object("summary")
+            let baseTTFT = try baselineSummary.double("ttft_median_ms")
+            let candidateTTFT = try candidateSummary.double("ttft_median_ms")
+            let ttftLimit = max(
+                baseTTFT * contract.benchmark.comparison.ttftRatioMax,
+                baseTTFT + contract.benchmark.comparison.ttftAbsoluteSlackMilliseconds
+            )
+            let baseSpeed = try baselineSummary.double("tokens_per_second_median")
+            let candidateSpeed = try candidateSummary.double("tokens_per_second_median")
+            let speedFloor = baseSpeed * contract.benchmark.comparison.tokensPerSecondRatioMin
+            let baseMemory = try baselineSummary.double("peak_resident_bytes")
+            let candidateMemory = try candidateSummary.double("peak_resident_bytes")
+            let memoryLimit = max(
+                baseMemory * contract.benchmark.comparison.peakResidentRatioMax,
+                baseMemory + Double(contract.benchmark.comparison.peakResidentAbsoluteSlackBytes)
+            )
+            if candidateTTFT > ttftLimit {
+                findings.append(metricFinding(model, route, "ttft", baseTTFT, candidateTTFT, ttftLimit))
+            }
+            if candidateSpeed < speedFloor {
+                findings.append(metricFinding(model, route, "tokens_per_second", baseSpeed, candidateSpeed, speedFloor))
+            }
+            if candidateMemory > memoryLimit {
+                findings.append(metricFinding(
+                    model,
+                    route,
+                    "peak_resident_bytes",
+                    baseMemory,
+                    candidateMemory,
+                    memoryLimit
+                ))
+            }
+        }
+    }
+    if candidate["passed"] as? Bool != true {
+        findings.append([
+            "metric": "candidate_contract",
+            "candidate": "failed reliability or architecture gate"
+        ])
+    }
+    return ["comparable": comparable, "findings": findings, "passed": findings.isEmpty]
+}
+
+private func metricFinding(
+    _ model: String,
+    _ route: String,
+    _ metric: String,
+    _ baseline: Double,
+    _ candidate: Double,
+    _ limit: Double
+) -> JSONObject {
+    [
+        "model": model,
+        "route": route,
+        "metric": metric,
+        "baseline": baseline,
+        "candidate": candidate,
+        "limit": limit
+    ]
+}
+
+private func metalSourceIdentities(_ metal: JSONObject) throws -> [String] {
+    try metal.array("sources").compactMap { value in
+        guard let item = value as? JSONObject,
+              let path = item["path"] as? String,
+              let hash = item["sha256"] as? String
+        else {
+            return nil
+        }
+
+        return "\(path):\(hash)"
+    }
+}
+
+private func jsonEqual(_ lhs: Any?, _ rhs: Any?) throws -> Bool {
+    guard let lhs, let rhs else {
+        return lhs == nil && rhs == nil
+    }
+
+    return try compactJSONData([lhs]) == compactJSONData([rhs])
+}
+
+private func allJSONBooleansTrue(_ object: JSONObject) throws -> Bool {
+    for value in object.values {
+        if let boolean = value as? Bool {
+            if !boolean {
+                return false
+            }
+        }
+        else if let nested = value as? JSONObject {
+            if try !allJSONBooleansTrue(nested) {
+                return false
+            }
+        }
+        else {
+            throw AcceptanceFailure.unknown("comparability report contains a non-boolean leaf")
+        }
+    }
+    return true
+}

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Compare.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Compare.swift
@@ -59,9 +59,10 @@ func compareReports(
         "mlx_swift_revision",
         "sha256"
     ]
-    var metalComparable = Dictionary(uniqueKeysWithValues: metalKeys.map { key in
-        (key, baselineMetal[key] as? String == candidateMetal[key] as? String && baselineMetal[key] != nil)
-    })
+    var metalComparable: JSONObject = [:]
+    for key in metalKeys {
+        metalComparable[key] = try baselineMetal.string(key) == candidateMetal.string(key)
+    }
     metalComparable["source_inputs"] = try metalSourceIdentities(baselineMetal) == metalSourceIdentities(candidateMetal)
         && !metalSourceIdentities(baselineMetal).isEmpty
     comparable["metal_toolchain"] = metalComparable
@@ -74,6 +75,12 @@ func compareReports(
     var findings: [JSONObject] = []
     let baselineBenchmarks = try baseline.object("benchmarks")
     let candidateBenchmarks = try candidate.object("benchmarks")
+    guard !baselineBenchmarks.isEmpty else {
+        throw AcceptanceFailure.unknown("baseline contains no benchmark models")
+    }
+
+    let benchmarkRoutes = ["core", "http"]
+    var comparedRouteCount = 0
     for model in baselineBenchmarks.keys.sorted() {
         guard let baselineRoutes = baselineBenchmarks[model] as? JSONObject,
               let candidateRoutes = candidateBenchmarks[model] as? JSONObject
@@ -81,7 +88,7 @@ func compareReports(
             throw AcceptanceFailure.unknown("candidate is missing benchmark model: \(model)")
         }
 
-        for route in ["core", "http"] {
+        for route in benchmarkRoutes {
             let baselineSummary = try baselineRoutes.object(route).object("summary")
             let candidateSummary = try candidateRoutes.object(route).object("summary")
             let baseTTFT = try baselineSummary.double("ttft_median_ms")
@@ -115,6 +122,7 @@ func compareReports(
                     memoryLimit
                 ))
             }
+            comparedRouteCount += 1
         }
     }
     if candidate["passed"] as? Bool != true {
@@ -123,7 +131,15 @@ func compareReports(
             "candidate": "failed reliability or architecture gate"
         ])
     }
-    return ["comparable": comparable, "findings": findings, "passed": findings.isEmpty]
+    return [
+        "comparable": comparable,
+        "comparison_coverage": [
+            "benchmark_models": baselineBenchmarks.count,
+            "benchmark_routes": comparedRouteCount
+        ],
+        "findings": findings,
+        "passed": findings.isEmpty
+    ]
 }
 
 private func metricFinding(

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Contract.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Contract.swift
@@ -1,0 +1,126 @@
+import Foundation
+
+// MARK: - AcceptanceContract
+
+struct AcceptanceContract: Codable, Sendable {
+    let schemaVersion: Int
+    let models: [ModelContract]
+    let benchmark: BenchmarkContract
+    let reliability: ReliabilityContract
+    let architecture: ArchitectureContract
+
+    enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case models
+        case benchmark
+        case reliability
+        case architecture
+    }
+
+    static func load(from url: URL) throws -> Self {
+        do {
+            return try JSONDecoder().decode(Self.self, from: Data(contentsOf: url))
+        }
+        catch {
+            throw AcceptanceFailure.unknown("cannot decode contract \(url.path): \(error)")
+        }
+    }
+}
+
+// MARK: - ModelContract
+
+struct ModelContract: Codable, Sendable {
+    let id: String
+    let role: String
+    let benchmark: Bool
+}
+
+// MARK: - BenchmarkContract
+
+struct BenchmarkContract: Codable, Sendable {
+    let maxTokens: Int
+    let rounds: Int
+    let warmupRounds: Int
+    let minimumMeasuredRounds: Int
+    let prompt: String
+    let comparison: ComparisonContract
+
+    enum CodingKeys: String, CodingKey {
+        case maxTokens = "max_tokens"
+        case rounds
+        case warmupRounds = "warmup_rounds"
+        case minimumMeasuredRounds = "minimum_measured_rounds"
+        case prompt
+        case comparison
+    }
+}
+
+// MARK: - ComparisonContract
+
+struct ComparisonContract: Codable, Sendable {
+    let ttftRatioMax: Double
+    let ttftAbsoluteSlackMilliseconds: Double
+    let tokensPerSecondRatioMin: Double
+    let peakResidentRatioMax: Double
+    let peakResidentAbsoluteSlackBytes: UInt64
+
+    enum CodingKeys: String, CodingKey {
+        case ttftRatioMax = "ttft_ratio_max"
+        case ttftAbsoluteSlackMilliseconds = "ttft_absolute_slack_ms"
+        case tokensPerSecondRatioMin = "tokens_per_second_ratio_min"
+        case peakResidentRatioMax = "peak_resident_ratio_max"
+        case peakResidentAbsoluteSlackBytes = "peak_resident_absolute_slack_bytes"
+    }
+}
+
+// MARK: - ReliabilityContract
+
+struct ReliabilityContract: Codable, Sendable {
+    let cancelMaxTokens: Int
+    let cancelObservedTokenCeiling: Int
+    let cancellationLatencyMillisecondsMax: Double
+    let concurrentRequests: Int
+    let concurrentMaxTokens: Int
+    let repeatRounds: Int
+    let repeatMaxTokens: Int
+    let switchCycles: Int
+    let switchMaxTokens: Int
+    let releaseSettleMilliseconds: Int
+    let releaseRSSRatioMax: Double
+    let releaseRSSAbsoluteSlackBytes: UInt64
+    let disconnectRecoveryTTFTMillisecondsMax: Double
+    let timeoutSeconds: Double
+
+    enum CodingKeys: String, CodingKey {
+        case cancelMaxTokens = "cancel_max_tokens"
+        case cancelObservedTokenCeiling = "cancel_observed_token_ceiling"
+        case cancellationLatencyMillisecondsMax = "cancellation_latency_ms_max"
+        case concurrentRequests = "concurrent_requests"
+        case concurrentMaxTokens = "concurrent_max_tokens"
+        case repeatRounds = "repeat_rounds"
+        case repeatMaxTokens = "repeat_max_tokens"
+        case switchCycles = "switch_cycles"
+        case switchMaxTokens = "switch_max_tokens"
+        case releaseSettleMilliseconds = "release_settle_ms"
+        case releaseRSSRatioMax = "release_rss_ratio_max"
+        case releaseRSSAbsoluteSlackBytes = "release_rss_absolute_slack_bytes"
+        case disconnectRecoveryTTFTMillisecondsMax = "disconnect_recovery_ttft_ms_max"
+        case timeoutSeconds = "timeout_seconds"
+    }
+}
+
+// MARK: - ArchitectureContract
+
+struct ArchitectureContract: Codable, Sendable {
+    let legacyForbiddenImportAllowlist: [String]
+    let legacyPublicMLXLeakAllowlist: [String]
+    let goalCoreTarget: String
+    let goalForbiddenImports: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case legacyForbiddenImportAllowlist = "legacy_forbidden_import_allowlist"
+        case legacyPublicMLXLeakAllowlist = "legacy_public_mlx_leak_allowlist"
+        case goalCoreTarget = "goal_core_target"
+        case goalForbiddenImports = "goal_forbidden_imports"
+    }
+}

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/HTTP.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/HTTP.swift
@@ -1,0 +1,245 @@
+import Darwin
+import Foundation
+
+// MARK: - PeakResidentSampler
+
+actor PeakResidentSampler {
+    private var peak: UInt64 = 0
+
+    func observe(pid: pid_t) {
+        peak = max(peak, residentBytes(pid: pid))
+    }
+
+    func value() -> UInt64 { peak }
+}
+
+func withServer<T>(
+    executable: URL,
+    environment: [String: String],
+    paths: WorkspacePaths,
+    operation: (Int) async throws -> T
+) async throws -> (value: T, peakResidentBytes: UInt64, stderr: String) {
+    let port = try freePort()
+    let temporary = FileManager.default
+        .temporaryDirectory
+        .appendingPathComponent("swama-acceptance-server-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: temporary, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: temporary) }
+
+    let stdoutURL = temporary.appendingPathComponent("stdout")
+    let stderrURL = temporary.appendingPathComponent("stderr")
+    FileManager.default.createFile(atPath: stdoutURL.path, contents: nil)
+    FileManager.default.createFile(atPath: stderrURL.path, contents: nil)
+    let stdoutHandle = try FileHandle(forWritingTo: stdoutURL)
+    let stderrHandle = try FileHandle(forWritingTo: stderrURL)
+    defer {
+        try? stdoutHandle.close()
+        try? stderrHandle.close()
+    }
+
+    let process = Process()
+    process.executableURL = executable
+    process.arguments = ["serve", "--host", "127.0.0.1", "--port", String(port)]
+    process.currentDirectoryURL = paths.package
+    process.environment = environment
+    process.standardOutput = stdoutHandle
+    process.standardError = stderrHandle
+    try process.run()
+
+    let pid = process.processIdentifier
+    let sampler = PeakResidentSampler()
+    let samplingTask = Task.detached {
+        while !Task.isCancelled {
+            await sampler.observe(pid: pid)
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+    }
+
+    func stop() async throws -> (UInt64, String) {
+        if process.isRunning {
+            kill(pid, SIGINT)
+            let deadline = Date().addingTimeInterval(10)
+            while process.isRunning, Date() < deadline {
+                try? await Task.sleep(for: .milliseconds(20))
+            }
+            if process.isRunning {
+                kill(pid, SIGKILL)
+            }
+        }
+        process.waitUntilExit()
+        samplingTask.cancel()
+        _ = await samplingTask.result
+        let peak = await sampler.value()
+        try stdoutHandle.synchronize()
+        try stderrHandle.synchronize()
+        let stderr = try String(decoding: Data(contentsOf: stderrURL), as: UTF8.self)
+        let returnCode = process.terminationReason == .uncaughtSignal
+            ? -process.terminationStatus
+            : process.terminationStatus
+        guard returnCode == 0 || returnCode == -SIGINT else {
+            throw AcceptanceFailure.failed("server exited unexpectedly (\(returnCode)): \(stderr.suffix(2000))")
+        }
+
+        return (peak, stderr)
+    }
+
+    do {
+        try await waitForServer(port: port)
+        let value = try await operation(port)
+        guard process.isRunning else {
+            throw AcceptanceFailure.failed("server crashed before the operation completed")
+        }
+
+        let (peak, stderr) = try await stop()
+        return (value, peak, stderr)
+    }
+    catch {
+        _ = try? await stop()
+        throw error
+    }
+}
+
+func httpStream(
+    port: Int,
+    model: String,
+    prompt: String,
+    maxTokens: Int,
+    disconnectAfterFirst: Bool = false
+) async throws -> JSONObject {
+    let payload: JSONObject = [
+        "model": model,
+        "messages": [["role": "user", "content": prompt]],
+        "temperature": 0,
+        "top_p": 1,
+        "max_tokens": maxTokens,
+        "stream": true
+    ]
+    var request = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!)
+    request.httpMethod = "POST"
+    request.timeoutInterval = 300
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.httpBody = try compactJSONData(payload)
+
+    let clock = ContinuousClock()
+    let started = clock.now
+    let (bytes, response) = try await URLSession.shared.bytes(for: request)
+    guard let http = response as? HTTPURLResponse else {
+        throw AcceptanceFailure.unknown("HTTP completion returned a non-HTTP response")
+    }
+    guard http.statusCode == 200 else {
+        throw AcceptanceFailure.failed("HTTP completion failed (\(http.statusCode))")
+    }
+
+    var firstContent: ContinuousClock.Instant?
+    var output = ""
+    var usage: JSONObject?
+    var eventCount = 0
+    for try await rawLine in bytes.lines {
+        let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard line.hasPrefix("data: ") else { continue }
+
+        let dataText = String(line.dropFirst(6))
+        if dataText == "[DONE]" { break }
+        guard let data = dataText.data(using: .utf8),
+              let event = try JSONSerialization.jsonObject(with: data) as? JSONObject
+        else {
+            throw AcceptanceFailure.unknown("invalid SSE JSON: \(dataText)")
+        }
+
+        eventCount += 1
+        if let eventUsage = event["usage"] as? JSONObject {
+            usage = eventUsage
+        }
+        guard let choices = event["choices"] as? [JSONObject],
+              let first = choices.first,
+              let delta = first["delta"] as? JSONObject,
+              let content = delta["content"] as? String,
+              !content.isEmpty
+        else {
+            continue
+        }
+
+        if firstContent == nil {
+            firstContent = clock.now
+        }
+        output += content
+        if disconnectAfterFirst {
+            return [
+                "disconnected": true,
+                "ttft_ms": milliseconds(from: started, to: firstContent!),
+                "events": eventCount
+            ]
+        }
+    }
+
+    guard let firstContent else {
+        throw AcceptanceFailure.failed("HTTP stream completed without a content event")
+    }
+
+    return [
+        "ttft_ms": milliseconds(from: started, to: firstContent),
+        "total_ms": milliseconds(from: started, to: clock.now),
+        "events": eventCount,
+        "output": output,
+        "usage": usage ?? NSNull()
+    ]
+}
+
+private func waitForServer(port: Int) async throws {
+    let deadline = Date().addingTimeInterval(30)
+    while Date() < deadline {
+        var request = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/v1/models")!)
+        request.timeoutInterval = 1
+        if let (_, response) = try? await URLSession.shared.data(for: request),
+           (response as? HTTPURLResponse)?.statusCode == 200
+        {
+            return
+        }
+        try? await Task.sleep(for: .milliseconds(100))
+    }
+    throw AcceptanceFailure.failed("server did not become ready on port \(port)")
+}
+
+private func freePort() throws -> Int {
+    let descriptor = socket(AF_INET, SOCK_STREAM, 0)
+    guard descriptor >= 0 else {
+        throw AcceptanceFailure.unknown("cannot create socket for port allocation")
+    }
+
+    defer { close(descriptor) }
+
+    var address = sockaddr_in()
+    address.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+    address.sin_family = sa_family_t(AF_INET)
+    address.sin_port = 0
+    address.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
+    let bindResult = withUnsafePointer(to: &address) { pointer in
+        pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+            bind(descriptor, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+        }
+    }
+    guard bindResult == 0 else {
+        throw AcceptanceFailure.unknown("cannot bind socket for port allocation")
+    }
+
+    var length = socklen_t(MemoryLayout<sockaddr_in>.size)
+    let nameResult = withUnsafeMutablePointer(to: &address) { pointer in
+        pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+            getsockname(descriptor, $0, &length)
+        }
+    }
+    guard nameResult == 0 else {
+        throw AcceptanceFailure.unknown("cannot read allocated port")
+    }
+
+    return Int(UInt16(bigEndian: address.sin_port))
+}
+
+func milliseconds(
+    from start: ContinuousClock.Instant,
+    to end: ContinuousClock.Instant
+) -> Double {
+    let duration = start.duration(to: end)
+    return Double(duration.components.seconds) * 1000
+        + Double(duration.components.attoseconds) / 1_000_000_000_000_000
+}

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/MetalBuilder.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/MetalBuilder.swift
@@ -1,0 +1,154 @@
+import Foundation
+
+// MARK: - MetalBuildArtifact
+
+struct MetalBuildArtifact {
+    let library: URL
+    let provenance: JSONObject
+    let temporaryDirectory: URL
+
+    func remove() {
+        try? FileManager.default.removeItem(at: temporaryDirectory)
+    }
+}
+
+func buildMetallib(
+    metalDeveloperDirectory: URL,
+    paths: WorkspacePaths
+) throws -> MetalBuildArtifact {
+    let environment = try developerEnvironment(metalDeveloperDirectory)
+    let metalVersion = try commandOutput(
+        ["xcrun", "-sdk", "macosx", "metal", "--version"],
+        currentDirectory: paths.repository,
+        environment: environment
+    )
+    let metallibVersion = try commandOutput(
+        ["xcrun", "-sdk", "macosx", "metallib", "--version"],
+        currentDirectory: paths.repository,
+        environment: environment
+    )
+    let metalExecutable = try URL(fileURLWithPath: commandOutput(
+        ["xcrun", "-sdk", "macosx", "-f", "metal"],
+        currentDirectory: paths.repository,
+        environment: environment
+    )).standardizedFileURL
+    let metallibExecutable = try URL(fileURLWithPath: commandOutput(
+        ["xcrun", "-sdk", "macosx", "-f", "metallib"],
+        currentDirectory: paths.repository,
+        environment: environment
+    )).standardizedFileURL
+    guard FileManager.default.fileExists(atPath: metalExecutable.path),
+          FileManager.default.fileExists(atPath: metallibExecutable.path)
+    else {
+        throw AcceptanceFailure.unknown("resolved Metal compiler executable is missing")
+    }
+
+    let checkout = paths.package.appendingPathComponent(".build/checkouts/mlx-swift")
+    let sourceRoot = checkout.appendingPathComponent("Source/Cmlx/mlx-generated/metal")
+    let sources = try regularFiles(in: sourceRoot, extensions: ["metal"]).sorted { $0.path < $1.path }
+    guard !sources.isEmpty else {
+        throw AcceptanceFailure.unknown("current mlx-swift checkout has no generated Metal sources")
+    }
+
+    let checkoutRevision = try commandOutput(["git", "rev-parse", "HEAD"], currentDirectory: checkout)
+
+    let temporary = FileManager.default
+        .temporaryDirectory
+        .appendingPathComponent("swama-acceptance-metal-\(UUID().uuidString)")
+    let airDirectory = temporary.appendingPathComponent("air")
+    try FileManager.default.createDirectory(at: airDirectory, withIntermediateDirectories: true)
+    do {
+        var commands: [[String]] = []
+        var airFiles: [URL] = []
+        var sourceManifest: [JSONObject] = []
+        for (index, source) in sources.enumerated() {
+            let air = airDirectory.appendingPathComponent(String(
+                format: "%02d-%@.air",
+                index,
+                source.deletingPathExtension().lastPathComponent
+            ))
+            let command = [
+                "xcrun", "-sdk", "macosx", "metal", "-c",
+                "-target", "air64-apple-macos14.0",
+                "-fmetal-math-mode=fast",
+                "-fmetal-math-fp32-functions=fast",
+                source.path,
+                "-o", air.path
+            ]
+            let result = try runCommand(
+                command,
+                currentDirectory: paths.repository,
+                environment: environment,
+                timeout: 300,
+                sampleMemory: false
+            )
+            guard result.returnCode == 0, FileManager.default.fileExists(atPath: air.path) else {
+                throw AcceptanceFailure
+                    .unknown("Metal source compilation failed for \(source.lastPathComponent): \(result.stderr)")
+            }
+
+            commands.append(command)
+            airFiles.append(air)
+            try sourceManifest.append([
+                "path": source.path.replacingOccurrences(of: checkout.path + "/", with: ""),
+                "sha256": sha256File(source),
+                "air_sha256": sha256File(air)
+            ])
+        }
+
+        let output = temporary.appendingPathComponent("default.metallib")
+        let linkCommand = ["xcrun", "-sdk", "macosx", "metallib"]
+            + airFiles.map(\.path)
+            + ["-o", output.path]
+        let linkResult = try runCommand(
+            linkCommand,
+            currentDirectory: paths.repository,
+            environment: environment,
+            timeout: 300,
+            sampleMemory: false
+        )
+        guard linkResult.returnCode == 0, FileManager.default.fileExists(atPath: output.path) else {
+            throw AcceptanceFailure.unknown("metallib link failed: \(linkResult.stderr)")
+        }
+
+        let normalizedMetalVersion = metalVersion.split(separator: "\n")
+            .filter { !$0.hasPrefix("InstalledDir:") }
+            .joined(separator: "\n")
+        return try .init(
+            library: output,
+            provenance: [
+                "developer_dir": metalDeveloperDirectory.path,
+                "metal_version": normalizedMetalVersion,
+                "metallib_version": metallibVersion,
+                "metal_executable": metalExecutable.path,
+                "metal_executable_sha256": sha256File(metalExecutable),
+                "metallib_executable": metallibExecutable.path,
+                "metallib_executable_sha256": sha256File(metallibExecutable),
+                "mlx_swift_revision": checkoutRevision,
+                "sources": sourceManifest,
+                "compile_commands": commands,
+                "link_command": linkCommand,
+                "sha256": sha256File(output)
+            ],
+            temporaryDirectory: temporary
+        )
+    }
+    catch {
+        try? FileManager.default.removeItem(at: temporary)
+        throw error
+    }
+}
+
+func installMetallib(_ source: URL, nextTo binary: URL) throws -> JSONObject {
+    let destination = binary.deletingLastPathComponent().appendingPathComponent("mlx.metallib")
+    if FileManager.default.fileExists(atPath: destination.path) {
+        try FileManager.default.removeItem(at: destination)
+    }
+    try FileManager.default.copyItem(at: source, to: destination)
+    return try [
+        "path": destination.path,
+        "sha256": sha256File(destination),
+        "copied": "true",
+        "source": source.path
+    ]
+}

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/ProcessRunner.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/ProcessRunner.swift
@@ -1,0 +1,158 @@
+import Darwin
+import Foundation
+
+// MARK: - CommandResult
+
+struct CommandResult: Sendable {
+    let command: [String]
+    let returnCode: Int32
+    let stdout: String
+    let stderr: String
+    let durationMilliseconds: Double
+    let peakResidentBytes: UInt64
+}
+
+func developerEnvironment(_ developerDirectory: URL) throws -> [String: String] {
+    guard FileManager.default.fileExists(
+        atPath: developerDirectory.appendingPathComponent("usr/bin/xcodebuild").path
+    )
+    else {
+        throw AcceptanceFailure.unknown("missing Xcode developer directory: \(developerDirectory.path)")
+    }
+
+    var environment = ProcessInfo.processInfo.environment
+    environment["DEVELOPER_DIR"] = developerDirectory.path
+    return environment
+}
+
+func runCommand(
+    _ command: [String],
+    currentDirectory: URL,
+    environment: [String: String]? = nil,
+    timeout: TimeInterval = 300,
+    sampleMemory: Bool = true
+) throws -> CommandResult {
+    guard let executable = command.first else {
+        throw AcceptanceFailure.unknown("empty command")
+    }
+
+    let temporary = FileManager.default
+        .temporaryDirectory
+        .appendingPathComponent("swama-acceptance-command-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: temporary, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: temporary) }
+
+    let stdoutURL = temporary.appendingPathComponent("stdout")
+    let stderrURL = temporary.appendingPathComponent("stderr")
+    FileManager.default.createFile(atPath: stdoutURL.path, contents: nil)
+    FileManager.default.createFile(atPath: stderrURL.path, contents: nil)
+    let stdoutHandle = try FileHandle(forWritingTo: stdoutURL)
+    let stderrHandle = try FileHandle(forWritingTo: stderrURL)
+    defer {
+        try? stdoutHandle.close()
+        try? stderrHandle.close()
+    }
+
+    let process = Process()
+    if executable.contains("/") {
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = Array(command.dropFirst())
+    }
+    else {
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = command
+    }
+    process.currentDirectoryURL = currentDirectory
+    process.environment = environment
+    process.standardOutput = stdoutHandle
+    process.standardError = stderrHandle
+
+    let start = ContinuousClock.now
+    do {
+        try process.run()
+    }
+    catch {
+        throw AcceptanceFailure.unknown("cannot launch \(command.joined(separator: " ")): \(error)")
+    }
+
+    let deadline = Date().addingTimeInterval(timeout)
+    var peak: UInt64 = 0
+    while process.isRunning {
+        if sampleMemory {
+            peak = max(peak, residentBytes(pid: process.processIdentifier))
+        }
+        if Date() >= deadline {
+            kill(process.processIdentifier, SIGKILL)
+            process.waitUntilExit()
+            throw AcceptanceFailure.failed("timeout after \(timeout)s: \(command.joined(separator: " "))")
+        }
+        Thread.sleep(forTimeInterval: 0.02)
+    }
+    process.waitUntilExit()
+    peak = max(peak, residentBytes(pid: process.processIdentifier))
+
+    try stdoutHandle.synchronize()
+    try stderrHandle.synchronize()
+    let stdout = try String(decoding: Data(contentsOf: stdoutURL), as: UTF8.self)
+    let stderr = try String(decoding: Data(contentsOf: stderrURL), as: UTF8.self)
+    let duration = start.duration(to: .now)
+    let milliseconds = Double(duration.components.seconds) * 1000
+        + Double(duration.components.attoseconds) / 1_000_000_000_000_000
+    let returnCode = process.terminationReason == .uncaughtSignal
+        ? -process.terminationStatus
+        : process.terminationStatus
+
+    return .init(
+        command: command,
+        returnCode: returnCode,
+        stdout: stdout,
+        stderr: stderr,
+        durationMilliseconds: milliseconds,
+        peakResidentBytes: peak
+    )
+}
+
+func commandOutput(
+    _ command: [String],
+    currentDirectory: URL,
+    environment: [String: String]? = nil
+) throws -> String {
+    let result = try runCommand(
+        command,
+        currentDirectory: currentDirectory,
+        environment: environment,
+        sampleMemory: false
+    )
+    guard result.returnCode == 0 else {
+        throw AcceptanceFailure.unknown(
+            "command failed (\(result.returnCode)): \(command.joined(separator: " "))\n\(result.stderr)"
+        )
+    }
+
+    return result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+}
+
+func residentBytes(pid: pid_t) -> UInt64 {
+    let process = Process()
+    let pipe = Pipe()
+    process.executableURL = URL(fileURLWithPath: "/bin/ps")
+    process.arguments = ["-o", "rss=", "-p", String(pid)]
+    process.standardOutput = pipe
+    process.standardError = FileHandle.nullDevice
+    do {
+        try process.run()
+        process.waitUntilExit()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        guard process.terminationStatus == 0,
+              let text = String(data: data, encoding: .utf8),
+              let kibibytes = UInt64(text.trimmingCharacters(in: .whitespacesAndNewlines))
+        else {
+            return 0
+        }
+
+        return kibibytes * 1024
+    }
+    catch {
+        return 0
+    }
+}

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Provenance.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Provenance.swift
@@ -1,0 +1,137 @@
+import Foundation
+
+// MARK: - SystemTool
+
+enum SystemTool {
+    static let systemProfiler = "/usr/sbin/system_profiler"
+    static let uname = "/usr/bin/uname"
+    static let swVers = "/usr/bin/sw_vers"
+}
+
+func captureProvenance(
+    developerDirectory: URL,
+    models: [String],
+    paths: WorkspacePaths
+) throws -> JSONObject {
+    let environment = try developerEnvironment(developerDirectory)
+    let hardwareText = try commandOutput(
+        [SystemTool.systemProfiler, "SPHardwareDataType"],
+        currentDirectory: paths.repository
+    )
+    var hardware: JSONObject = [:]
+    for key in ["Model Identifier", "Chip", "Total Number of Cores", "Memory"] {
+        hardware[key] = value(after: "\(key):", in: hardwareText) ?? "UNKNOWN"
+    }
+    let sourceDiff = try commandOutput(
+        ["git", "diff", "--name-only", "origin/main", "--", "swama/Sources"],
+        currentDirectory: paths.repository
+    )
+
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime]
+    return try [
+        "captured_at_utc": formatter.string(from: Date()),
+        "git": [
+            "head": commandOutput(["git", "rev-parse", "HEAD"], currentDirectory: paths.repository),
+            "tree": commandOutput(["git", "rev-parse", "HEAD^{tree}"], currentDirectory: paths.repository),
+            "origin_main": commandOutput(["git", "rev-parse", "origin/main"], currentDirectory: paths.repository),
+            "production_source_diff": sourceDiff.split(separator: "\n").map(String.init)
+        ],
+        "platform": [
+            "system": "Darwin",
+            "machine": commandOutput([SystemTool.uname, "-m"], currentDirectory: paths.repository),
+            "macos": commandOutput([SystemTool.swVers, "-productVersion"], currentDirectory: paths.repository),
+            "hardware": hardware
+        ],
+        "toolchain": [
+            "developer_dir": developerDirectory.path,
+            "swift": commandOutput(
+                ["xcrun", "swift", "--version"],
+                currentDirectory: paths.repository,
+                environment: environment
+            ),
+            "xcode": commandOutput(
+                ["xcodebuild", "-version"],
+                currentDirectory: paths.repository,
+                environment: environment
+            ),
+            "package_resolved_sha256": sha256File(paths.package.appendingPathComponent("Package.resolved"))
+        ],
+        "models": models.map(modelIdentity)
+    ]
+}
+
+func currentInstrumentIdentity(paths: WorkspacePaths) throws -> JSONObject {
+    let executable = URL(fileURLWithPath: CommandLine.arguments[0]).standardizedFileURL
+    let harnessSources = try regularFiles(
+        in: paths.harness.appendingPathComponent("Sources"),
+        extensions: ["swift"]
+    ) + [paths.harness.appendingPathComponent("Package.swift")]
+    let harnessTests = try regularFiles(
+        in: paths.harness.appendingPathComponent("Tests"),
+        extensions: ["swift"]
+    )
+    let probeSources = try regularFiles(
+        in: paths.fixture.appendingPathComponent("Sources"),
+        extensions: ["swift"]
+    )
+    return try [
+        "harness_binary_sha256": sha256File(executable),
+        "harness_sources_sha256": sha256Tree(harnessSources, relativeTo: paths.repository),
+        "harness_tests_sha256": sha256Tree(harnessTests, relativeTo: paths.repository),
+        "core_probe_sha256": sha256Tree(probeSources, relativeTo: paths.repository),
+        "fixture_manifest_sha256": sha256File(paths.fixture.appendingPathComponent("Package.swift")),
+        "package_manifest_sha256": sha256File(paths.package.appendingPathComponent("Package.swift"))
+    ]
+}
+
+private func modelIdentity(_ modelID: String) throws -> JSONObject {
+    let directory = FileManager.default
+        .homeDirectoryForCurrentUser
+        .appendingPathComponent(".swama/models")
+        .appendingPathComponent(modelID)
+    let metadataURL = directory.appendingPathComponent(".swama-meta.json")
+    guard FileManager.default.fileExists(atPath: metadataURL.path) else {
+        throw AcceptanceFailure.unknown("local Swama model is absent or unowned: \(modelID)")
+    }
+    guard let enumerator = FileManager.default.enumerator(
+        at: directory,
+        includingPropertiesForKeys: [.isRegularFileKey, .fileSizeKey]
+    )
+    else {
+        throw AcceptanceFailure.unknown("cannot enumerate model directory: \(directory.path)")
+    }
+
+    let files = try enumerator.compactMap { item -> JSONObject? in
+        guard let url = item as? URL, url.lastPathComponent != ".DS_Store" else { return nil }
+
+        let values = try url.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+        guard values.isRegularFile == true else {
+            return nil
+        }
+
+        return try [
+            "path": url.path.replacingOccurrences(of: directory.path + "/", with: ""),
+            "bytes": values.fileSize ?? 0,
+            "sha256": sha256File(url)
+        ]
+    }
+    .sorted {
+        ($0["path"] as? String ?? "") < ($1["path"] as? String ?? "")
+    }
+
+    return try [
+        "id": modelID,
+        "metadata": loadJSONObject(metadataURL),
+        "directory": directory.path,
+        "files": files
+    ]
+}
+
+private func value(after prefix: String, in text: String) -> String? {
+    text.split(separator: "\n")
+        .map { $0.trimmingCharacters(in: .whitespaces) }
+        .first { $0.hasPrefix(prefix) }?
+        .dropFirst(prefix.count)
+        .trimmingCharacters(in: .whitespaces)
+}

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Provenance.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Provenance.swift
@@ -8,6 +8,19 @@ enum SystemTool {
     static let swVers = "/usr/bin/sw_vers"
 }
 
+func requireCleanWorktree(paths: WorkspacePaths) throws {
+    let status = try commandOutput(
+        ["git", "status", "--porcelain=v1", "--untracked-files=all"],
+        currentDirectory: paths.repository
+    )
+    guard status.isEmpty else {
+        let entries = status.split(separator: "\n").prefix(20).joined(separator: "\n")
+        throw AcceptanceFailure.unknown(
+            "working tree is dirty; refusing to bind a report to HEAD:\n\(entries)"
+        )
+    }
+}
+
 func captureProvenance(
     developerDirectory: URL,
     models: [String],

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Support.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Support.swift
@@ -1,0 +1,277 @@
+import CryptoKit
+import Foundation
+
+typealias JSONObject = [String: Any]
+
+// MARK: - AcceptanceKind
+
+enum AcceptanceKind {
+    case failed
+    case unknown
+}
+
+// MARK: - AcceptanceFailure
+
+struct AcceptanceFailure: Error, CustomStringConvertible {
+    let kind: AcceptanceKind
+    let message: String
+
+    var description: String { message }
+
+    static func failed(_ message: String) -> Self {
+        .init(kind: .failed, message: message)
+    }
+
+    static func unknown(_ message: String) -> Self {
+        .init(kind: .unknown, message: message)
+    }
+}
+
+// MARK: - WorkspacePaths
+
+struct WorkspacePaths: Sendable {
+    let repository: URL
+
+    var package: URL { repository.appendingPathComponent("swama") }
+    var harness: URL { repository.appendingPathComponent("Tools/SwamaAcceptance") }
+    var fixture: URL { repository.appendingPathComponent("Tests/AcceptanceFixture") }
+    var contract: URL { harness.appendingPathComponent("contract.json") }
+
+    static func discover(explicit: String?) throws -> Self {
+        if let explicit {
+            return try validate(URL(fileURLWithPath: explicit).standardizedFileURL.resolvingSymlinksInPath())
+        }
+
+        var cursor = URL(fileURLWithPath: FileManager.default.currentDirectoryPath).standardizedFileURL
+        while cursor.path != "/" {
+            if let result = try? validate(cursor) {
+                return result
+            }
+            cursor.deleteLastPathComponent()
+        }
+        throw AcceptanceFailure.unknown("cannot locate repository root; pass --repo-root")
+    }
+
+    private static func validate(_ root: URL) throws -> Self {
+        let required = [
+            root.appendingPathComponent("swama/Package.swift"),
+            root.appendingPathComponent("Tools/SwamaAcceptance/Package.swift"),
+            root.appendingPathComponent("Tests/AcceptanceFixture/Package.swift")
+        ]
+        guard required.allSatisfy({ FileManager.default.fileExists(atPath: $0.path) }) else {
+            throw AcceptanceFailure.unknown("not a Swama acceptance repository root: \(root.path)")
+        }
+
+        return .init(repository: root)
+    }
+}
+
+func loadJSONObject(_ url: URL) throws -> JSONObject {
+    do {
+        let data = try Data(contentsOf: url)
+        guard let object = try JSONSerialization.jsonObject(with: data) as? JSONObject else {
+            throw AcceptanceFailure.unknown("JSON root is not an object: \(url.path)")
+        }
+
+        return object
+    }
+    catch let error as AcceptanceFailure {
+        throw error
+    }
+    catch {
+        throw AcceptanceFailure.unknown("cannot read JSON \(url.path): \(error)")
+    }
+}
+
+func compactJSONData(_ object: Any) throws -> Data {
+    guard JSONSerialization.isValidJSONObject(object) else {
+        throw AcceptanceFailure.unknown("report contains a non-JSON value")
+    }
+
+    do {
+        return try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys, .withoutEscapingSlashes])
+    }
+    catch {
+        throw AcceptanceFailure.unknown("cannot serialize JSON: \(error)")
+    }
+}
+
+func prettyJSONData(_ object: Any) throws -> Data {
+    guard JSONSerialization.isValidJSONObject(object) else {
+        throw AcceptanceFailure.unknown("report contains a non-JSON value")
+    }
+
+    do {
+        var data = try JSONSerialization.data(
+            withJSONObject: object,
+            options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        )
+        data.append(0x0A)
+        return data
+    }
+    catch {
+        throw AcceptanceFailure.unknown("cannot serialize JSON: \(error)")
+    }
+}
+
+func sealReport(_ report: inout JSONObject) throws {
+    report.removeValue(forKey: "report_sha256")
+    report["report_sha256"] = try sha256(compactJSONData(report))
+}
+
+func verifyReport(_ report: JSONObject) throws {
+    guard let expected = report["report_sha256"] as? String else {
+        throw AcceptanceFailure.unknown("report self-hash is missing")
+    }
+
+    var payload = report
+    payload.removeValue(forKey: "report_sha256")
+    let actual = try sha256(compactJSONData(payload))
+    guard expected == actual else {
+        throw AcceptanceFailure.unknown("report self-hash is invalid")
+    }
+}
+
+func sha256(_ data: Data) -> String {
+    SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+}
+
+func sha256File(_ url: URL) throws -> String {
+    guard let input = InputStream(url: url) else {
+        throw AcceptanceFailure.unknown("cannot open file for hashing: \(url.path)")
+    }
+
+    input.open()
+    defer { input.close() }
+
+    var hasher = SHA256()
+    let capacity = 8 * 1024 * 1024
+    let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: capacity)
+    defer { buffer.deallocate() }
+
+    while input.hasBytesAvailable {
+        let count = input.read(buffer, maxLength: capacity)
+        if count < 0 {
+            throw AcceptanceFailure.unknown("failed while hashing file: \(url.path)")
+        }
+        if count == 0 {
+            break
+        }
+        hasher.update(data: Data(bytesNoCopy: buffer, count: count, deallocator: .none))
+    }
+    return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+}
+
+func sha256Tree(_ urls: [URL], relativeTo root: URL) throws -> String {
+    var hasher = SHA256()
+    for url in urls.sorted(by: { $0.path < $1.path }) {
+        let relative = url.path.replacingOccurrences(of: root.path + "/", with: "")
+        hasher.update(data: Data(relative.utf8))
+        hasher.update(data: Data([0]))
+        let data = try Data(contentsOf: url)
+        hasher.update(data: data)
+        hasher.update(data: Data([0]))
+    }
+    return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+}
+
+func regularFiles(in root: URL, extensions: Set<String>? = nil) throws -> [URL] {
+    guard let enumerator = FileManager.default.enumerator(
+        at: root,
+        includingPropertiesForKeys: [.isRegularFileKey],
+        options: [.skipsHiddenFiles]
+    )
+    else {
+        throw AcceptanceFailure.unknown("cannot enumerate directory: \(root.path)")
+    }
+
+    return try enumerator.compactMap { item in
+        guard let url = item as? URL else {
+            return nil
+        }
+
+        let values = try url.resourceValues(forKeys: [.isRegularFileKey])
+        guard values.isRegularFile == true else {
+            return nil
+        }
+
+        if let extensions, !extensions.contains(url.pathExtension) {
+            return nil
+        }
+        return url
+    }
+}
+
+func writeReport(_ report: JSONObject, to output: URL) throws {
+    var sealed = report
+    try sealReport(&sealed)
+    try FileManager.default.createDirectory(
+        at: output.deletingLastPathComponent(),
+        withIntermediateDirectories: true
+    )
+    try prettyJSONData(sealed).write(to: output, options: .atomic)
+}
+
+func lastJSONValue(_ output: String) throws -> Any {
+    for line in output.split(separator: "\n").reversed() {
+        let candidate = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard candidate.first == "[" || candidate.first == "{" else { continue }
+
+        if let data = candidate.data(using: .utf8),
+           let value = try? JSONSerialization.jsonObject(with: data)
+        {
+            return value
+        }
+    }
+    throw AcceptanceFailure.unknown("process produced no machine-readable JSON record")
+}
+
+extension [String: Any] {
+    func object(_ key: String) throws -> JSONObject {
+        guard let value = self[key] as? JSONObject else {
+            throw AcceptanceFailure.unknown("missing JSON object: \(key)")
+        }
+
+        return value
+    }
+
+    func array(_ key: String) throws -> [Any] {
+        guard let value = self[key] as? [Any] else {
+            throw AcceptanceFailure.unknown("missing JSON array: \(key)")
+        }
+
+        return value
+    }
+
+    func string(_ key: String) throws -> String {
+        guard let value = self[key] as? String else {
+            throw AcceptanceFailure.unknown("missing JSON string: \(key)")
+        }
+
+        return value
+    }
+
+    func integer(_ key: String) throws -> Int {
+        guard let value = self[key] as? NSNumber else {
+            throw AcceptanceFailure.unknown("missing JSON integer: \(key)")
+        }
+
+        return value.intValue
+    }
+
+    func double(_ key: String) throws -> Double {
+        guard let value = self[key] as? NSNumber else {
+            throw AcceptanceFailure.unknown("missing JSON number: \(key)")
+        }
+
+        return value.doubleValue
+    }
+
+    func boolean(_ key: String) throws -> Bool {
+        guard let value = self[key] as? Bool else {
+            throw AcceptanceFailure.unknown("missing JSON boolean: \(key)")
+        }
+
+        return value
+    }
+}

--- a/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
+++ b/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
@@ -1,0 +1,271 @@
+import Foundation
+@testable import SwamaAcceptanceKit
+import Testing
+
+@Suite("Swama acceptance harness")
+struct AcceptanceTests {
+    @Test func reportSealRejectsEditedPayload() throws {
+        var report: JSONObject = ["passed": true, "metric": 10]
+        try sealReport(&report)
+        try verifyReport(report)
+
+        report["metric"] = 100
+        #expect(throws: AcceptanceFailure.self) {
+            try verifyReport(report)
+        }
+    }
+
+    @Test func compareDetectsARealPerformanceRegression() throws {
+        let paths = try WorkspacePaths.discover(explicit: repositoryRoot.path)
+        let contract = try AcceptanceContract.load(from: paths.contract)
+        var baseline = try syntheticReport(paths: paths)
+        var candidate = baseline
+        var benchmarks = try candidate.object("benchmarks")
+        var model = try benchmarks.object("model")
+        var core = try model.object("core")
+        var summary = try core.object("summary")
+        summary["tokens_per_second_median"] = 1.0
+        core["summary"] = summary
+        model["core"] = core
+        benchmarks["model"] = model
+        candidate["benchmarks"] = benchmarks
+        try sealReport(&baseline)
+        try sealReport(&candidate)
+
+        let result = try compareReports(
+            baseline: baseline,
+            candidate: candidate,
+            contract: contract,
+            contractURL: paths.contract,
+            paths: paths
+        )
+        #expect(result["passed"] as? Bool == false)
+        #expect((result["findings"] as? [JSONObject])?
+            .contains { $0["metric"] as? String == "tokens_per_second" } == true
+        )
+    }
+
+    @Test func compareRejectsPostHocInstrumentIdentityChange() throws {
+        let paths = try WorkspacePaths.discover(explicit: repositoryRoot.path)
+        let contract = try AcceptanceContract.load(from: paths.contract)
+        var baseline = try syntheticReport(paths: paths)
+        var candidate = baseline
+        var instrument = try baseline.object("instrument")
+        instrument["harness_sources_sha256"] = String(repeating: "0", count: 64)
+        baseline["instrument"] = instrument
+        try sealReport(&baseline)
+        try sealReport(&candidate)
+
+        #expect(throws: AcceptanceFailure.self) {
+            _ = try compareReports(
+                baseline: baseline,
+                candidate: candidate,
+                contract: contract,
+                contractURL: paths.contract,
+                paths: paths
+            )
+        }
+    }
+
+    @Test func compareRejectsPostHocContractChange() throws {
+        let paths = try WorkspacePaths.discover(explicit: repositoryRoot.path)
+        let contract = try AcceptanceContract.load(from: paths.contract)
+        var baseline = try syntheticReport(paths: paths)
+        var candidate = baseline
+        try sealReport(&baseline)
+        try sealReport(&candidate)
+        let alteredContract = FileManager.default
+            .temporaryDirectory
+            .appendingPathComponent("swama-altered-contract-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: alteredContract) }
+        var bytes = try Data(contentsOf: paths.contract)
+        bytes.append(0x0A)
+        try bytes.write(to: alteredContract)
+
+        #expect(throws: AcceptanceFailure.self) {
+            _ = try compareReports(
+                baseline: baseline,
+                candidate: candidate,
+                contract: contract,
+                contractURL: alteredContract,
+                paths: paths
+            )
+        }
+    }
+
+    @Test func compareRejectsDifferentModelBytes() throws {
+        let paths = try WorkspacePaths.discover(explicit: repositoryRoot.path)
+        let contract = try AcceptanceContract.load(from: paths.contract)
+        var baseline = try syntheticReport(paths: paths)
+        var candidate = baseline
+        var provenance = try candidate.object("provenance")
+        provenance["models"] = [["id": "test", "sha256": "different"]]
+        candidate["provenance"] = provenance
+        try sealReport(&baseline)
+        try sealReport(&candidate)
+
+        #expect(throws: AcceptanceFailure.self) {
+            _ = try compareReports(
+                baseline: baseline,
+                candidate: candidate,
+                contract: contract,
+                contractURL: paths.contract,
+                paths: paths
+            )
+        }
+    }
+
+    @Test func truncatedReportIsUnknown() throws {
+        let truncated = FileManager.default
+            .temporaryDirectory
+            .appendingPathComponent("swama-truncated-report-\(UUID().uuidString).json")
+        defer { try? FileManager.default.removeItem(at: truncated) }
+        try Data(#"{"passed":true"#.utf8).write(to: truncated)
+        #expect(throws: AcceptanceFailure.self) {
+            _ = try loadJSONObject(truncated)
+        }
+    }
+
+    @Test func cancellationAndDisconnectGatesCarryWeight() throws {
+        let contract = ReliabilityContract(
+            cancelMaxTokens: 512,
+            cancelObservedTokenCeiling: 8,
+            cancellationLatencyMillisecondsMax: 1000,
+            concurrentRequests: 2,
+            concurrentMaxTokens: 48,
+            repeatRounds: 12,
+            repeatMaxTokens: 32,
+            switchCycles: 2,
+            switchMaxTokens: 16,
+            releaseSettleMilliseconds: 1000,
+            releaseRSSRatioMax: 1.25,
+            releaseRSSAbsoluteSlackBytes: 268_435_456,
+            disconnectRecoveryTTFTMillisecondsMax: 1000,
+            timeoutSeconds: 300
+        )
+        var report = reliabilityReport()
+        var gates = try reliabilityGateStatus(report, contract: contract)
+        #expect(!gates.values.contains(false))
+
+        var cancel = try report.object("cancel_then_recover")
+        cancel["observedTokensBeforeCancel"] = 99
+        report["cancel_then_recover"] = cancel
+        gates = try reliabilityGateStatus(report, contract: contract)
+        #expect(gates["cancel_then_recover"] == false)
+
+        report = reliabilityReport()
+        var disconnect = try report.object("http_disconnect_then_recover")
+        var followup = try disconnect.object("followup")
+        followup["ttft_ms"] = 5000
+        disconnect["followup"] = followup
+        report["http_disconnect_then_recover"] = disconnect
+        gates = try reliabilityGateStatus(report, contract: contract)
+        #expect(gates["http_disconnect_then_recover"] == false)
+    }
+
+    @Test func architectureGateRejectsInternalShellReverseImport() throws {
+        let temporary = FileManager.default
+            .temporaryDirectory
+            .appendingPathComponent("swama-architecture-test-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: temporary) }
+        for directory in [
+            "swama/Sources/SwamaKit",
+            "Tools/SwamaAcceptance",
+            "Tests/AcceptanceFixture"
+        ] {
+            try FileManager.default.createDirectory(
+                at: temporary.appendingPathComponent(directory),
+                withIntermediateDirectories: true
+            )
+        }
+        for file in [
+            "swama/Package.swift",
+            "Tools/SwamaAcceptance/Package.swift",
+            "Tests/AcceptanceFixture/Package.swift"
+        ] {
+            try Data().write(to: temporary.appendingPathComponent(file))
+        }
+        try Data("import SwamaServer\n".utf8).write(
+            to: temporary.appendingPathComponent("swama/Sources/SwamaKit/Bad.swift")
+        )
+
+        let paths = try WorkspacePaths.discover(explicit: temporary.path)
+        let contract = ArchitectureContract(
+            legacyForbiddenImportAllowlist: [],
+            legacyPublicMLXLeakAllowlist: [],
+            goalCoreTarget: "SwamaCore",
+            goalForbiddenImports: ["SwamaServer", "SwamaAppSupport"]
+        )
+        let report = try architectureReport(contract: contract, stage: .legacyRatchet, paths: paths)
+        #expect(report["passed"] as? Bool == false)
+        #expect((report["new_forbidden_imports"] as? [String]) == ["swama/Sources/SwamaKit/Bad.swift:SwamaServer"])
+    }
+
+    @Test func medianUsesAllMeasuredSamples() {
+        #expect(median([511, 568, 580, 574, 572]) == 572)
+    }
+
+    @Test func provenanceUsesResolvableAbsoluteSystemTools() {
+        for tool in [SystemTool.systemProfiler, SystemTool.uname, SystemTool.swVers] {
+            #expect(tool.hasPrefix("/"))
+            #expect(FileManager.default.isExecutableFile(atPath: tool))
+        }
+    }
+
+    private var repositoryRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+    }
+
+    private func syntheticReport(paths: WorkspacePaths) throws -> JSONObject {
+        let instrument = try currentInstrumentIdentity(paths: paths)
+        let summary: JSONObject = [
+            "ttft_median_ms": 10.0,
+            "tokens_per_second_median": 100.0,
+            "peak_resident_bytes": 1000
+        ]
+        let route: JSONObject = ["summary": summary]
+        return try [
+            "contract_sha256": sha256File(paths.contract),
+            "instrument": instrument,
+            "provenance": [
+                "platform": ["machine": "test"],
+                "toolchain": ["swift": "test"],
+                "models": [["id": "test"]]
+            ],
+            "build": [
+                "metal_build": [
+                    "metal_version": "test",
+                    "metallib_version": "test",
+                    "metal_executable_sha256": "test",
+                    "metallib_executable_sha256": "test",
+                    "mlx_swift_revision": "test",
+                    "sha256": "test",
+                    "sources": [["path": "a.metal", "sha256": "test"]]
+                ]
+            ],
+            "benchmarks": ["model": ["core": route, "http": route]],
+            "passed": true
+        ]
+    }
+
+    private func reliabilityReport() -> JSONObject {
+        [
+            "cancel_then_recover": [
+                "observedTokensBeforeCancel": 2,
+                "cancellationMilliseconds": 10.0,
+                "followupOutput": "ok"
+            ],
+            "same_model_concurrency": ["outputs": ["a", "b"]],
+            "repeat_generation": ["outputs_nonempty": true],
+            "model_switch_and_release": ["release_gate_passed": true],
+            "http_disconnect_then_recover": [
+                "followup": ["output": "ok", "ttft_ms": 10.0]
+            ]
+        ]
+    }
+}

--- a/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
+++ b/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
@@ -43,6 +43,73 @@ struct AcceptanceTests {
         #expect((result["findings"] as? [JSONObject])?
             .contains { $0["metric"] as? String == "tokens_per_second" } == true
         )
+        let coverage = try result.object("comparison_coverage")
+        #expect(try coverage.integer("benchmark_models") == 1)
+        #expect(try coverage.integer("benchmark_routes") == 2)
+    }
+
+    @Test func compareRejectsAnEmptyBaselineBenchmarkSet() throws {
+        let paths = try WorkspacePaths.discover(explicit: repositoryRoot.path)
+        let contract = try AcceptanceContract.load(from: paths.contract)
+        var baseline = try syntheticReport(paths: paths)
+        var candidate = baseline
+        baseline["benchmarks"] = JSONObject()
+        candidate["benchmarks"] = JSONObject()
+        try sealReport(&baseline)
+        try sealReport(&candidate)
+
+        do {
+            _ = try compareReports(
+                baseline: baseline,
+                candidate: candidate,
+                contract: contract,
+                contractURL: paths.contract,
+                paths: paths
+            )
+            Issue.record("an empty baseline benchmark set must not compare as passing")
+        }
+        catch let error as AcceptanceFailure {
+            if case .failed = error.kind {
+                Issue.record("an empty benchmark set is invalid evidence, not a product failure")
+            }
+            #expect(error.message == "baseline contains no benchmark models")
+        }
+    }
+
+    @Test func compareRejectsNonStringMetalIdentityValues() throws {
+        let paths = try WorkspacePaths.discover(explicit: repositoryRoot.path)
+        let contract = try AcceptanceContract.load(from: paths.contract)
+        var baseline = try syntheticReport(paths: paths)
+        var candidate = baseline
+        var baselineBuild = try baseline.object("build")
+        var baselineMetal = try baselineBuild.object("metal_build")
+        baselineMetal["metal_version"] = 1
+        baselineBuild["metal_build"] = baselineMetal
+        baseline["build"] = baselineBuild
+        var candidateBuild = try candidate.object("build")
+        var candidateMetal = try candidateBuild.object("metal_build")
+        candidateMetal["metal_version"] = 1
+        candidateBuild["metal_build"] = candidateMetal
+        candidate["build"] = candidateBuild
+        try sealReport(&baseline)
+        try sealReport(&candidate)
+
+        do {
+            _ = try compareReports(
+                baseline: baseline,
+                candidate: candidate,
+                contract: contract,
+                contractURL: paths.contract,
+                paths: paths
+            )
+            Issue.record("non-string metal identity values must not compare as equal")
+        }
+        catch let error as AcceptanceFailure {
+            if case .failed = error.kind {
+                Issue.record("metal identity schema drift is invalid evidence, not a product failure")
+            }
+            #expect(error.message == "missing JSON string: metal_version")
+        }
     }
 
     @Test func compareRejectsPostHocInstrumentIdentityChange() throws {

--- a/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
+++ b/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
@@ -212,6 +212,47 @@ struct AcceptanceTests {
         }
     }
 
+    @Test func cleanWorktreeCanBeBoundToHead() throws {
+        let repository = try temporaryRepository()
+        defer { try? FileManager.default.removeItem(at: repository) }
+        let paths = try WorkspacePaths.discover(explicit: repository.path)
+        try requireCleanWorktree(paths: paths)
+    }
+
+    @Test func trackedDirtyWorktreeIsUnknown() throws {
+        let repository = try temporaryRepository()
+        defer { try? FileManager.default.removeItem(at: repository) }
+        try Data("changed\n".utf8).write(to: repository.appendingPathComponent("swama/Package.swift"))
+        let paths = try WorkspacePaths.discover(explicit: repository.path)
+        #expect(throws: AcceptanceFailure.self) {
+            try requireCleanWorktree(paths: paths)
+        }
+    }
+
+    @Test func untrackedDirtyWorktreeIsUnknown() throws {
+        let repository = try temporaryRepository()
+        defer { try? FileManager.default.removeItem(at: repository) }
+        try Data("untracked\n".utf8).write(to: repository.appendingPathComponent("untracked.txt"))
+        let paths = try WorkspacePaths.discover(explicit: repository.path)
+        #expect(throws: AcceptanceFailure.self) {
+            try requireCleanWorktree(paths: paths)
+        }
+    }
+
+    @Test func buildFailureSummaryKeepsErrorLines() {
+        let result = CommandResult(
+            command: ["swift", "build"],
+            returnCode: 1,
+            stdout: String(repeating: "warning: setup\n", count: 500) + "error: root cause\n",
+            stderr: "warning: final warning\n",
+            durationMilliseconds: 1,
+            peakResidentBytes: 0
+        )
+        let summary = commandFailureSummary(result, maximumCharacters: 80)
+        #expect(summary.contains("error: root cause"))
+        #expect(summary.contains("output tail:"))
+    }
+
     private var repositoryRoot: URL {
         URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
@@ -267,5 +308,46 @@ struct AcceptanceTests {
                 "followup": ["output": "ok", "ttft_ms": 10.0]
             ]
         ]
+    }
+
+    private func temporaryRepository() throws -> URL {
+        let root = FileManager.default
+            .temporaryDirectory
+            .appendingPathComponent("swama-clean-tree-test-\(UUID().uuidString)")
+        for directory in [
+            "swama",
+            "Tools/SwamaAcceptance",
+            "Tests/AcceptanceFixture"
+        ] {
+            try FileManager.default.createDirectory(
+                at: root.appendingPathComponent(directory),
+                withIntermediateDirectories: true
+            )
+        }
+        for file in [
+            "swama/Package.swift",
+            "Tools/SwamaAcceptance/Package.swift",
+            "Tests/AcceptanceFixture/Package.swift"
+        ] {
+            try Data("fixture\n".utf8).write(to: root.appendingPathComponent(file))
+        }
+        for command in [
+            ["git", "init"],
+            ["git", "config", "user.email", "acceptance@example.invalid"],
+            ["git", "config", "user.name", "Acceptance Test"],
+            ["git", "add", "."],
+            ["git", "commit", "-m", "fixture"]
+        ] {
+            let result = try runCommand(
+                command,
+                currentDirectory: root,
+                timeout: 30,
+                sampleMemory: false
+            )
+            guard result.returnCode == 0 else {
+                throw AcceptanceFailure.unknown("cannot prepare clean repository: \(commandFailureSummary(result))")
+            }
+        }
+        return root
     }
 }

--- a/Tools/SwamaAcceptance/contract.json
+++ b/Tools/SwamaAcceptance/contract.json
@@ -1,0 +1,98 @@
+{
+  "schema_version": 2,
+  "models": [
+    {
+      "id": "mlx-community/SmolLM-135M-Instruct-4bit",
+      "role": "small-control",
+      "benchmark": true
+    },
+    {
+      "id": "Qwen/Qwen3-1.7B-MLX-4bit",
+      "role": "reliability",
+      "benchmark": false
+    },
+    {
+      "id": "Qwen/Qwen3-4B-MLX-4bit",
+      "role": "large-reference",
+      "benchmark": true
+    }
+  ],
+  "benchmark": {
+    "max_tokens": 64,
+    "rounds": 7,
+    "warmup_rounds": 2,
+    "minimum_measured_rounds": 5,
+    "prompt": "Write one short sentence containing the exact marker SWAMA_ACCEPTANCE_OK.",
+    "comparison": {
+      "ttft_ratio_max": 1.1,
+      "ttft_absolute_slack_ms": 50.0,
+      "tokens_per_second_ratio_min": 0.95,
+      "peak_resident_ratio_max": 1.1,
+      "peak_resident_absolute_slack_bytes": 134217728
+    }
+  },
+  "reliability": {
+    "cancel_max_tokens": 512,
+    "cancel_observed_token_ceiling": 8,
+    "cancellation_latency_ms_max": 1000,
+    "concurrent_requests": 2,
+    "concurrent_max_tokens": 48,
+    "repeat_rounds": 12,
+    "repeat_max_tokens": 32,
+    "switch_cycles": 2,
+    "switch_max_tokens": 16,
+    "release_settle_ms": 1000,
+    "release_rss_ratio_max": 1.25,
+    "release_rss_absolute_slack_bytes": 268435456,
+    "disconnect_recovery_ttft_ms_max": 1000,
+    "timeout_seconds": 300
+  },
+  "architecture": {
+    "legacy_forbidden_import_allowlist": [
+      "swama/Sources/SwamaKit/MenuBarApp.swift:AppKit",
+      "swama/Sources/SwamaKit/Model/SpeechToTextRunner.swift:MLXAudioCore",
+      "swama/Sources/SwamaKit/Model/SpeechToTextRunner.swift:MLXAudioSTT",
+      "swama/Sources/SwamaKit/Model/TTSRunner.swift:MLXAudioTTS",
+      "swama/Sources/SwamaKit/Server/CompletionsHandler.swift:NIOCore",
+      "swama/Sources/SwamaKit/Server/CompletionsHandler.swift:NIOHTTP1",
+      "swama/Sources/SwamaKit/Server/EmbeddingsHandler.swift:NIOCore",
+      "swama/Sources/SwamaKit/Server/EmbeddingsHandler.swift:NIOHTTP1",
+      "swama/Sources/SwamaKit/Server/HTTPHandler.swift:NIOCore",
+      "swama/Sources/SwamaKit/Server/HTTPHandler.swift:NIOHTTP1",
+      "swama/Sources/SwamaKit/Server/ModelsHandler.swift:NIOCore",
+      "swama/Sources/SwamaKit/Server/ModelsHandler.swift:NIOHTTP1",
+      "swama/Sources/SwamaKit/Server/ServerManager.swift:NIO",
+      "swama/Sources/SwamaKit/Server/ServerManager.swift:NIOHTTP1",
+      "swama/Sources/SwamaKit/Server/TextToSpeechHandler.swift:MLXAudioCore",
+      "swama/Sources/SwamaKit/Server/TextToSpeechHandler.swift:NIOCore",
+      "swama/Sources/SwamaKit/Server/TextToSpeechHandler.swift:NIOHTTP1",
+      "swama/Sources/SwamaKit/Server/TranscriptionsHandler.swift:NIOCore",
+      "swama/Sources/SwamaKit/Server/TranscriptionsHandler.swift:NIOHTTP1"
+    ],
+    "legacy_public_mlx_leak_allowlist": [
+      "swama/Sources/SwamaKit/Model/ModelRunner.swift:public let completionInfo: GenerateCompletionInfo?",
+      "swama/Sources/SwamaKit/Model/ModelRunner.swift:public let toolCalls: [MLXLMCommon.ToolCall]",
+      "swama/Sources/SwamaKit/Model/ModelRunner.swift:public init(container: ModelContainer, promptCacheStore: PromptCacheStore = .shared) {",
+      "swama/Sources/SwamaKit/Model/ModelRunner.swift:public func run(prompt: String, images _: [Data]? = nil, parameters: GenerateParameters) async throws -> String {",
+      "swama/Sources/SwamaKit/Model/ModelRunner.swift:public nonisolated func runWithChatUsage( chatMessages: [MLXLMCommon.Chat.Message], parameters: GenerateParameters ) async throws -> ChatRunResult {",
+      "swama/Sources/SwamaKit/Model/ModelRunner.swift:public nonisolated func runChatNonStream( userInput: MLXLMCommon.UserInput, parameters: GenerateParameters ) async throws -> ChatRunResult {",
+      "swama/Sources/SwamaKit/Model/ModelRunner.swift:public nonisolated func runChat( userInput: MLXLMCommon.UserInput, parameters: GenerateParameters, onToken: (@Sendable (String) async throws -> Void)? = nil, onToolCall: (@Sendable (MLXLMCommon.ToolCall) async throws -> Void)? = nil ) async throws -> ChatRunResult {",
+      "swama/Sources/SwamaKit/Model/PromptCacheStore.swift:public init(parameters: GenerateParameters, maxKVSize: Int) {",
+      "swama/Sources/SwamaKit/Server/CompletionsHandler.swift:public static func sendNonStreamResponse( channel: Channel, modelName: String, chatMessages: [MLXLMCommon.Chat.Message], model: String, parameters: GenerateParameters, mlxTools: [ToolSpec]? = nil ) async throws {",
+      "swama/Sources/SwamaKit/Server/CompletionsHandler.swift:public static func sendStreamResponse( channel: Channel, modelName: String, chatMessages: [MLXLMCommon.Chat.Message], model: String, parameters: GenerateParameters, tools: [ToolSpec]? = nil ) async throws {"
+    ],
+    "goal_core_target": "SwamaCore",
+    "goal_forbidden_imports": [
+      "AppKit",
+      "ArgumentParser",
+      "NIO",
+      "NIOCore",
+      "NIOHTTP1",
+      "MLXAudioCore",
+      "MLXAudioSTT",
+      "MLXAudioTTS",
+      "SwamaServer",
+      "SwamaAppSupport"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- add a standalone SwiftPM acceptance referee under `Tools/SwamaAcceptance`; it has no dependency on Swama and is built before candidates
- add a separate `Tests/AcceptanceFixture` SwiftPM package that consumes `../../swama` like a third-party library user
- cover Core, CLI and streaming HTTP behavior; cancellation, concurrency, repeated generation, disconnect recovery and model eviction; TTFT/tokens-per-second/RSS; architecture ratchets; report sealing and fail-closed comparison
- keep Python and acceptance-only targets out of the production package (`swama/Sources` and `swama/Package.swift` are unchanged)

## Why this shape

The referee must survive a candidate Swift compile/runtime failure, but the project should remain Swift-native. The harness is therefore an independently compiled Swift executable; the Core probe is a different Swift package, so it cannot use Swama `internal` or `package` APIs. The fixture pins the same dependency revisions as production.

## Validation

Exact signed head: `8b4ceca8d0f566deb1830c91c62fb6ed7ba537c1`

- harness tests: 14/14 in debug and release
- independent fresh-checkout validation: pass
- dirty-tree positive/negative controls: clean tree runs; tracked or untracked changes return `UNKNOWN` before build and write no report
- tamper controls: edited/truncated report, post-hoc contract/tool change and model-byte mismatch return `UNKNOWN`
- real 200ms inference regression crosses a valid report seal and produces four TTFT findings
- current-main Python-to-Swift transition check: identical production `swama/Sources` tree and identical gate vector under the same v2 contract

Current `main` intentionally remains red only on the already-confirmed model-eviction memory contract; every other reliability and surface gate is green. The next PR fixes that product defect. The independent reviewer holds the Swift baseline-of-record together with the exact referee binary required by its live identity binding.

## Evidence boundary

Real-model benchmark reports are not committed: they include machine-local paths and hardware/model provenance. The harness and deterministic unit tests are committed; full Apple Silicon evidence was generated independently on a clean checkout. Report self-hashes detect accidental edits, not malicious resealing, so baseline custody remains independent.
