### PR TITLE
refactor: split core from server and app shells

### DIFF
--- a/swama-macos/Swama/Swama.xcodeproj/project.pbxproj
+++ b/swama-macos/Swama/Swama.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		894B2BC62DD33F930081F47B /* SwamaKit in Frameworks */ = {isa = PBXBuildFile; productRef = 894B2BC52DD33F930081F47B /* SwamaKit */; };
+		89A100012F52A00100000001 /* SwamaAppSupport in Frameworks */ = {isa = PBXBuildFile; productRef = 89A100022F52A00100000001 /* SwamaAppSupport */; };
 		8983B0302DD7316B00840502 /* swama-bin in CopyFiles */ = {isa = PBXBuildFile; fileRef = 894B2BC82DD3428A0081F47B /* swama-bin */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		89E5EE6A2F04DD010093AB6A /* swift-nio_NIOPosix.bundle in CopyFiles */ = {isa = PBXBuildFile; fileRef = 8983B0352DD733CB00840502 /* swift-nio_NIOPosix.bundle */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		89E5EE6B2F04DD010093AB6A /* swift-transformers_Hub.bundle in CopyFiles */ = {isa = PBXBuildFile; fileRef = 8983B0332DD733C600840502 /* swift-transformers_Hub.bundle */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -84,6 +85,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				894B2BC62DD33F930081F47B /* SwamaKit in Frameworks */,
+				89A100012F52A00100000001 /* SwamaAppSupport in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -151,6 +153,7 @@
 			name = Swama;
 			packageProductDependencies = (
 				894B2BC52DD33F930081F47B /* SwamaKit */,
+				89A100022F52A00100000001 /* SwamaAppSupport */,
 			);
 			productName = Swama;
 			productReference = 894B2B992DD33F680081F47B /* Swama.app */;
@@ -609,6 +612,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 894B4F8E2DF6DD3C000E0E11 /* XCLocalSwiftPackageReference "../../swama" */;
 			productName = SwamaKit;
+		};
+		89A100022F52A00100000001 /* SwamaAppSupport */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 894B4F8E2DF6DD3C000E0E11 /* XCLocalSwiftPackageReference "../../swama" */;
+			productName = SwamaAppSupport;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/swama-macos/Swama/Swama/SwamaApp.swift
+++ b/swama-macos/Swama/Swama/SwamaApp.swift
@@ -5,14 +5,15 @@
 //  Created by Xingyue on 2025/05/08.
 //
 
+import SwamaAppSupport
 import SwamaKit
 import SwiftUI
 
 @main
 struct SwamaApp: App {
     /// Use NSApplicationDelegateAdaptor to integrate the existing AppDelegate
-    /// from SwamaKit for managing the application lifecycle and menu bar.
-    @NSApplicationDelegateAdaptor(SwamaKit.AppDelegate.self) var appDelegate
+    /// from SwamaAppSupport for managing the application lifecycle and menu bar.
+    @NSApplicationDelegateAdaptor(SwamaAppSupport.AppDelegate.self) var appDelegate
 
     @State private var cliToolStatus: CLIToolStatus = .notInstalled
     @State private var contextLimit: Int = ContextLimitConfig.Constants.defaultLimit

--- a/swama/Package.swift
+++ b/swama/Package.swift
@@ -11,6 +11,14 @@ let package = Package(
             name: "SwamaKit",
             targets: ["SwamaKit"]
         ),
+        .library(
+            name: "SwamaServer",
+            targets: ["SwamaServer"]
+        ),
+        .library(
+            name: "SwamaAppSupport",
+            targets: ["SwamaAppSupport"]
+        ),
         .executable(
             name: "swama",
             targets: ["Swama"]
@@ -35,8 +43,6 @@ let package = Package(
         .target(
             name: "SwamaKit",
             dependencies: [
-                .product(name: "NIO", package: "swift-nio"),
-                .product(name: "NIOHTTP1", package: "swift-nio"),
                 .product(name: "MLXLLM", package: "mlx-swift-lm"),
                 .product(name: "MLXVLM", package: "mlx-swift-lm"),
                 .product(name: "MLXLMCommon", package: "mlx-swift-lm"),
@@ -47,15 +53,35 @@ let package = Package(
                 .product(name: "MLXAudioCore", package: "mlx-audio-swift"),
                 .product(name: "MLXAudioSTT", package: "mlx-audio-swift"),
                 .product(name: "MLXAudioTTS", package: "mlx-audio-swift"),
-                .product(name: "ArgumentParser", package: "swift-argument-parser"),
             ],
             path: "Sources/SwamaKit",
             resources: []
+        ),
+        .target(
+            name: "SwamaServer",
+            dependencies: [
+                .target(name: "SwamaKit"),
+                .product(name: "NIO", package: "swift-nio"),
+                .product(name: "NIOHTTP1", package: "swift-nio"),
+                .product(name: "MLXLMCommon", package: "mlx-swift-lm"),
+                .product(name: "MLXAudioCore", package: "mlx-audio-swift"),
+            ],
+            path: "Sources/SwamaServer"
+        ),
+        .target(
+            name: "SwamaAppSupport",
+            dependencies: [
+                .target(name: "SwamaKit"),
+                .target(name: "SwamaServer"),
+            ],
+            path: "Sources/SwamaAppSupport"
         ),
         .executableTarget(
             name: "Swama",
             dependencies: [
                 .target(name: "SwamaKit"),
+                .target(name: "SwamaServer"),
+                .target(name: "SwamaAppSupport"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
             ],
             path: "Sources/Swama",
@@ -66,6 +92,7 @@ let package = Package(
             name: "SwamaKitTests",
             dependencies: [
                 "SwamaKit",
+                "SwamaServer",
                 .product(name: "NIOEmbedded", package: "swift-nio"),
             ]
         ),

--- a/swama/Sources/Swama/CLI/Command.swift
+++ b/swama/Sources/Swama/CLI/Command.swift
@@ -1,5 +1,6 @@
 import AppKit // Required for NSApplication
 import ArgumentParser
+import SwamaAppSupport
 import SwamaKit
 
 // MARK: - Swama
@@ -44,9 +45,8 @@ struct MenuBar: AsyncParsableCommand {
         // Re-implementing the core logic of the old bootstrapMenuBarApp here
         let app = NSApplication.shared
 
-        // Create and assign the AppDelegate from SwamaKit
-        // SwamaKit.AppDelegate's applicationDidFinishLaunching will handle icon and menu setup.
-        let delegate = SwamaKit.AppDelegate()
+        // Create and assign the menu-bar shell delegate.
+        let delegate = SwamaAppSupport.AppDelegate()
         app.delegate = delegate
 
         // Set activation policy for a menu bar app (no Dock icon, no main window usually)

--- a/swama/Sources/Swama/CLI/Serve.swift
+++ b/swama/Sources/Swama/CLI/Serve.swift
@@ -1,7 +1,6 @@
 import ArgumentParser
-import NIO
-import NIOHTTP1
 import SwamaKit
+import SwamaServer
 
 struct Serve: AsyncParsableCommand {
     static let configuration: CommandConfiguration = .init(
@@ -22,11 +21,11 @@ struct Serve: AsyncParsableCommand {
         // Create a new instance of ServerManager for the CLI.
         // The ServerManager's properties (group, channel) are not used by runForCLI directly,
         // as runForCLI manages its own NIO resources.
-        let serverManager = SwamaKit.ServerManager()
+        let serverManager = SwamaServer.ServerManager()
         print("CLI Serve: Initialized SwamaKit.ServerManager for CLI operation.")
 
         // Use provided port or fallback to environment variable/default
-        let actualPort = port ?? SwamaKit.ServerManager.defaultPort()
+        let actualPort = port ?? SwamaServer.ServerManager.defaultPort()
 
         if let limit = commonOptions.resolvedContextLimit {
             await ContextLimitConfig.shared.updateLimit(limit)

--- a/swama/Sources/SwamaAppSupport/MenuBarApp.swift
+++ b/swama/Sources/SwamaAppSupport/MenuBarApp.swift
@@ -1,5 +1,7 @@
 import AppKit
 import Foundation
+import SwamaKit
+import SwamaServer
 
 // MARK: - CLIToolStatus
 

--- a/swama/Sources/SwamaKit/Model/ModelManager.swift
+++ b/swama/Sources/SwamaKit/Model/ModelManager.swift
@@ -25,7 +25,7 @@ public enum ModelManager {
     ///   • flat:   `{root}/{model}/.swama-meta.json`
     ///   • nested: `{root}/{org}/{model}/.swama-meta.json`
     /// The nested case also covers the audio layout `{root}/mlx-audio/{repo_underscore}/`.
-    static func scanModelsDirectory(at modelsRootDirectory: URL) -> [ModelInfo] {
+    package static func scanModelsDirectory(at modelsRootDirectory: URL) -> [ModelInfo] {
         var modelInfos: [ModelInfo] = []
 
         let topLevel: [URL]

--- a/swama/Sources/SwamaServer/CompletionsHandler.swift
+++ b/swama/Sources/SwamaServer/CompletionsHandler.swift
@@ -7,6 +7,7 @@ import Foundation
 @preconcurrency import MLXLMCommon
 import NIOCore
 import NIOHTTP1
+import SwamaKit
 import struct Tokenizers.ToolSpec
 
 // MARK: - CompletionsHandler

--- a/swama/Sources/SwamaServer/EmbeddingsHandler.swift
+++ b/swama/Sources/SwamaServer/EmbeddingsHandler.swift
@@ -1,6 +1,7 @@
 import Foundation
 import NIOCore
 import NIOHTTP1
+import SwamaKit
 
 // MARK: - EmbeddingsRequest
 

--- a/swama/Sources/SwamaServer/HTTPHandler.swift
+++ b/swama/Sources/SwamaServer/HTTPHandler.swift
@@ -7,6 +7,7 @@ import Foundation
 import MLXLMCommon
 import NIOCore
 import NIOHTTP1
+import SwamaKit
 
 /// This modelPool instance should ideally be managed and injected by ServerManager or a DI system.
 /// For now, keeping it global within SwamaKit as per original Router.swift structure.

--- a/swama/Sources/SwamaServer/ModelsHandler.swift
+++ b/swama/Sources/SwamaServer/ModelsHandler.swift
@@ -6,6 +6,7 @@
 import Foundation
 import NIOCore
 import NIOHTTP1
+import SwamaKit
 
 // MARK: - ModelsHandler
 

--- a/swama/Sources/SwamaServer/ServerManager.swift
+++ b/swama/Sources/SwamaServer/ServerManager.swift
@@ -6,6 +6,7 @@
 import Foundation
 import NIO
 import NIOHTTP1
+import SwamaKit
 
 // MARK: - ServerError
 

--- a/swama/Sources/SwamaServer/TextToSpeechHandler.swift
+++ b/swama/Sources/SwamaServer/TextToSpeechHandler.swift
@@ -2,6 +2,7 @@ import Foundation
 import MLXAudioCore
 import NIOCore
 import NIOHTTP1
+import SwamaKit
 
 // MARK: - TextToSpeechHandler
 

--- a/swama/Sources/SwamaServer/TranscriptionsHandler.swift
+++ b/swama/Sources/SwamaServer/TranscriptionsHandler.swift
@@ -6,6 +6,7 @@
 import Foundation
 import NIOCore
 import NIOHTTP1
+import SwamaKit
 
 // MARK: - TranscriptionsHandler
 

--- a/swama/Tests/SwamaKitTests/CompletionsHandlerTests.swift
+++ b/swama/Tests/SwamaKitTests/CompletionsHandlerTests.swift
@@ -4,6 +4,7 @@ import NIOCore
 import NIOEmbedded
 import NIOHTTP1
 @testable import SwamaKit
+@testable import SwamaServer
 import Testing
 
 // MARK: - CompletionsHandlerTests

--- a/swama/Tests/SwamaKitTests/EmbeddingRunnerTests.swift
+++ b/swama/Tests/SwamaKitTests/EmbeddingRunnerTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 @testable import SwamaKit
+@testable import SwamaServer
 import Testing
 
 @MainActor @Suite(.serialized)

--- a/swama/Tests/SwamaKitTests/ModelsHandlerTests.swift
+++ b/swama/Tests/SwamaKitTests/ModelsHandlerTests.swift
@@ -3,6 +3,7 @@ import NIOCore
 import NIOEmbedded
 import NIOHTTP1
 @testable import SwamaKit
+@testable import SwamaServer
 import Testing
 
 // MARK: - ModelsHandlerTests

--- a/swama/Tests/SwamaKitTests/TargetBoundaryTests.swift
+++ b/swama/Tests/SwamaKitTests/TargetBoundaryTests.swift
@@ -1,0 +1,97 @@
+import Foundation
+import Testing
+
+@Suite("Swama target boundaries")
+struct TargetBoundaryTests {
+    @Test func coreManifestHasNoShellDependencies() throws {
+        let manifest = try String(
+            contentsOf: packageRoot.appendingPathComponent("Package.swift"),
+            encoding: .utf8
+        )
+        let core = try targetDeclaration(named: "SwamaKit", in: manifest)
+        let server = try targetDeclaration(named: "SwamaServer", in: manifest)
+        let appSupport = try targetDeclaration(named: "SwamaAppSupport", in: manifest)
+
+        for forbiddenDependency in ["NIO", "NIOHTTP1", "ArgumentParser", "SwamaServer", "SwamaAppSupport"] {
+            if core.contains("name: \"\(forbiddenDependency)\"") {
+                Issue.record("SwamaKit must not depend on shell target or product \(forbiddenDependency)")
+            }
+        }
+
+        #expect(server.contains(".target(name: \"SwamaKit\")"))
+        #expect(server.contains("name: \"NIO\""))
+        #expect(server.contains("name: \"NIOHTTP1\""))
+        #expect(appSupport.contains(".target(name: \"SwamaKit\")"))
+        #expect(appSupport.contains(".target(name: \"SwamaServer\")"))
+    }
+
+    @Test func coreSourcesDoNotImportShellFrameworks() throws {
+        let coreRoot = packageRoot.appendingPathComponent("Sources/SwamaKit")
+        let forbiddenModules = [
+            "AppKit",
+            "ArgumentParser",
+            "NIO",
+            "NIOCore",
+            "NIOHTTP1",
+            "SwamaServer",
+            "SwamaAppSupport"
+        ]
+
+        let sourceURLs = try #require(
+            FileManager.default
+                .enumerator(
+                    at: coreRoot,
+                    includingPropertiesForKeys: nil
+                )?.allObjects
+                .compactMap { $0 as? URL }
+                .filter { $0.pathExtension == "swift" }
+        )
+
+        for sourceURL in sourceURLs {
+            let source = try String(contentsOf: sourceURL, encoding: .utf8)
+            let imports = source.split(separator: "\n").map {
+                $0.trimmingCharacters(in: .whitespaces)
+            }
+
+            for module in forbiddenModules {
+                if imports.contains("import \(module)") {
+                    Issue.record("SwamaKit must not import shell module \(module): \(sourceURL.lastPathComponent)")
+                }
+            }
+        }
+    }
+
+    @Test func shellSourcesLiveOutsideTheCoreTarget() {
+        let sources = packageRoot.appendingPathComponent("Sources")
+
+        #expect(!FileManager.default.fileExists(atPath: sources.appendingPathComponent("SwamaKit/Server").path))
+        #expect(!FileManager.default
+            .fileExists(atPath: sources.appendingPathComponent("SwamaKit/MenuBarApp.swift").path)
+        )
+        #expect(FileManager.default
+            .fileExists(atPath: sources.appendingPathComponent("SwamaServer/ServerManager.swift").path)
+        )
+        #expect(FileManager.default
+            .fileExists(atPath: sources.appendingPathComponent("SwamaAppSupport/MenuBarApp.swift").path)
+        )
+    }
+
+    private var packageRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+    }
+
+    private func targetDeclaration(named name: String, in manifest: String) throws -> Substring {
+        let marker = ".target(\n            name: \"\(name)\""
+        let start = try #require(manifest.range(of: marker)?.lowerBound)
+        let end = try #require(
+            manifest.range(
+                of: "\n        ),",
+                range: start ..< manifest.endIndex
+            )?.upperBound
+        )
+        return manifest[start ..< end]
+    }
+}

--- a/swama/Tests/SwamaKitTests/ToolCallingTests.swift
+++ b/swama/Tests/SwamaKitTests/ToolCallingTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 @testable import SwamaKit
+@testable import SwamaServer
 import Testing
 
 @MainActor @Suite(.serialized)


### PR DESCRIPTION
## Summary

Mechanically split the existing package into three layers:

- `SwamaKit`: model/runtime core with no NIO, ArgumentParser, or AppKit dependency
- `SwamaServer`: the existing NIO HTTP server implementation
- `SwamaAppSupport`: the existing AppKit menu-bar shell

The CLI and app now import the shell modules they use. Moved implementation bodies are unchanged apart from module imports and the minimum access widening required across package targets.

## Stack status

PR #127 merged as `7eef8d1112b6e388bf5f1ab0de94674724ef71bf`; PR #128 merged as `c1f37077b5bcb202534df7338b2ca923575c128c`. This PR now targets live `main` directly.

The branch was rebuilt from that #128 main exact by replaying its one target-split commit. The old `bbdd1609` and current commit have the same stable patch ID, `c96c0dde2170a093efa61d0811734261b5fe9240`.

## Invariants

- no public API redesign
- no concurrency-policy change
- no model/runtime behavior change
- no in-package acceptance probe target
- no new architecture debt

The architecture ratchet removes 16 forbidden-import identities (including NIOCore) and two public MLX type leaks, with zero new debt.

## Verification

Exact signed head: `888f97cbaae85e377bcf4293e8465ea3e48dd037`

- 112 Swift product tests passed
- Core, CLI, and HTTP parity gates passed
- cancellation, concurrency, repeated generation, disconnect recovery, and model-switch/release gates passed
- paired-referee comparison against the #128 green baseline is fully comparable: `benchmark_models=2`, `benchmark_routes=4`, `passed=true`, no findings
- architecture debt only decreases: 16 forbidden imports and two public MLX leaks removed; zero new debt
- the patch is byte-identical to the previously independently reviewed target-split milestone; current-main custody independently reproduced the same result

## Evidence boundary

The current core source tree has zero forbidden imports, verified independently with positive controls, and the package dependency graph rejects reverse package-product edges. The source-level regex test catches plain forbidden imports but does not yet recognize attributed forms such as `@preconcurrency import AppKit`; system frameworks can compile without a manifest dependency. That guard-hardening follow-up is recorded as team task #9 and is not claimed by this mechanical split.

The OpenCode/Swama real-agent experiment is intentionally local-only and is not part of this PR.
