### PR TITLE
test: harden core import boundary against attributed imports

### DIFF
--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Architecture.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Architecture.swift
@@ -1,5 +1,22 @@
 import Foundation
 
+/// Import attributes are open-ended (`@_exported`, `@_spi(...)`, etc.), so match their
+/// grammar rather than enumerating spellings. Access modifiers and scoped-import kinds are
+/// finite parts of the Swift import declaration grammar.
+let swiftImportDeclarationPattern =
+    #"^\s*(?:@[A-Za-z_][A-Za-z0-9_]*(?:\([^)]*\))?\s+)*(?:(?:private|fileprivate|internal|package|public|open)\s+)?import\s+(?:(?:typealias|struct|class|enum|protocol|let|var|func|macro)\s+)?([A-Za-z_][A-Za-z0-9_]*)\b"#
+
+func swiftImportedModule(in line: String, matching expression: NSRegularExpression) -> String? {
+    let range = NSRange(line.startIndex ..< line.endIndex, in: line)
+    guard let match = expression.firstMatch(in: line, range: range),
+          let moduleRange = Range(match.range(at: 1), in: line)
+    else {
+        return nil
+    }
+
+    return String(line[moduleRange])
+}
+
 // MARK: - ArchitectureStage
 
 enum ArchitectureStage: String, Sendable {
@@ -70,21 +87,17 @@ private func imports(
         return []
     }
 
-    let expression = try NSRegularExpression(pattern: #"^\s*(?:@preconcurrency\s+)?import\s+([A-Za-z0-9_]+)"#)
+    let expression = try NSRegularExpression(pattern: swiftImportDeclarationPattern)
     var hits: [JSONObject] = []
 
     for file in try regularFiles(in: root, extensions: ["swift"]).sorted(by: { $0.path < $1.path }) {
         let text = try String(contentsOf: file, encoding: .utf8)
         for (index, line) in text.split(separator: "\n", omittingEmptySubsequences: false).enumerated() {
             let value = String(line)
-            let range = NSRange(value.startIndex ..< value.endIndex, in: value)
-            guard let match = expression.firstMatch(in: value, range: range),
-                  let moduleRange = Range(match.range(at: 1), in: value)
-            else {
+            guard let module = swiftImportedModule(in: value, matching: expression) else {
                 continue
             }
 
-            let module = String(value[moduleRange])
             if forbidden.contains(module) {
                 hits.append([
                     "file": relativePath(file, to: repository),

--- a/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
+++ b/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
@@ -230,7 +230,7 @@ struct AcceptanceTests {
         #expect(gates["http_disconnect_then_recover"] == false)
     }
 
-    @Test func architectureGateRejectsInternalShellReverseImport() throws {
+    @Test func architectureGateRejectsAttributedShellReverseImports() throws {
         let temporary = FileManager.default
             .temporaryDirectory
             .appendingPathComponent("swama-architecture-test-\(UUID().uuidString)")
@@ -252,7 +252,15 @@ struct AcceptanceTests {
         ] {
             try Data().write(to: temporary.appendingPathComponent(file))
         }
-        try Data("import SwamaServer\n".utf8).write(
+        try Data(
+            """
+            @_exported import SwamaServer
+            internal import AppKit
+            @testable import ArgumentParser
+            @preconcurrency import MLXLMCommon
+
+            """.utf8
+        ).write(
             to: temporary.appendingPathComponent("swama/Sources/SwamaKit/Bad.swift")
         )
 
@@ -261,11 +269,36 @@ struct AcceptanceTests {
             legacyForbiddenImportAllowlist: [],
             legacyPublicMLXLeakAllowlist: [],
             goalCoreTarget: "SwamaCore",
-            goalForbiddenImports: ["SwamaServer", "SwamaAppSupport"]
+            goalForbiddenImports: ["AppKit", "ArgumentParser", "SwamaServer", "SwamaAppSupport"]
         )
         let report = try architectureReport(contract: contract, stage: .legacyRatchet, paths: paths)
         #expect(report["passed"] as? Bool == false)
-        #expect((report["new_forbidden_imports"] as? [String]) == ["swama/Sources/SwamaKit/Bad.swift:SwamaServer"])
+        #expect((report["new_forbidden_imports"] as? [String]) == [
+            "swama/Sources/SwamaKit/Bad.swift:AppKit",
+            "swama/Sources/SwamaKit/Bad.swift:ArgumentParser",
+            "swama/Sources/SwamaKit/Bad.swift:SwamaServer"
+        ])
+    }
+
+    @Test func architectureImportParserHandlesAttributesAccessAndScopedImports() throws {
+        let expression = try NSRegularExpression(pattern: swiftImportDeclarationPattern)
+        let imports = [
+            "import SwamaServer": "SwamaServer",
+            "@_exported import NIO": "NIO",
+            "@preconcurrency import AppKit": "AppKit",
+            "@testable import SwamaServer": "SwamaServer",
+            "@_implementationOnly import ArgumentParser": "ArgumentParser",
+            "@_spi(Testing) import NIOHTTP1": "NIOHTTP1",
+            "internal import SwamaAppSupport": "SwamaAppSupport",
+            "package import struct NIOCore.ByteBuffer": "NIOCore",
+            "@preconcurrency import MLXLMCommon": "MLXLMCommon"
+        ]
+
+        for (line, module) in imports {
+            #expect(swiftImportedModule(in: line, matching: expression) == module)
+        }
+        #expect(swiftImportedModule(in: "// @_exported import NIO", matching: expression) == nil)
+        #expect(swiftImportedModule(in: "let example = \"import NIO\"", matching: expression) == nil)
     }
 
     @Test func medianUsesAllMeasuredSamples() {

--- a/swama/Tests/SwamaKitTests/TargetBoundaryTests.swift
+++ b/swama/Tests/SwamaKitTests/TargetBoundaryTests.swift
@@ -27,7 +27,7 @@ struct TargetBoundaryTests {
 
     @Test func coreSourcesDoNotImportShellFrameworks() throws {
         let coreRoot = packageRoot.appendingPathComponent("Sources/SwamaKit")
-        let forbiddenModules = [
+        let forbiddenModules: Set = [
             "AppKit",
             "ArgumentParser",
             "NIO",
@@ -36,6 +36,7 @@ struct TargetBoundaryTests {
             "SwamaServer",
             "SwamaAppSupport"
         ]
+        let importExpression = try NSRegularExpression(pattern: swiftImportDeclarationPattern)
 
         let sourceURLs = try #require(
             FileManager.default
@@ -49,16 +50,35 @@ struct TargetBoundaryTests {
 
         for sourceURL in sourceURLs {
             let source = try String(contentsOf: sourceURL, encoding: .utf8)
-            let imports = source.split(separator: "\n").map {
-                $0.trimmingCharacters(in: .whitespaces)
-            }
-
-            for module in forbiddenModules {
-                if imports.contains("import \(module)") {
+            for line in source.split(separator: "\n", omittingEmptySubsequences: false) {
+                if let module = importedModule(in: String(line), matching: importExpression),
+                   forbiddenModules.contains(module)
+                {
                     Issue.record("SwamaKit must not import shell module \(module): \(sourceURL.lastPathComponent)")
                 }
             }
         }
+    }
+
+    @Test func importParserHandlesAttributesAccessAndScopedImports() throws {
+        let expression = try NSRegularExpression(pattern: swiftImportDeclarationPattern)
+        let imports = [
+            "import SwamaServer": "SwamaServer",
+            "@_exported import NIO": "NIO",
+            "@preconcurrency import AppKit": "AppKit",
+            "@testable import SwamaServer": "SwamaServer",
+            "@_implementationOnly import ArgumentParser": "ArgumentParser",
+            "@_spi(Testing) import NIOHTTP1": "NIOHTTP1",
+            "internal import SwamaAppSupport": "SwamaAppSupport",
+            "package import struct NIOCore.ByteBuffer": "NIOCore",
+            "@preconcurrency import MLXLMCommon": "MLXLMCommon"
+        ]
+
+        for (line, module) in imports {
+            #expect(importedModule(in: line, matching: expression) == module)
+        }
+        #expect(importedModule(in: "// @_exported import NIO", matching: expression) == nil)
+        #expect(importedModule(in: "let example = \"import NIO\"", matching: expression) == nil)
     }
 
     @Test func shellSourcesLiveOutsideTheCoreTarget() {
@@ -81,6 +101,23 @@ struct TargetBoundaryTests {
             .deletingLastPathComponent()
             .deletingLastPathComponent()
             .deletingLastPathComponent()
+    }
+
+    private var swiftImportDeclarationPattern: String {
+        // Keep this grammar aligned with the external acceptance scanner. This committed test
+        // must still protect the boundary when that external tool is not being run.
+        #"^\s*(?:@[A-Za-z_][A-Za-z0-9_]*(?:\([^)]*\))?\s+)*(?:(?:private|fileprivate|internal|package|public|open)\s+)?import\s+(?:(?:typealias|struct|class|enum|protocol|let|var|func|macro)\s+)?([A-Za-z_][A-Za-z0-9_]*)\b"#
+    }
+
+    private func importedModule(in line: String, matching expression: NSRegularExpression) -> String? {
+        let range = NSRange(line.startIndex ..< line.endIndex, in: line)
+        guard let match = expression.firstMatch(in: line, range: range),
+              let moduleRange = Range(match.range(at: 1), in: line)
+        else {
+            return nil
+        }
+
+        return String(line[moduleRange])
     }
 
     private func targetDeclaration(named name: String, in manifest: String) throws -> Substring {


### PR DESCRIPTION
## Summary

The core-boundary scanners previously recognized plain imports (and one scanner recognized `@preconcurrency`) but could miss other valid Swift forms such as:

```swift
@_exported import AppKit
internal import SwamaServer
@testable import ArgumentParser
package import struct NIOCore.ByteBuffer
```

An attributed system-framework import can compile without a package-manifest edge, so SwiftPM cannot backstop this source-level gate.

This change makes both the external acceptance scanner and the committed `TargetBoundaryTests` parse the import-declaration shape: arbitrary attributes (including arguments), access modifiers, optional scoped-import kind, and the root module name. Attribute names are not enumerated one by one.

## Scope

Three guard/test files only:

- `Tools/SwamaAcceptance/.../Architecture.swift`
- `Tools/SwamaAcceptance/.../AcceptanceTests.swift`
- `swama/Tests/SwamaKitTests/TargetBoundaryTests.swift`

No product source, package graph, public API, runtime, or concurrency change.

## Verification

Signed exact: `f5f5029e390487104f68f980a94eb9985d4c83fb`

- 17/17 standalone harness tests
- 4/4 target-boundary tests
- full signed-exact acceptance: 113 product tests, five reliability gates green, Core/CLI/HTTP green, architecture debt still removes 16 imports + two public MLX leaks with zero new debt
- real `@_exported import AppKit` mutation compiles and reddens only `coreSourcesDoNotImportShellFrameworks`
- real `@_exported import NIO` mutation makes the rebuilt external architecture scanner report the exact file/module
- restoring the old external matcher reddens six attributed/access/scoped cases
- restoring the old committed matcher reddens all eight parser cases
- allowed attributed import control (`@preconcurrency import MLXLMCommon`) remains accepted

## Evidence note

During mutation testing, the first external-scanner attempt accidentally reused the pre-change debug binary and falsely stayed green. Rebuilding the referee before rerunning produced the expected RED. The handoff calls this out so reviewers do not confuse edited sources with the executable actually under test.

Because the acceptance harness source changed, its instrument hashes changed too. The attached author baseline is a new generation; independent custody must rebuild/reseal rather than inherit the prior referee binary.
