### PR TITLE
fix: prevent in-flight model loads from surviving teardown

### DIFF
--- a/swama/Sources/SwamaKit/Model/ModelPool.swift
+++ b/swama/Sources/SwamaKit/Model/ModelPool.swift
@@ -121,7 +121,7 @@ private final class LoadedValueOwner<Value: AnyObject>: @unchecked Sendable {
 private struct PendingModelLoad<Value: AnyObject>: Sendable {
     let token: ModelLoadToken
     let task: Task<LoadedValueOwner<Value>, Error>
-    let staleCleanupGate: OneShotGate = .init()
+    let postLoadCleanupGate: OneShotGate = .init()
 }
 
 // MARK: - OneShotGate
@@ -234,24 +234,22 @@ public actor ModelPool {
         operation: @Sendable @escaping (SpeechToTextRunner) async throws -> T
     ) async throws -> T {
         // Wait for available slot AND ensure the specific model is not already running
-        while runningInferences >= maxConcurrentInferences || runningModels.contains(modelName) {
+        while runningInferences >= maxConcurrentInferences || runningModels[modelName] != nil {
             try await Task.sleep(nanoseconds: 50_000_000) // 50ms
         }
 
         try Task.checkCancellation()
 
         runningInferences += 1
-        runningModels.insert(modelName)
-        loadingModels.insert(modelName)
+        let operationToken = beginModelOperation(modelName)
         defer {
             runningInferences = max(0, runningInferences - 1)
-            runningModels.remove(modelName)
-            loadingModels.remove(modelName)
+            endModelOperation(modelName, token: operationToken)
         }
 
         // Get or load the speech-to-text runner
         let runner = try await getSpeechToTextRunner(modelName: modelName)
-        loadingModels.remove(modelName)
+        finishLoadingPhase(modelName, token: operationToken)
 
         // Execute the operation
         return try await operation(runner)
@@ -264,19 +262,17 @@ public actor ModelPool {
         repository: String? = nil,
         operation: @Sendable @escaping (TTSRunner) async throws -> T
     ) async throws -> T {
-        while runningInferences >= maxConcurrentInferences || runningModels.contains(modelKey) {
+        while runningInferences >= maxConcurrentInferences || runningModels[modelKey] != nil {
             try await Task.sleep(nanoseconds: 50_000_000) // 50ms
         }
 
         try Task.checkCancellation()
 
         runningInferences += 1
-        runningModels.insert(modelKey)
-        loadingModels.insert(modelKey)
+        let operationToken = beginModelOperation(modelKey)
         defer {
             runningInferences = max(0, runningInferences - 1)
-            runningModels.remove(modelKey)
-            loadingModels.remove(modelKey)
+            endModelOperation(modelKey, token: operationToken)
         }
 
         let runner = try await getTTSRunner(
@@ -284,7 +280,7 @@ public actor ModelPool {
             kind: kind,
             repository: repository
         )
-        loadingModels.remove(modelKey)
+        finishLoadingPhase(modelKey, token: operationToken)
         return try await operation(runner)
     }
 
@@ -388,12 +384,34 @@ public actor ModelPool {
     private var runningInferences = 0
     private let maxConcurrentInferences = 3 // Optimal for high-performance machines
 
-    /// Per-model concurrency control: track which models are currently running inference
-    private var runningModels: Set<String> = []
+    /// Per-model concurrency control: map each reserved model to its owning operation token.
+    private var runningModels: [String: UInt64] = [:]
 
-    /// Subset of `runningModels` that has not yet reached its inference operation. Periodic
-    /// teardown may invalidate these pending loads, but must still skip a live operation.
-    private var loadingModels: Set<String> = []
+    /// The same operation token remains here only until its model load finishes. Matching tokens
+    /// are an explicit credential for eviction to cancel a load without touching a live operation.
+    private var loadingModels: [String: UInt64] = [:]
+    private var nextOperationSequence: UInt64 = 0
+
+    private func beginModelOperation(_ modelName: String) -> UInt64 {
+        nextOperationSequence &+= 1
+        let token = nextOperationSequence
+        runningModels[modelName] = token
+        loadingModels[modelName] = token
+        return token
+    }
+
+    private func finishLoadingPhase(_ modelName: String, token: UInt64) {
+        if loadingModels[modelName] == token {
+            loadingModels.removeValue(forKey: modelName)
+        }
+    }
+
+    private func endModelOperation(_ modelName: String, token: UInt64) {
+        finishLoadingPhase(modelName, token: token)
+        if runningModels[modelName] == token {
+            runningModels.removeValue(forKey: modelName)
+        }
+    }
 
     /// Safely run a model operation with concurrency control to prevent MLX heap corruption
     public func run<T: Sendable>(
@@ -401,24 +419,22 @@ public actor ModelPool {
         operation: @Sendable @escaping (ModelRunner) async throws -> T
     ) async throws -> T {
         // Wait for available slot AND ensure the specific model is not already running
-        while runningInferences >= maxConcurrentInferences || runningModels.contains(modelName) {
+        while runningInferences >= maxConcurrentInferences || runningModels[modelName] != nil {
             try await Task.sleep(nanoseconds: 50_000_000) // 50ms
         }
 
         try Task.checkCancellation()
 
         runningInferences += 1
-        runningModels.insert(modelName)
-        loadingModels.insert(modelName)
+        let operationToken = beginModelOperation(modelName)
         defer {
             runningInferences = max(0, runningInferences - 1)
-            runningModels.remove(modelName)
-            loadingModels.remove(modelName)
+            endModelOperation(modelName, token: operationToken)
         }
 
         // Get or load the model container
         let container = try await getContainer(modelName: modelName)
-        loadingModels.remove(modelName)
+        finishLoadingPhase(modelName, token: operationToken)
         let runner = ModelRunner(container: container)
 
         // Execute the operation
@@ -430,7 +446,9 @@ public actor ModelPool {
         modelName: String,
         operation: @Sendable @escaping (EmbeddingRunner) async throws -> T
     ) async throws -> T {
-        // Wait for available slot
+        // Embedding requests share the global pool limit but deliberately do not reserve
+        // `runningModels`: EmbeddingRunner is an actor and EmbedderModelContainer serializes
+        // access internally, so same-model callers may coalesce one load and then queue there.
         while runningInferences >= maxConcurrentInferences {
             try await Task.sleep(nanoseconds: 50_000_000) // 50ms
         }
@@ -613,6 +631,18 @@ public actor ModelPool {
                 embeddingTasks[modelName] != nil
             }
         }
+
+        func hasMatchingLoadingOperationForTesting(modelName: String) -> Bool {
+            guard let runningOwner = runningModels[modelName] else {
+                return false
+            }
+
+            return loadingModels[modelName] == runningOwner
+        }
+
+        func runningInferenceCountForTesting() -> Int {
+            runningInferences
+        }
     #endif
 
     // MARK: Private
@@ -667,13 +697,13 @@ public actor ModelPool {
         _ owner: LoadedValueOwner<Value>,
         token: ModelLoadToken,
         modelName: String,
-        staleCleanupGate: OneShotGate
+        postLoadCleanupGate: OneShotGate
     ) throws -> Value {
         guard isCurrent(token, modelName: modelName) else {
             // clear/remove/evict already ran one cleanup while this owner was still live. Drop
             // the Task-retained value first, then run the bounded follow-up cleanup exactly once.
             owner.release()
-            if staleCleanupGate.claim() {
+            if postLoadCleanupGate.claim() {
                 memoryHooks.clearCache()
             }
             throw CancellationError()
@@ -789,28 +819,43 @@ public actor ModelPool {
     ) async throws -> Value {
         do {
             let owner = try await pending.task.value
+
+            guard isCurrent(pending.token, modelName: modelName) else {
+                return try resolvedLoadedValue(
+                    owner,
+                    token: pending.token,
+                    modelName: modelName,
+                    postLoadCleanupGate: pending.postLoadCleanupGate
+                )
+            }
+
+            if let existing = cachedValue() {
+                recordCachedUse()
+                // Another waiter or an explicit cache setter won the commit. A completed Task
+                // must not retain its unused load; if it owned a distinct value, clean up after
+                // releasing it. Multiple waiters share this one-shot cleanup gate.
+                if owner.release(), pending.postLoadCleanupGate.claim() {
+                    memoryHooks.clearCache()
+                }
+                if currentPendingToken() == pending.token {
+                    removePending()
+                }
+                return existing
+            }
+
             let loaded = try resolvedLoadedValue(
                 owner,
                 token: pending.token,
                 modelName: modelName,
-                staleCleanupGate: pending.staleCleanupGate
+                postLoadCleanupGate: pending.postLoadCleanupGate
             )
-
-            let value: Value
-            if let existing = cachedValue() {
-                recordCachedUse()
-                value = existing
-            }
-            else {
-                storeLoaded(loaded)
-                value = loaded
-            }
+            storeLoaded(loaded)
             owner.release()
 
             if currentPendingToken() == pending.token {
                 removePending()
             }
-            return value
+            return loaded
         }
         catch {
             let wasInvalidated = !isCurrent(pending.token, modelName: modelName)
@@ -835,7 +880,7 @@ public actor ModelPool {
         modelName: String
     ) {
         guard !isCurrent(pending.token, modelName: modelName),
-              pending.staleCleanupGate.claim()
+              pending.postLoadCleanupGate.claim()
         else {
             return
         }
@@ -1294,7 +1339,7 @@ public actor ModelPool {
     private func getIdleModels() -> [(name: String, idleTime: TimeInterval)] {
         modelUsageInfo.compactMap { modelName, usage in
             // Skip models that are currently running
-            guard !runningModels.contains(modelName) else {
+            guard runningModels[modelName] == nil else {
                 return nil
             }
 
@@ -1311,7 +1356,7 @@ public actor ModelPool {
     private func getEvictionCandidates() -> [(name: String, score: Double)] {
         modelUsageInfo.compactMap { modelName, usage in
             // Skip models that are currently running
-            guard !runningModels.contains(modelName) else {
+            guard runningModels[modelName] == nil else {
                 return nil
             }
 
@@ -1332,8 +1377,11 @@ public actor ModelPool {
     private func evictModel(modelName: String, reason: String) async {
         // A pending load has not reached inference yet and is safe to invalidate. Continue to
         // protect a genuinely running cached model from periodic eviction.
-        let isPendingLoad = loadingModels.contains(modelName) && hasPendingLoad(for: modelName)
-        guard !runningModels.contains(modelName) || isPendingLoad else {
+        let runningOwner = runningModels[modelName]
+        let isPendingLoad = runningOwner != nil
+            && loadingModels[modelName] == runningOwner
+            && hasPendingLoad(for: modelName)
+        guard runningOwner == nil || isPendingLoad else {
             NSLog("SwamaKit.ModelPool: Skipping eviction of \(modelName) - currently running")
             return
         }

--- a/swama/Sources/SwamaKit/Model/ModelPool.swift
+++ b/swama/Sources/SwamaKit/Model/ModelPool.swift
@@ -65,6 +65,92 @@ struct ModelPoolMemoryHooks: Sendable {
     )
 }
 
+// MARK: - ModelPoolLoadOverrides
+
+/// Test-only seams for making each asynchronous load path deterministic without touching MLX.
+/// Production pools leave this nil and use the real model factories below.
+struct ModelPoolLoadOverrides: Sendable {
+    let modelExistsLocally: @Sendable (String) -> Bool
+    let determineIsVLM: @Sendable (String) -> Bool
+    let loadLanguage: @Sendable (String, Bool) async throws -> MLXLMCommon.ModelContainer
+    let loadSpeechToText: @Sendable (String) async throws -> SpeechToTextRunner
+    let loadTTS: @Sendable (String, TTSModelKind, String?) async throws -> TTSRunner
+    let loadEmbedding: @Sendable (String) async throws -> EmbeddingRunner
+}
+
+// MARK: - ModelLoadToken
+
+private struct ModelLoadToken: Equatable, Sendable {
+    let globalGeneration: UInt64
+    let modelGeneration: UInt64
+    let sequence: UInt64
+}
+
+// MARK: - LoadedValueOwner
+
+/// A completed Task normally retains its success value. Keeping that value behind a releasable
+/// owner lets a stale load drop the last Task-owned model reference *before* the follow-up MLX
+/// cleanup runs.
+private final class LoadedValueOwner<Value: AnyObject>: @unchecked Sendable {
+    init(_ value: Value) {
+        self.value = value
+    }
+
+    func retainedValue() -> Value? {
+        lock.withLock { value }
+    }
+
+    @discardableResult
+    func release() -> Bool {
+        lock.withLock {
+            guard value != nil else {
+                return false
+            }
+
+            value = nil
+            return true
+        }
+    }
+
+    private let lock: NSLock = .init()
+    private var value: Value?
+}
+
+// MARK: - PendingModelLoad
+
+private struct PendingModelLoad<Value: AnyObject>: Sendable {
+    let token: ModelLoadToken
+    let task: Task<LoadedValueOwner<Value>, Error>
+    let staleCleanupGate: OneShotGate = .init()
+}
+
+// MARK: - OneShotGate
+
+private final class OneShotGate: @unchecked Sendable {
+    func claim() -> Bool {
+        lock.withLock {
+            guard !claimed else {
+                return false
+            }
+
+            claimed = true
+            return true
+        }
+    }
+
+    private let lock: NSLock = .init()
+    private var claimed = false
+}
+
+// MARK: - ModelPoolModelKind
+
+enum ModelPoolModelKind: CaseIterable, Sendable {
+    case language
+    case speechToText
+    case textToSpeech
+    case embedding
+}
+
 // MARK: - ModelPool
 
 /// A pool to manage and cache `ModelContainer` instances with built-in concurrency control.
@@ -78,6 +164,7 @@ public actor ModelPool {
 
     public init() {
         memoryHooks = .live
+        loadOverrides = nil
         // Cache limit and memory management timer are both deferred: the former until MLX is
         // genuinely about to be used (see `ensureCacheLimitConfigured()`), the latter until
         // first model access (see `ensureMemoryManagementStarted()`). Neither may run here --
@@ -87,8 +174,12 @@ public actor ModelPool {
         // construct under `swift test` (no colocated `mlx.metallib` for the test binary).
     }
 
-    init(memoryHooks: ModelPoolMemoryHooks) {
+    init(
+        memoryHooks: ModelPoolMemoryHooks,
+        loadOverrides: ModelPoolLoadOverrides? = nil
+    ) {
         self.memoryHooks = memoryHooks
+        self.loadOverrides = loadOverrides
     }
 
     /// Ensures memory management timer is running (called on first model access)
@@ -114,7 +205,9 @@ public actor ModelPool {
         }
 
         didConfigureCacheLimit = true
-        Self.configureCacheLimit()
+        if loadOverrides == nil {
+            Self.configureCacheLimit()
+        }
     }
 
     /// Whether `configureCacheLimit()` has already run for this pool.
@@ -149,13 +242,16 @@ public actor ModelPool {
 
         runningInferences += 1
         runningModels.insert(modelName)
+        loadingModels.insert(modelName)
         defer {
             runningInferences = max(0, runningInferences - 1)
             runningModels.remove(modelName)
+            loadingModels.remove(modelName)
         }
 
         // Get or load the speech-to-text runner
         let runner = try await getSpeechToTextRunner(modelName: modelName)
+        loadingModels.remove(modelName)
 
         // Execute the operation
         return try await operation(runner)
@@ -176,9 +272,11 @@ public actor ModelPool {
 
         runningInferences += 1
         runningModels.insert(modelKey)
+        loadingModels.insert(modelKey)
         defer {
             runningInferences = max(0, runningInferences - 1)
             runningModels.remove(modelKey)
+            loadingModels.remove(modelKey)
         }
 
         let runner = try await getTTSRunner(
@@ -186,6 +284,7 @@ public actor ModelPool {
             kind: kind,
             repository: repository
         )
+        loadingModels.remove(modelKey)
         return try await operation(runner)
     }
 
@@ -200,11 +299,8 @@ public actor ModelPool {
             return runner
         }
 
-        if let task = sttTasks[modelName] {
-            let runner = try await task.value
-            // Record usage for newly loaded runner
-            modelUsageInfo[modelName]?.recordUsage()
-            return runner
+        if let pending = sttTasks[modelName] {
+            return try await finishSpeechToTextLoad(pending, modelName: modelName)
         }
 
         // Check if we need to free up memory before loading a new model
@@ -213,16 +309,14 @@ public actor ModelPool {
         // About to genuinely touch MLX -- configure the cache limit now, idempotently.
         ensureCacheLimitConfigured()
 
-        let task = Task {
-            let runner = await MainActor.run { SpeechToTextRunner() }
-            try await runner.loadModel(modelName)
-
-            // Update caches back on the actor
-            self.setSpeechToTextRunner(runner, forKey: modelName)
-            return runner
+        let token = makeLoadToken(for: modelName)
+        let task = Task { [self] in
+            let runner = try await loadSpeechToTextRunner(modelName: modelName)
+            return LoadedValueOwner(runner)
         }
-        sttTasks[modelName] = task
-        return try await task.value
+        let pending = PendingModelLoad(token: token, task: task)
+        sttTasks[modelName] = pending
+        return try await finishSpeechToTextLoad(pending, modelName: modelName)
     }
 
     private func setSpeechToTextRunner(_ runner: SpeechToTextRunner, forKey modelName: String) {
@@ -243,10 +337,8 @@ public actor ModelPool {
             return runner
         }
 
-        if let task = ttsTasks[modelKey] {
-            let runner = try await task.value
-            modelUsageInfo[modelKey]?.recordUsage()
-            return runner
+        if let pending = ttsTasks[modelKey] {
+            return try await finishTTSLoad(pending, modelKey: modelKey)
         }
 
         await performMemoryPressureCheck()
@@ -254,16 +346,19 @@ public actor ModelPool {
         // About to genuinely touch MLX -- configure the cache limit now, idempotently.
         ensureCacheLimitConfigured()
 
-        let task = Task {
-            let runner = repository.map { TTSRunner(kind: kind, repository: $0) }
-                ?? TTSRunner(kind: kind)
-            try await runner.loadModel()
-            self.setTTSRunner(runner, forKey: modelKey)
-            return runner
+        let token = makeLoadToken(for: modelKey)
+        let task = Task { [self] in
+            let runner = try await loadTTSRunner(
+                modelKey: modelKey,
+                kind: kind,
+                repository: repository
+            )
+            return LoadedValueOwner(runner)
         }
 
-        ttsTasks[modelKey] = task
-        return try await task.value
+        let pending = PendingModelLoad(token: token, task: task)
+        ttsTasks[modelKey] = pending
+        return try await finishTTSLoad(pending, modelKey: modelKey)
     }
 
     private func setTTSRunner(_ runner: TTSRunner, forKey modelKey: String) {
@@ -296,6 +391,10 @@ public actor ModelPool {
     /// Per-model concurrency control: track which models are currently running inference
     private var runningModels: Set<String> = []
 
+    /// Subset of `runningModels` that has not yet reached its inference operation. Periodic
+    /// teardown may invalidate these pending loads, but must still skip a live operation.
+    private var loadingModels: Set<String> = []
+
     /// Safely run a model operation with concurrency control to prevent MLX heap corruption
     public func run<T: Sendable>(
         modelName: String,
@@ -310,13 +409,16 @@ public actor ModelPool {
 
         runningInferences += 1
         runningModels.insert(modelName)
+        loadingModels.insert(modelName)
         defer {
             runningInferences = max(0, runningInferences - 1)
             runningModels.remove(modelName)
+            loadingModels.remove(modelName)
         }
 
         // Get or load the model container
         let container = try await getContainer(modelName: modelName)
+        loadingModels.remove(modelName)
         let runner = ModelRunner(container: container)
 
         // Execute the operation
@@ -340,20 +442,7 @@ public actor ModelPool {
             runningInferences = max(0, runningInferences - 1)
         }
 
-        // Get or create embedding runner
-        let runner: EmbeddingRunner
-        if let existingRunner = embeddingRunnerCache[modelName] {
-            runner = existingRunner
-        }
-        else {
-            // About to genuinely touch MLX -- configure the cache limit now, idempotently.
-            ensureCacheLimitConfigured()
-
-            // Load the embedding model
-            let container = try await loadEmbeddingModelContainer(modelName: modelName)
-            runner = EmbeddingRunner(container: container)
-            embeddingRunnerCache[modelName] = runner
-        }
+        let runner = try await getOrLoadEmbeddingRunner(modelName: modelName)
 
         // Execute the operation
         return try await operation(runner)
@@ -370,56 +459,32 @@ public actor ModelPool {
             return container
         }
 
-        if let task = tasks[modelName] {
-            let container = try await task.value
-            modelUsageInfo[modelName]?.recordUsage()
-            return container
+        if let pending = tasks[modelName] {
+            return try await finishLanguageLoad(pending, modelName: modelName)
         }
 
         // Check if we need to free up memory before loading a new model
         await performMemoryPressureCheck()
 
-        let task = Task {
-            defer { tasks[modelName] = nil }
-
-            if let isVLM = modelTypeCache[modelName] {
-                guard ModelPaths.modelExistsLocally(modelName) else {
-                    modelTypeCache.removeValue(forKey: modelName)
-                    throw ModelPoolError.modelNotFoundLocally(modelName)
-                }
-
-                let container = try await loadModelContainer(
-                    modelName: modelName,
-                    isVLM: isVLM
-                )
-
-                cache[modelName] = container
-                modelUsageInfo[modelName] = ModelUsageInfo()
-                return container
-            }
-
-            guard ModelPaths.modelExistsLocally(modelName) else {
-                throw ModelPoolError.modelNotFoundLocally(modelName)
-            }
-
-            // Determine if this is a VLM model using unified detection logic (registry priority)
-            let isVLMModel = determineIfVLMModel(modelName: modelName)
-
-            // Cache the model type for future fast path
-            modelTypeCache[modelName] = isVLMModel
-
-            // Load container using unified logic
-            let container = try await loadModelContainer(
-                modelName: modelName,
-                isVLM: isVLMModel
-            )
-
-            cache[modelName] = container
-            modelUsageInfo[modelName] = ModelUsageInfo()
-            return container
+        guard modelExistsLocally(modelName) else {
+            modelTypeCache.removeValue(forKey: modelName)
+            throw ModelPoolError.modelNotFoundLocally(modelName)
         }
-        tasks[modelName] = task
-        return try await task.value
+
+        let isVLM = modelTypeCache[modelName] ?? determineModelType(modelName)
+        modelTypeCache[modelName] = isVLM
+
+        let token = makeLoadToken(for: modelName)
+        let task = Task { [self] in
+            let container = try await loadLanguageContainer(
+                modelName: modelName,
+                isVLM: isVLM
+            )
+            return LoadedValueOwner(container)
+        }
+        let pending = PendingModelLoad(token: token, task: task)
+        tasks[modelName] = pending
+        return try await finishLanguageLoad(pending, modelName: modelName)
     }
 
     /// Gets or loads an embedding model runner for the given model name.
@@ -437,16 +502,21 @@ public actor ModelPool {
         let memoryBefore = memoryHooks.activeMemory()
         let evictedCount = cache.count
 
+        invalidateAllLoads()
+
         // Cancel loading work before dropping the task dictionaries. Do not snapshot their
         // values into local arrays: completed Task values can retain loaded model containers.
-        for task in tasks.values {
-            task.cancel()
+        for pending in tasks.values {
+            pending.task.cancel()
         }
-        for task in sttTasks.values {
-            task.cancel()
+        for pending in embeddingTasks.values {
+            pending.task.cancel()
         }
-        for task in ttsTasks.values {
-            task.cancel()
+        for pending in sttTasks.values {
+            pending.task.cancel()
+        }
+        for pending in ttsTasks.values {
+            pending.task.cancel()
         }
 
         // Release every owner before asking MLX to return unused allocations. The previous
@@ -455,6 +525,7 @@ public actor ModelPool {
         // were still strongly retained; after the Task released them, no second clear occurred.
         cache.removeAll()
         tasks.removeAll()
+        embeddingTasks.removeAll()
         sttTasks.removeAll()
         ttsTasks.removeAll()
         modelTypeCache.removeAll()
@@ -478,6 +549,8 @@ public actor ModelPool {
 
     /// Removes a specific model from the cache and cancels its loading task if active.
     public func remove(modelName: String) {
+        invalidateLoads(for: modelName)
+
         cache.removeValue(forKey: modelName)
         modelTypeCache.removeValue(forKey: modelName) // Clear type cache for this model
         embeddingRunnerCache.removeValue(forKey: modelName) // Clear embedding cache for this model
@@ -486,16 +559,20 @@ public actor ModelPool {
         ttsRunnerCache.removeValue(forKey: modelName) // Clear TTS cache for this model
         modelUsageInfo.removeValue(forKey: modelName) // Clear usage tracking for this model
 
-        if let task = tasks.removeValue(forKey: modelName) {
-            task.cancel()
+        if let pending = tasks.removeValue(forKey: modelName) {
+            pending.task.cancel()
         }
 
-        if let sttTask = sttTasks.removeValue(forKey: modelName) {
-            sttTask.cancel()
+        if let pending = embeddingTasks.removeValue(forKey: modelName) {
+            pending.task.cancel()
         }
 
-        if let ttsTask = ttsTasks.removeValue(forKey: modelName) {
-            ttsTask.cancel()
+        if let pending = sttTasks.removeValue(forKey: modelName) {
+            pending.task.cancel()
+        }
+
+        if let pending = ttsTasks.removeValue(forKey: modelName) {
+            pending.task.cancel()
         }
 
         // All strong owners have been removed before MLX cleanup runs.
@@ -510,17 +587,50 @@ public actor ModelPool {
         func evictModelForTesting(modelName: String) async {
             await evictModel(modelName: modelName, reason: "test")
         }
+
+        func isCachedForTesting(_ kind: ModelPoolModelKind, modelName: String) -> Bool {
+            switch kind {
+            case .language:
+                cache[modelName] != nil
+            case .speechToText:
+                sttRunnerCache[modelName] != nil
+            case .textToSpeech:
+                ttsRunnerCache[modelName] != nil
+            case .embedding:
+                embeddingRunnerCache[modelName] != nil
+            }
+        }
+
+        func hasPendingLoadForTesting(_ kind: ModelPoolModelKind, modelName: String) -> Bool {
+            switch kind {
+            case .language:
+                tasks[modelName] != nil
+            case .speechToText:
+                sttTasks[modelName] != nil
+            case .textToSpeech:
+                ttsTasks[modelName] != nil
+            case .embedding:
+                embeddingTasks[modelName] != nil
+            }
+        }
     #endif
 
     // MARK: Private
 
     private var cache: [String: MLXLMCommon.ModelContainer] = .init()
-    private var tasks: [String: Task<MLXLMCommon.ModelContainer, Error>] = .init()
+    private var tasks: [String: PendingModelLoad<MLXLMCommon.ModelContainer>] = .init()
     private var embeddingRunnerCache: [String: EmbeddingRunner] = .init()
+    private var embeddingTasks: [String: PendingModelLoad<EmbeddingRunner>] = .init()
     private var sttRunnerCache: [String: SpeechToTextRunner] = .init()
-    private var sttTasks: [String: Task<SpeechToTextRunner, Error>] = .init()
+    private var sttTasks: [String: PendingModelLoad<SpeechToTextRunner>] = .init()
     private var ttsRunnerCache: [String: TTSRunner] = .init()
-    private var ttsTasks: [String: Task<TTSRunner, Error>] = .init()
+    private var ttsTasks: [String: PendingModelLoad<TTSRunner>] = .init()
+
+    /// Every teardown changes either the global generation or the named model generation.
+    /// A load may ignore cooperative cancellation, but it cannot commit across this boundary.
+    private var globalLoadGeneration: UInt64 = 0
+    private var modelLoadGenerations: [String: UInt64] = .init()
+    private var nextLoadSequence: UInt64 = 0
 
     /// Memory management tracking
     private var modelUsageInfo: [String: ModelUsageInfo] = .init()
@@ -528,6 +638,263 @@ public actor ModelPool {
     private var modelTypeCache: [String: Bool] = .init()
     private var vlmRegistryCache: [String: MLXLMCommon.ModelConfiguration]?
     private let memoryHooks: ModelPoolMemoryHooks
+    private let loadOverrides: ModelPoolLoadOverrides?
+
+    private func makeLoadToken(for modelName: String) -> ModelLoadToken {
+        nextLoadSequence &+= 1
+        return ModelLoadToken(
+            globalGeneration: globalLoadGeneration,
+            modelGeneration: modelLoadGenerations[modelName, default: 0],
+            sequence: nextLoadSequence
+        )
+    }
+
+    private func invalidateAllLoads() {
+        globalLoadGeneration &+= 1
+        modelLoadGenerations.removeAll()
+    }
+
+    private func invalidateLoads(for modelName: String) {
+        modelLoadGenerations[modelName, default: 0] &+= 1
+    }
+
+    private func isCurrent(_ token: ModelLoadToken, modelName: String) -> Bool {
+        token.globalGeneration == globalLoadGeneration
+            && token.modelGeneration == modelLoadGenerations[modelName, default: 0]
+    }
+
+    private func resolvedLoadedValue<Value: AnyObject>(
+        _ owner: LoadedValueOwner<Value>,
+        token: ModelLoadToken,
+        modelName: String,
+        staleCleanupGate: OneShotGate
+    ) throws -> Value {
+        guard isCurrent(token, modelName: modelName) else {
+            // clear/remove/evict already ran one cleanup while this owner was still live. Drop
+            // the Task-retained value first, then run the bounded follow-up cleanup exactly once.
+            owner.release()
+            if staleCleanupGate.claim() {
+                memoryHooks.clearCache()
+            }
+            throw CancellationError()
+        }
+        guard let value = owner.retainedValue() else {
+            throw CancellationError()
+        }
+
+        return value
+    }
+
+    private func finishLanguageLoad(
+        _ pending: PendingModelLoad<MLXLMCommon.ModelContainer>,
+        modelName: String
+    ) async throws -> MLXLMCommon.ModelContainer {
+        try await finishLoad(
+            pending,
+            modelName: modelName,
+            currentPendingToken: { tasks[modelName]?.token },
+            removePending: { tasks.removeValue(forKey: modelName) },
+            cachedValue: { cache[modelName] },
+            storeLoaded: { loaded in
+                cache[modelName] = loaded
+                modelUsageInfo[modelName] = ModelUsageInfo()
+            },
+            recordCachedUse: {
+                modelUsageInfo[modelName]?.recordUsage()
+            }
+        )
+    }
+
+    private func finishSpeechToTextLoad(
+        _ pending: PendingModelLoad<SpeechToTextRunner>,
+        modelName: String
+    ) async throws -> SpeechToTextRunner {
+        try await finishLoad(
+            pending,
+            modelName: modelName,
+            currentPendingToken: { sttTasks[modelName]?.token },
+            removePending: { sttTasks.removeValue(forKey: modelName) },
+            cachedValue: { sttRunnerCache[modelName] },
+            storeLoaded: { loaded in
+                setSpeechToTextRunner(loaded, forKey: modelName)
+            },
+            recordCachedUse: {
+                modelUsageInfo[modelName]?.recordUsage()
+            }
+        )
+    }
+
+    private func finishTTSLoad(
+        _ pending: PendingModelLoad<TTSRunner>,
+        modelKey: String
+    ) async throws -> TTSRunner {
+        try await finishLoad(
+            pending,
+            modelName: modelKey,
+            currentPendingToken: { ttsTasks[modelKey]?.token },
+            removePending: { ttsTasks.removeValue(forKey: modelKey) },
+            cachedValue: { ttsRunnerCache[modelKey] },
+            storeLoaded: { loaded in
+                setTTSRunner(loaded, forKey: modelKey)
+            },
+            recordCachedUse: {
+                modelUsageInfo[modelKey]?.recordUsage()
+            }
+        )
+    }
+
+    private func getOrLoadEmbeddingRunner(modelName: String) async throws -> EmbeddingRunner {
+        if let runner = embeddingRunnerCache[modelName] {
+            return runner
+        }
+
+        if let pending = embeddingTasks[modelName] {
+            return try await finishEmbeddingLoad(pending, modelName: modelName)
+        }
+
+        ensureCacheLimitConfigured()
+        let token = makeLoadToken(for: modelName)
+        let task = Task { [self] in
+            let runner = try await loadEmbeddingRunner(modelName: modelName)
+            return LoadedValueOwner(runner)
+        }
+        let pending = PendingModelLoad(token: token, task: task)
+        embeddingTasks[modelName] = pending
+        return try await finishEmbeddingLoad(pending, modelName: modelName)
+    }
+
+    private func finishEmbeddingLoad(
+        _ pending: PendingModelLoad<EmbeddingRunner>,
+        modelName: String
+    ) async throws -> EmbeddingRunner {
+        try await finishLoad(
+            pending,
+            modelName: modelName,
+            currentPendingToken: { embeddingTasks[modelName]?.token },
+            removePending: { embeddingTasks.removeValue(forKey: modelName) },
+            cachedValue: { embeddingRunnerCache[modelName] },
+            storeLoaded: { embeddingRunnerCache[modelName] = $0 },
+            recordCachedUse: {}
+        )
+    }
+
+    private func finishLoad<Value: AnyObject>(
+        _ pending: PendingModelLoad<Value>,
+        modelName: String,
+        currentPendingToken: () -> ModelLoadToken?,
+        removePending: () -> Void,
+        cachedValue: () -> Value?,
+        storeLoaded: (Value) -> Void,
+        recordCachedUse: () -> Void
+    ) async throws -> Value {
+        do {
+            let owner = try await pending.task.value
+            let loaded = try resolvedLoadedValue(
+                owner,
+                token: pending.token,
+                modelName: modelName,
+                staleCleanupGate: pending.staleCleanupGate
+            )
+
+            let value: Value
+            if let existing = cachedValue() {
+                recordCachedUse()
+                value = existing
+            }
+            else {
+                storeLoaded(loaded)
+                value = loaded
+            }
+            owner.release()
+
+            if currentPendingToken() == pending.token {
+                removePending()
+            }
+            return value
+        }
+        catch {
+            let wasInvalidated = !isCurrent(pending.token, modelName: modelName)
+            cleanupAfterStaleFailure(pending, modelName: modelName)
+            if currentPendingToken() == pending.token {
+                removePending()
+            }
+            if wasInvalidated {
+                throw CancellationError()
+            }
+            throw error
+        }
+    }
+
+    private func modelExistsLocally(_ modelName: String) -> Bool {
+        loadOverrides?.modelExistsLocally(modelName)
+            ?? ModelPaths.modelExistsLocally(modelName)
+    }
+
+    private func cleanupAfterStaleFailure(
+        _ pending: PendingModelLoad<some AnyObject>,
+        modelName: String
+    ) {
+        guard !isCurrent(pending.token, modelName: modelName),
+              pending.staleCleanupGate.claim()
+        else {
+            return
+        }
+
+        memoryHooks.clearCache()
+    }
+
+    private func determineModelType(_ modelName: String) -> Bool {
+        loadOverrides?.determineIsVLM(modelName)
+            ?? determineIfVLMModel(modelName: modelName)
+    }
+
+    private func loadLanguageContainer(
+        modelName: String,
+        isVLM: Bool
+    ) async throws -> MLXLMCommon.ModelContainer {
+        if let load = loadOverrides?.loadLanguage {
+            return try await load(modelName, isVLM)
+        }
+        return try await loadModelContainer(modelName: modelName, isVLM: isVLM)
+    }
+
+    private func loadSpeechToTextRunner(modelName: String) async throws -> SpeechToTextRunner {
+        if let load = loadOverrides?.loadSpeechToText {
+            return try await load(modelName)
+        }
+        let runner = await MainActor.run { SpeechToTextRunner() }
+        try await runner.loadModel(modelName)
+        return runner
+    }
+
+    private func loadTTSRunner(
+        modelKey: String,
+        kind: TTSModelKind,
+        repository: String?
+    ) async throws -> TTSRunner {
+        if let load = loadOverrides?.loadTTS {
+            return try await load(modelKey, kind, repository)
+        }
+        let runner = repository.map { TTSRunner(kind: kind, repository: $0) }
+            ?? TTSRunner(kind: kind)
+        try await runner.loadModel()
+        return runner
+    }
+
+    private func loadEmbeddingRunner(modelName: String) async throws -> EmbeddingRunner {
+        if let load = loadOverrides?.loadEmbedding {
+            return try await load(modelName)
+        }
+        let container = try await loadEmbeddingModelContainer(modelName: modelName)
+        return EmbeddingRunner(container: container)
+    }
+
+    private func hasPendingLoad(for modelName: String) -> Bool {
+        tasks[modelName] != nil
+            || embeddingTasks[modelName] != nil
+            || sttTasks[modelName] != nil
+            || ttsTasks[modelName] != nil
+    }
 
     /// Unified VLM detection logic with registry priority
     private func determineIfVLMModel(modelName: String) -> Bool {
@@ -963,13 +1330,17 @@ public actor ModelPool {
 
     /// Evicts a specific model from the cache
     private func evictModel(modelName: String, reason: String) async {
-        // Double-check the model is not currently running
-        guard !runningModels.contains(modelName) else {
+        // A pending load has not reached inference yet and is safe to invalidate. Continue to
+        // protect a genuinely running cached model from periodic eviction.
+        let isPendingLoad = loadingModels.contains(modelName) && hasPendingLoad(for: modelName)
+        guard !runningModels.contains(modelName) || isPendingLoad else {
             NSLog("SwamaKit.ModelPool: Skipping eviction of \(modelName) - currently running")
             return
         }
 
         let memoryBefore = memoryHooks.activeMemory()
+
+        invalidateLoads(for: modelName)
 
         // Remove from all caches to release strong references
         cache.removeValue(forKey: modelName)
@@ -981,17 +1352,21 @@ public actor ModelPool {
         modelUsageInfo.removeValue(forKey: modelName)
 
         // Cancel loading task if active
-        if let task = tasks.removeValue(forKey: modelName) {
-            task.cancel()
+        if let pending = tasks.removeValue(forKey: modelName) {
+            pending.task.cancel()
+        }
+
+        if let pending = embeddingTasks.removeValue(forKey: modelName) {
+            pending.task.cancel()
         }
 
         // Cancel speech-to-text loading task if active
-        if let sttTask = sttTasks.removeValue(forKey: modelName) {
-            sttTask.cancel()
+        if let pending = sttTasks.removeValue(forKey: modelName) {
+            pending.task.cancel()
         }
 
-        if let ttsTask = ttsTasks.removeValue(forKey: modelName) {
-            ttsTask.cancel()
+        if let pending = ttsTasks.removeValue(forKey: modelName) {
+            pending.task.cancel()
         }
 
         // All strong owners have been removed before MLX cleanup runs.

--- a/swama/Tests/SwamaKitTests/ModelPoolInFlightTeardownTests.swift
+++ b/swama/Tests/SwamaKitTests/ModelPoolInFlightTeardownTests.swift
@@ -1,0 +1,752 @@
+import Foundation
+import MLX
+import MLXEmbedders
+@preconcurrency import MLXLMCommon
+import MLXNN
+@testable import SwamaKit
+import Testing
+
+// MARK: - ModelPoolInFlightTeardownTests
+
+@Suite("ModelPool in-flight load teardown", .serialized)
+struct ModelPoolInFlightTeardownTests {
+    @Test
+    func newerEmbeddingLoadSurvivesOlderGenerationFinishingLate() async throws {
+        let modelName = "overlapping-embedding-generations"
+        var first: EmbeddingRunner? = makeLifetimeEmbeddingRunner()
+        let loader = try ControlledLoader(
+            first: #require(first),
+            next: makeLifetimeEmbeddingRunner(),
+            blockSecond: true
+        )
+        let witness = CleanupWitness(first)
+        first = nil
+        let pool = makePool(witness: witness, embeddingLoader: loader)
+
+        let staleRequest = Task<Result<String, Error>, Never> {
+            do {
+                return try await .success(pool.runEmbeddingWithConcurrencyControl(modelName: modelName) { _ in
+                    "stale"
+                })
+            }
+            catch {
+                return .failure(error)
+            }
+        }
+        await loader.waitUntilFirstLoadEntered()
+        await pool.clearCache()
+
+        let freshRequest = Task<Result<String, Error>, Never> {
+            do {
+                return try await .success(pool.runEmbeddingWithConcurrencyControl(modelName: modelName) { _ in
+                    "fresh"
+                })
+            }
+            catch {
+                return .failure(error)
+            }
+        }
+        await loader.waitUntilSecondLoadEntered()
+
+        await loader.releaseFirstLoad()
+        switch await staleRequest.value {
+        case .success:
+            Issue.record("the older embedding generation unexpectedly reached its operation")
+        case let .failure(error):
+            #expect(error is CancellationError)
+        }
+        #expect(await pool.hasPendingLoadForTesting(.embedding, modelName: modelName))
+
+        await loader.releaseSecondLoad()
+        switch await freshRequest.value {
+        case let .success(value):
+            #expect(value == "fresh")
+        case let .failure(error):
+            Issue.record("newer embedding generation unexpectedly failed: \(error)")
+        }
+        #expect(await pool.isCachedForTesting(.embedding, modelName: modelName))
+        #expect(await !(pool.hasPendingLoadForTesting(.embedding, modelName: modelName)))
+        #expect(witness.cleanupReleaseStates == [false, true])
+    }
+
+    @Test
+    func pendingLoadWithSameNameDoesNotLetEvictionInterruptALiveOperation() async throws {
+        let modelName = "shared-modality-key"
+        let languageLoader = ControlledLoader(
+            first: makeLifetimeTestContainer(),
+            next: makeLifetimeTestContainer()
+        )
+        await languageLoader.releaseFirstLoad()
+        let embeddingLoader = ControlledLoader(
+            first: makeLifetimeEmbeddingRunner(),
+            next: makeLifetimeEmbeddingRunner()
+        )
+        let witness = CleanupWitness(nil)
+        let pool = makePool(
+            witness: witness,
+            languageLoader: languageLoader,
+            embeddingLoader: embeddingLoader
+        )
+        let operationBarrier = OperationBarrier()
+
+        let languageRequest = Task<Result<String, Error>, Never> {
+            do {
+                return try await .success(pool.run(modelName: modelName) { _ in
+                    await operationBarrier.enterAndWait()
+                    return "language"
+                })
+            }
+            catch {
+                return .failure(error)
+            }
+        }
+        await operationBarrier.waitUntilEntered()
+
+        let embeddingRequest = Task<Result<String, Error>, Never> {
+            do {
+                return try await .success(pool.runEmbeddingWithConcurrencyControl(modelName: modelName) { _ in
+                    "embedding"
+                })
+            }
+            catch {
+                return .failure(error)
+            }
+        }
+        await embeddingLoader.waitUntilFirstLoadEntered()
+
+        await pool.evictModelForTesting(modelName: modelName)
+        #expect(await pool.isCachedForTesting(.language, modelName: modelName))
+        #expect(await pool.hasPendingLoadForTesting(.embedding, modelName: modelName))
+        #expect(witness.cleanupReleaseStates.isEmpty)
+
+        await embeddingLoader.releaseFirstLoad()
+        switch await embeddingRequest.value {
+        case let .success(value):
+            #expect(value == "embedding")
+        case let .failure(error):
+            Issue.record("pending embedding load unexpectedly failed: \(error)")
+        }
+
+        await operationBarrier.release()
+        switch await languageRequest.value {
+        case let .success(value):
+            #expect(value == "language")
+        case let .failure(error):
+            Issue.record("active language operation unexpectedly failed: \(error)")
+        }
+    }
+
+    @Test
+    func periodicEvictionStillSkipsALiveInferenceOperation() async throws {
+        let modelName = "active-language-operation"
+        let loader = ControlledLoader(
+            first: makeLifetimeTestContainer(),
+            next: makeLifetimeTestContainer()
+        )
+        await loader.releaseFirstLoad()
+        let witness = CleanupWitness(nil)
+        let pool = makePool(witness: witness, languageLoader: loader)
+        let operationBarrier = OperationBarrier()
+
+        let request = Task<Result<String, Error>, Never> {
+            do {
+                return try await .success(pool.run(modelName: modelName) { _ in
+                    await operationBarrier.enterAndWait()
+                    return "finished"
+                })
+            }
+            catch {
+                return .failure(error)
+            }
+        }
+
+        await operationBarrier.waitUntilEntered()
+        #expect(await pool.isCachedForTesting(.language, modelName: modelName))
+        await pool.evictModelForTesting(modelName: modelName)
+        #expect(await pool.isCachedForTesting(.language, modelName: modelName))
+        #expect(witness.cleanupReleaseStates.isEmpty)
+
+        await operationBarrier.release()
+        switch await request.value {
+        case let .success(value):
+            #expect(value == "finished")
+        case let .failure(error):
+            Issue.record("active operation unexpectedly failed: \(error)")
+        }
+    }
+
+    @Test
+    func cancelledLoadFailureStillRunsCleanupAfterItsPartialOwnerReleases() async throws {
+        let modelName = "in-flight-failing-language"
+        var partialOwner: PartialLoadOwner? = PartialLoadOwner()
+        let loader = try FailingControlledLoader(partialOwner: #require(partialOwner))
+        let witness = CleanupWitness(partialOwner)
+        partialOwner = nil
+        let pool = ModelPool(
+            memoryHooks: .init(
+                activeMemory: { 0 },
+                clearCache: { witness.recordCleanup() }
+            ),
+            loadOverrides: .init(
+                modelExistsLocally: { _ in true },
+                determineIsVLM: { _ in false },
+                loadLanguage: { _, _ in try await loader.load() },
+                loadSpeechToText: { _ in fatalError("unexpected STT load") },
+                loadTTS: { _, _, _ in fatalError("unexpected TTS load") },
+                loadEmbedding: { _ in fatalError("unexpected embedding load") }
+            )
+        )
+
+        let request = Task<Result<String, Error>, Never> {
+            do {
+                return try await .success(pool.run(modelName: modelName) { _ in "unexpected" })
+            }
+            catch {
+                return .failure(error)
+            }
+        }
+
+        await loader.waitUntilEntered()
+        await pool.clearCache()
+        #expect(await loader.isBlocked)
+        await loader.releaseAndFail()
+
+        switch await request.value {
+        case .success:
+            Issue.record("an invalidated failed load must not reach its operation")
+        case let .failure(error):
+            #expect(error is CancellationError)
+        }
+        #expect(witness.cleanupReleaseStates == [false, true])
+    }
+
+    @Test(arguments: TeardownPath.allCases)
+    func languageLoadCannotResurrectAfterTeardown(_ path: TeardownPath) async throws {
+        let modelName = "in-flight-language-\(path)"
+        var first: MLXLMCommon.ModelContainer? = makeLifetimeTestContainer()
+        let loader = try ControlledLoader(
+            first: #require(first),
+            next: makeLifetimeTestContainer()
+        )
+        let witness = CleanupWitness(first)
+        first = nil
+        let pool = makePool(witness: witness, languageLoader: loader)
+        let operationCount = LockedCounter()
+
+        let request = Task<Result<String, Error>, Never> {
+            do {
+                return try await .success(pool.run(modelName: modelName) { _ in
+                    operationCount.increment()
+                    return "stale"
+                })
+            }
+            catch {
+                return .failure(error)
+            }
+        }
+
+        await loader.waitUntilFirstLoadEntered()
+        #expect(await pool.hasPendingLoadForTesting(.language, modelName: modelName))
+        await apply(path, to: pool, modelName: modelName)
+        #expect(await loader.isFirstLoadBlocked)
+        await loader.releaseFirstLoad()
+
+        await assertStaleLoadWasDiscarded(
+            request,
+            pool: pool,
+            kind: .language,
+            modelName: modelName,
+            operationCount: operationCount,
+            witness: witness
+        )
+
+        let fresh = try await pool.run(modelName: modelName) { _ in "fresh" }
+        #expect(fresh == "fresh")
+        #expect(await pool.isCachedForTesting(.language, modelName: modelName))
+    }
+
+    @Test(arguments: TeardownPath.allCases)
+    func speechToTextLoadCannotResurrectAfterTeardown(_ path: TeardownPath) async throws {
+        let modelName = "in-flight-stt-\(path)"
+        var first: SpeechToTextRunner? = await MainActor.run { SpeechToTextRunner() }
+        let next = await MainActor.run { SpeechToTextRunner() }
+        let loader = try ControlledLoader(first: #require(first), next: next)
+        let witness = CleanupWitness(first)
+        first = nil
+        let pool = makePool(witness: witness, speechToTextLoader: loader)
+        let operationCount = LockedCounter()
+
+        let request = Task<Result<String, Error>, Never> {
+            do {
+                return try await .success(pool.runSpeechToText(modelName: modelName) { _ in
+                    operationCount.increment()
+                    return "stale"
+                })
+            }
+            catch {
+                return .failure(error)
+            }
+        }
+
+        await loader.waitUntilFirstLoadEntered()
+        #expect(await pool.hasPendingLoadForTesting(.speechToText, modelName: modelName))
+        await apply(path, to: pool, modelName: modelName)
+        #expect(await loader.isFirstLoadBlocked)
+        await loader.releaseFirstLoad()
+
+        await assertStaleLoadWasDiscarded(
+            request,
+            pool: pool,
+            kind: .speechToText,
+            modelName: modelName,
+            operationCount: operationCount,
+            witness: witness
+        )
+
+        let fresh = try await pool.runSpeechToText(modelName: modelName) { _ in "fresh" }
+        #expect(fresh == "fresh")
+        #expect(await pool.isCachedForTesting(.speechToText, modelName: modelName))
+    }
+
+    @Test(arguments: TeardownPath.allCases)
+    func textToSpeechLoadCannotResurrectAfterTeardown(_ path: TeardownPath) async throws {
+        let modelName = "in-flight-tts-\(path)"
+        var first: TTSRunner? = TTSRunner(kind: .orpheus)
+        let loader = try ControlledLoader(
+            first: #require(first),
+            next: TTSRunner(kind: .orpheus)
+        )
+        let witness = CleanupWitness(first)
+        first = nil
+        let pool = makePool(witness: witness, textToSpeechLoader: loader)
+        let operationCount = LockedCounter()
+
+        let request = Task<Result<String, Error>, Never> {
+            do {
+                return try await .success(pool.runTTS(modelKey: modelName, kind: .orpheus) { _ in
+                    operationCount.increment()
+                    return "stale"
+                })
+            }
+            catch {
+                return .failure(error)
+            }
+        }
+
+        await loader.waitUntilFirstLoadEntered()
+        #expect(await pool.hasPendingLoadForTesting(.textToSpeech, modelName: modelName))
+        await apply(path, to: pool, modelName: modelName)
+        #expect(await loader.isFirstLoadBlocked)
+        await loader.releaseFirstLoad()
+
+        await assertStaleLoadWasDiscarded(
+            request,
+            pool: pool,
+            kind: .textToSpeech,
+            modelName: modelName,
+            operationCount: operationCount,
+            witness: witness
+        )
+
+        let fresh = try await pool.runTTS(modelKey: modelName, kind: .orpheus) { _ in "fresh" }
+        #expect(fresh == "fresh")
+        #expect(await pool.isCachedForTesting(.textToSpeech, modelName: modelName))
+    }
+
+    @Test(arguments: TeardownPath.allCases)
+    func embeddingLoadCannotResurrectAfterTeardown(_ path: TeardownPath) async throws {
+        let modelName = "in-flight-embedding-\(path)"
+        var first: EmbeddingRunner? = makeLifetimeEmbeddingRunner()
+        let loader = try ControlledLoader(
+            first: #require(first),
+            next: makeLifetimeEmbeddingRunner()
+        )
+        let witness = CleanupWitness(first)
+        first = nil
+        let pool = makePool(witness: witness, embeddingLoader: loader)
+        let operationCount = LockedCounter()
+
+        let request = Task<Result<String, Error>, Never> {
+            do {
+                return try await .success(pool.runEmbeddingWithConcurrencyControl(modelName: modelName) { _ in
+                    operationCount.increment()
+                    return "stale"
+                })
+            }
+            catch {
+                return .failure(error)
+            }
+        }
+
+        await loader.waitUntilFirstLoadEntered()
+        #expect(await pool.hasPendingLoadForTesting(.embedding, modelName: modelName))
+        await apply(path, to: pool, modelName: modelName)
+        #expect(await loader.isFirstLoadBlocked)
+        await loader.releaseFirstLoad()
+
+        await assertStaleLoadWasDiscarded(
+            request,
+            pool: pool,
+            kind: .embedding,
+            modelName: modelName,
+            operationCount: operationCount,
+            witness: witness
+        )
+
+        let fresh = try await pool.runEmbeddingWithConcurrencyControl(modelName: modelName) { _ in "fresh" }
+        #expect(fresh == "fresh")
+        #expect(await pool.isCachedForTesting(.embedding, modelName: modelName))
+    }
+
+    private func makePool(
+        witness: CleanupWitness,
+        languageLoader: ControlledLoader<MLXLMCommon.ModelContainer>? = nil,
+        speechToTextLoader: ControlledLoader<SpeechToTextRunner>? = nil,
+        textToSpeechLoader: ControlledLoader<TTSRunner>? = nil,
+        embeddingLoader: ControlledLoader<EmbeddingRunner>? = nil
+    ) -> ModelPool {
+        ModelPool(
+            memoryHooks: .init(
+                activeMemory: { 0 },
+                clearCache: { witness.recordCleanup() }
+            ),
+            loadOverrides: .init(
+                modelExistsLocally: { _ in true },
+                determineIsVLM: { _ in false },
+                loadLanguage: { _, _ in
+                    guard let languageLoader else {
+                        fatalError("unexpected language load")
+                    }
+
+                    return await languageLoader.load()
+                },
+                loadSpeechToText: { _ in
+                    guard let speechToTextLoader else {
+                        fatalError("unexpected STT load")
+                    }
+
+                    return await speechToTextLoader.load()
+                },
+                loadTTS: { _, _, _ in
+                    guard let textToSpeechLoader else {
+                        fatalError("unexpected TTS load")
+                    }
+
+                    return await textToSpeechLoader.load()
+                },
+                loadEmbedding: { _ in
+                    guard let embeddingLoader else {
+                        fatalError("unexpected embedding load")
+                    }
+
+                    return await embeddingLoader.load()
+                }
+            )
+        )
+    }
+
+    private func apply(_ path: TeardownPath, to pool: ModelPool, modelName: String) async {
+        switch path {
+        case .clear:
+            await pool.clearCache()
+        case .remove:
+            await pool.remove(modelName: modelName)
+        case .periodicEviction:
+            await pool.evictModelForTesting(modelName: modelName)
+        }
+    }
+
+    private func assertStaleLoadWasDiscarded(
+        _ request: Task<Result<String, Error>, Never>,
+        pool: ModelPool,
+        kind: ModelPoolModelKind,
+        modelName: String,
+        operationCount: LockedCounter,
+        witness: CleanupWitness
+    ) async {
+        switch await request.value {
+        case .success:
+            Issue.record("a load invalidated by teardown must not reach its operation")
+        case let .failure(error):
+            #expect(error is CancellationError, "expected CancellationError, got \(error)")
+        }
+
+        #expect(operationCount.value == 0)
+        #expect(await !(pool.isCachedForTesting(kind, modelName: modelName)))
+        #expect(await !(pool.hasPendingLoadForTesting(kind, modelName: modelName)))
+        #expect(witness.cleanupReleaseStates == [false, true])
+    }
+}
+
+// MARK: - TeardownPath
+
+enum TeardownPath: String, CaseIterable, CustomStringConvertible, Sendable {
+    case clear
+    case remove
+    case periodicEviction
+
+    var description: String { rawValue }
+}
+
+// MARK: - ControlledLoader
+
+private actor ControlledLoader<Value: AnyObject & Sendable> {
+    init(first: Value, next: Value, blockSecond: Bool = false) {
+        values = [first, next]
+        self.blockSecond = blockSecond
+    }
+
+    func load() async -> Value {
+        loadCount += 1
+        precondition(!values.isEmpty, "test loader exhausted")
+        let value = values.removeFirst()
+        if loadCount == 1 {
+            firstLoadEntered = true
+            enteredWaiters.forEach { $0.resume() }
+            enteredWaiters.removeAll()
+
+            if !firstLoadReleased {
+                await withCheckedContinuation { continuation in
+                    releaseWaiter = continuation
+                }
+            }
+        }
+        else if loadCount == 2, blockSecond {
+            secondLoadEntered = true
+            secondEnteredWaiters.forEach { $0.resume() }
+            secondEnteredWaiters.removeAll()
+
+            if !secondLoadReleased {
+                await withCheckedContinuation { continuation in
+                    secondReleaseWaiter = continuation
+                }
+            }
+        }
+
+        return value
+    }
+
+    func waitUntilFirstLoadEntered() async {
+        guard !firstLoadEntered else {
+            return
+        }
+
+        await withCheckedContinuation { continuation in
+            enteredWaiters.append(continuation)
+        }
+    }
+
+    func releaseFirstLoad() {
+        firstLoadReleased = true
+        releaseWaiter?.resume()
+        releaseWaiter = nil
+    }
+
+    func waitUntilSecondLoadEntered() async {
+        guard !secondLoadEntered else {
+            return
+        }
+
+        await withCheckedContinuation { continuation in
+            secondEnteredWaiters.append(continuation)
+        }
+    }
+
+    func releaseSecondLoad() {
+        secondLoadReleased = true
+        secondReleaseWaiter?.resume()
+        secondReleaseWaiter = nil
+    }
+
+    var isFirstLoadBlocked: Bool {
+        firstLoadEntered && !firstLoadReleased
+    }
+
+    private var values: [Value]
+    private let blockSecond: Bool
+    private var loadCount = 0
+    private var firstLoadEntered = false
+    private var firstLoadReleased = false
+    private var enteredWaiters: [CheckedContinuation<Void, Never>] = []
+    private var releaseWaiter: CheckedContinuation<Void, Never>?
+    private var secondLoadEntered = false
+    private var secondLoadReleased = false
+    private var secondEnteredWaiters: [CheckedContinuation<Void, Never>] = []
+    private var secondReleaseWaiter: CheckedContinuation<Void, Never>?
+}
+
+// MARK: - FailingControlledLoader
+
+private actor FailingControlledLoader {
+    init(partialOwner: PartialLoadOwner) {
+        self.partialOwner = partialOwner
+    }
+
+    func load() async throws -> MLXLMCommon.ModelContainer {
+        entered = true
+        enteredWaiters.forEach { $0.resume() }
+        enteredWaiters.removeAll()
+
+        if !released {
+            await withCheckedContinuation { continuation in
+                releaseWaiter = continuation
+            }
+        }
+
+        partialOwner = nil
+        throw SyntheticLoadError()
+    }
+
+    func waitUntilEntered() async {
+        guard !entered else {
+            return
+        }
+
+        await withCheckedContinuation { continuation in
+            enteredWaiters.append(continuation)
+        }
+    }
+
+    func releaseAndFail() {
+        released = true
+        releaseWaiter?.resume()
+        releaseWaiter = nil
+    }
+
+    var isBlocked: Bool { entered && !released }
+
+    private var partialOwner: PartialLoadOwner?
+    private var entered = false
+    private var released = false
+    private var enteredWaiters: [CheckedContinuation<Void, Never>] = []
+    private var releaseWaiter: CheckedContinuation<Void, Never>?
+}
+
+// MARK: - OperationBarrier
+
+private actor OperationBarrier {
+    func enterAndWait() async {
+        entered = true
+        enteredWaiters.forEach { $0.resume() }
+        enteredWaiters.removeAll()
+        guard !released else {
+            return
+        }
+
+        await withCheckedContinuation { continuation in
+            releaseWaiter = continuation
+        }
+    }
+
+    func waitUntilEntered() async {
+        guard !entered else {
+            return
+        }
+
+        await withCheckedContinuation { continuation in
+            enteredWaiters.append(continuation)
+        }
+    }
+
+    func release() {
+        released = true
+        releaseWaiter?.resume()
+        releaseWaiter = nil
+    }
+
+    private var entered = false
+    private var released = false
+    private var enteredWaiters: [CheckedContinuation<Void, Never>] = []
+    private var releaseWaiter: CheckedContinuation<Void, Never>?
+}
+
+// MARK: - SyntheticLoadError
+
+private struct SyntheticLoadError: Error {}
+
+// MARK: - PartialLoadOwner
+
+private final class PartialLoadOwner: @unchecked Sendable {}
+
+// MARK: - CleanupWitness
+
+private final class CleanupWitness: @unchecked Sendable {
+    init(_ object: AnyObject?) {
+        trackedObject = object
+    }
+
+    func recordCleanup() {
+        lock.withLock {
+            cleanupStates.append(trackedObject == nil)
+        }
+    }
+
+    var cleanupReleaseStates: [Bool] {
+        lock.withLock { cleanupStates }
+    }
+
+    private let lock: NSLock = .init()
+    private weak var trackedObject: AnyObject?
+    private var cleanupStates: [Bool] = []
+}
+
+// MARK: - LockedCounter
+
+private final class LockedCounter: @unchecked Sendable {
+    func increment() {
+        lock.withLock { count += 1 }
+    }
+
+    var value: Int {
+        lock.withLock { count }
+    }
+
+    private let lock: NSLock = .init()
+    private var count = 0
+}
+
+// MARK: - Minimal embedding value
+
+private func makeLifetimeEmbeddingRunner() -> EmbeddingRunner {
+    let context = EmbedderModelContext(
+        configuration: .init(id: "in-flight-embedding-test"),
+        model: LifetimeEmbeddingModel(),
+        tokenizer: LifetimeTokenizer(),
+        pooling: Pooling(strategy: .none)
+    )
+    return EmbeddingRunner(container: EmbedderModelContainer(context: context))
+}
+
+// MARK: - LifetimeEmbeddingModel
+
+private final class LifetimeEmbeddingModel: Module, EmbeddingModel {
+    let vocabularySize = 8
+    let maxPositionEmbeddings: Int? = nil
+
+    func callAsFunction(
+        _: MLXArray,
+        positionIds _: MLXArray?,
+        tokenTypeIds _: MLXArray?,
+        attentionMask _: MLXArray?
+    ) -> EmbeddingModelOutput {
+        fatalError("lifetime-only model must not run inference")
+    }
+}
+
+// MARK: - LifetimeTokenizer
+
+private struct LifetimeTokenizer: MLXLMCommon.Tokenizer {
+    var bosToken: String? { nil }
+    var eosToken: String? { nil }
+    var unknownToken: String? { nil }
+
+    func encode(text _: String, addSpecialTokens _: Bool) -> [Int] { [] }
+    func decode(tokenIds _: [Int], skipSpecialTokens _: Bool) -> String { "" }
+    func convertTokenToId(_: String) -> Int? { nil }
+    func convertIdToToken(_: Int) -> String? { nil }
+    func applyChatTemplate(
+        messages _: [[String: any Sendable]],
+        tools _: [[String: any Sendable]]?,
+        additionalContext _: [String: any Sendable]?
+    ) throws -> [Int] { [] }
+}

--- a/swama/Tests/SwamaKitTests/ModelPoolInFlightTeardownTests.swift
+++ b/swama/Tests/SwamaKitTests/ModelPoolInFlightTeardownTests.swift
@@ -11,6 +11,92 @@ import Testing
 @Suite("ModelPool in-flight load teardown", .serialized)
 struct ModelPoolInFlightTeardownTests {
     @Test
+    func concurrentEmbeddingWaitersShareOneLoadAndBothSucceed() async throws {
+        let modelName = "coalesced-embedding-waiters"
+        let loader = ControlledLoader(
+            first: makeLifetimeEmbeddingRunner(),
+            next: makeLifetimeEmbeddingRunner()
+        )
+        let witness = CleanupWitness(nil)
+        let pool = makePool(witness: witness, embeddingLoader: loader)
+
+        let firstRequest = Task<Result<String, Error>, Never> {
+            do {
+                return try await .success(pool.runEmbeddingWithConcurrencyControl(modelName: modelName) { _ in
+                    "first"
+                })
+            }
+            catch {
+                return .failure(error)
+            }
+        }
+        await loader.waitUntilFirstLoadEntered()
+
+        let secondRequest = Task<Result<String, Error>, Never> {
+            do {
+                return try await .success(pool.runEmbeddingWithConcurrencyControl(modelName: modelName) { _ in
+                    "second"
+                })
+            }
+            catch {
+                return .failure(error)
+            }
+        }
+        await waitUntilRunningInferenceCount(2, pool: pool)
+        #expect(await loader.numberOfLoads == 1)
+
+        await loader.releaseFirstLoad()
+        for (result, expected) in await [(firstRequest.value, "first"), (secondRequest.value, "second")] {
+            switch result {
+            case let .success(value):
+                #expect(value == expected)
+            case let .failure(error):
+                Issue.record("coalesced embedding waiter unexpectedly failed: \(error)")
+            }
+        }
+        #expect(await pool.isCachedForTesting(.embedding, modelName: modelName))
+        #expect(witness.cleanupReleaseStates.isEmpty)
+    }
+
+    @Test
+    func currentLoadedEmbeddingDiscardedBehindExistingCacheCleansUpAfterRelease() async throws {
+        let modelName = "embedding-cache-won-before-load"
+        var loaded: EmbeddingRunner? = makeLifetimeEmbeddingRunner()
+        let loader = try ControlledLoader(
+            first: #require(loaded),
+            next: makeLifetimeEmbeddingRunner()
+        )
+        let witness = CleanupWitness(loaded)
+        loaded = nil
+        let pool = makePool(witness: witness, embeddingLoader: loader)
+        let cached = makeLifetimeEmbeddingRunner()
+
+        let request = Task<Result<Bool, Error>, Never> {
+            do {
+                return try await .success(pool.runEmbeddingWithConcurrencyControl(modelName: modelName) { runner in
+                    runner === cached
+                })
+            }
+            catch {
+                return .failure(error)
+            }
+        }
+
+        await loader.waitUntilFirstLoadEntered()
+        await pool.setEmbeddingRunner(cached, for: modelName)
+        await loader.releaseFirstLoad()
+
+        switch await request.value {
+        case let .success(receivedExistingRunner):
+            #expect(receivedExistingRunner)
+        case let .failure(error):
+            Issue.record("current load should use the existing cache value: \(error)")
+        }
+        #expect(witness.cleanupReleaseStates == [true])
+        #expect(await pool.isCachedForTesting(.embedding, modelName: modelName))
+    }
+
+    @Test
     func newerEmbeddingLoadSurvivesOlderGenerationFinishingLate() async throws {
         let modelName = "overlapping-embedding-generations"
         var first: EmbeddingRunner? = makeLifetimeEmbeddingRunner()
@@ -247,6 +333,7 @@ struct ModelPoolInFlightTeardownTests {
 
         await loader.waitUntilFirstLoadEntered()
         #expect(await pool.hasPendingLoadForTesting(.language, modelName: modelName))
+        #expect(await pool.hasMatchingLoadingOperationForTesting(modelName: modelName))
         await apply(path, to: pool, modelName: modelName)
         #expect(await loader.isFirstLoadBlocked)
         await loader.releaseFirstLoad()
@@ -290,6 +377,7 @@ struct ModelPoolInFlightTeardownTests {
 
         await loader.waitUntilFirstLoadEntered()
         #expect(await pool.hasPendingLoadForTesting(.speechToText, modelName: modelName))
+        #expect(await pool.hasMatchingLoadingOperationForTesting(modelName: modelName))
         await apply(path, to: pool, modelName: modelName)
         #expect(await loader.isFirstLoadBlocked)
         await loader.releaseFirstLoad()
@@ -335,6 +423,7 @@ struct ModelPoolInFlightTeardownTests {
 
         await loader.waitUntilFirstLoadEntered()
         #expect(await pool.hasPendingLoadForTesting(.textToSpeech, modelName: modelName))
+        #expect(await pool.hasMatchingLoadingOperationForTesting(modelName: modelName))
         await apply(path, to: pool, modelName: modelName)
         #expect(await loader.isFirstLoadBlocked)
         await loader.releaseFirstLoad()
@@ -380,6 +469,7 @@ struct ModelPoolInFlightTeardownTests {
 
         await loader.waitUntilFirstLoadEntered()
         #expect(await pool.hasPendingLoadForTesting(.embedding, modelName: modelName))
+        #expect(await !(pool.hasMatchingLoadingOperationForTesting(modelName: modelName)))
         await apply(path, to: pool, modelName: modelName)
         #expect(await loader.isFirstLoadBlocked)
         await loader.releaseFirstLoad()
@@ -476,6 +566,16 @@ struct ModelPoolInFlightTeardownTests {
         #expect(await !(pool.hasPendingLoadForTesting(kind, modelName: modelName)))
         #expect(witness.cleanupReleaseStates == [false, true])
     }
+
+    private func waitUntilRunningInferenceCount(_ expected: Int, pool: ModelPool) async {
+        for _ in 0 ..< 1000 {
+            if await pool.runningInferenceCountForTesting() == expected {
+                return
+            }
+            await Task.yield()
+        }
+        Issue.record("timed out waiting for \(expected) running inference slots")
+    }
 }
 
 // MARK: - TeardownPath
@@ -561,6 +661,8 @@ private actor ControlledLoader<Value: AnyObject & Sendable> {
     var isFirstLoadBlocked: Bool {
         firstLoadEntered && !firstLoadReleased
     }
+
+    var numberOfLoads: Int { loadCount }
 
     private var values: [Value]
     private let blockSecond: Bool


### PR DESCRIPTION
## Problem

`ModelPool.clearCache()`, `remove(modelName:)`, and periodic eviction canceled active load tasks but did not wait for them. Swift cancellation is cooperative, so a loader that ignored cancellation could finish later and repopulate a cache that teardown had just cleared. A late model owner could also release its weights after the only MLX cleanup had already run.

The hole existed independently in language, speech-to-text, text-to-speech, and embedding loads. Embedding loads were not tracked at all.

## Change

- Give every load a global + per-model generation token and a unique sequence.
- Invalidate the relevant generation before clear/remove/evict cancels and drops pending work.
- Commit a loaded value only when its generation is still current; stale callers receive `CancellationError` and cannot reach inference.
- Wrap Task success values in a releasable owner so a stale completed Task drops its model before one bounded follow-up `MLX.Memory.clearCache()` call.
- Run the same follow-up cleanup when an invalidated loader fails after releasing partial state.
- Track embedding loads with the same pending-load protocol and deduplicate concurrent loads.
- Distinguish “still loading” from a live inference operation so periodic eviction may cancel a pending load without evicting an active operation, including a same-name cross-modality collision.
- Bind loading/running state with the same operation token, so that eviction escape hatch cannot be claimed by another same-name operation.
- Preserve coalesced embedding waiters: once one waiter commits the shared result, later waiters use the cache instead of reading an already-released Task owner. If an explicit cache setter wins with a different value, the unused load is released before one bounded cleanup.
- Keep the public API, package targets, and concurrency limit unchanged.

## Verification

- `swift test`: 123 tests passed.
- Release build passed under stable Xcode 26.6 / Swift 6.3.3.
- New deterministic matrix: 4 modalities × clear/remove/periodic eviction. Every case proves the load is inside the injected await when teardown returns, stale operation count remains zero, cache/pending state stays empty, the late owner is released before follow-up cleanup, and a fresh generation still loads.
- Additional controls cover a loader that fails after partial ownership, an older generation completing while a newer embedding generation is still pending, two callers coalescing one embedding load, a pre-existing cache winning against a completed load, live-operation eviction protection, and a same-name cross-modality pending load.
- Reverse mutations were run independently: removing clear/remove/evict invalidation reddens only that path's four cases; cleanup-before-owner-release reds all 12 lifetime witnesses; omitting failed-load cleanup reds its dedicated test; allowing an old completion to remove any pending task reds the overlapping-generation test; broad pending-load eviction bypass reds the live-operation collision test; mismatching loading/running operation tokens reds the credential witnesses and pending-eviction cases. Removing the cached-first return reds both coalesced-waiter and discarded-value tests because that same branch releases the Task owner; omitting only its bounded cleanup isolates the discarded-value lifetime test. All mutations were restored.
- Frozen-referee acceptance against the `f5f5029e` baseline: contract/instrument/Metal/model/platform/toolchain identities all comparable, 2 benchmark models / 4 routes, all five reliability gates green, no performance findings, no new architecture debt.

## Evidence boundary

The deterministic tests use injected non-MLX model values to control the exact suspension/teardown/completion order. The full acceptance run covers real local MLX models and unchanged Core/CLI/HTTP behavior, but it does not inject a real model factory pause mid-load. Independent transition-path validation remains a separate reviewer seat.

## Open-PR overlap

The only other open PR is #75, which also touches `ModelPool.swift`; it is currently `DIRTY` against main and still targets pre-split `SwamaKit` app files. #133 does not inherit or depend on it. If #75 is revived, it must rebase after this lifecycle fix and re-audit its ModelPool additions rather than merging first.
