### PR TITLE
fix: make cold acceptance builds reproducible

### DIFF
--- a/Tools/SwamaAcceptance/README.md
+++ b/Tools/SwamaAcceptance/README.md
@@ -35,6 +35,24 @@ Run the resulting binary directly. Do not use `swift run` for a candidate: the
 binary identity is part of every report and must already be frozen before the
 candidate build starts.
 
+## Cold build policy
+
+`baseline` builds Swama and the external fixture in `.build/swama-acceptance/`,
+separate from package-local `.build` directories. The scratch identity covers
+the Git head and tree, both resolved dependency files, and the selected
+Xcode/Swift toolchain. A changed identity clears the acceptance scratch; the
+same identity reuses a partial build, so a bounded timeout can resume without a
+manual prebuild. The same scratch owns SwiftPM's module cache, and the selected
+Xcode supplies `SDKROOT`, avoiding machine-level module-cache drift and a mixed
+Xcode/CommandLineTools SDK. The separately installed Metal Toolchain is checked
+before any cold Swift build begins; a missing component exits as `UNKNOWN`.
+
+Build budgets live in `contract.json`: product builds have 1,200 seconds and
+the cold external-fixture prebuild has up to two resumable 1,200-second attempts.
+A final build timeout is an acceptance-tool `UNKNOWN`; a compiler or test
+failure remains a product `FAIL`. Successful reports record each build phase,
+its attempts, budget, cache identity, and the produced executable hashes.
+
 ## Commands
 
 ```bash

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Baseline.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Baseline.swift
@@ -21,6 +21,7 @@ func runBaseline(
     }
 
     let build = try buildProducts(
+        contract: contract.build,
         developerDirectory: developerDirectory,
         metalDeveloperDirectory: metalDeveloperDirectory,
         paths: paths

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Build.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Build.swift
@@ -82,28 +82,11 @@ func buildProducts(
         throw AcceptanceFailure.failed("Swama release build failed:\n\(commandFailureSummary(releaseBuild))")
     }
 
-    let fixtureBuild = try runCommand(
-        [
-            "xcrun",
-            "swift",
-            "build",
-            "--package-path",
-            paths.fixture.path,
-            "--scratch-path",
-            scratch.fixture.path,
-            "--force-resolved-versions",
-            "-c",
-            "release",
-            "-j",
-            "4"
-        ],
-        currentDirectory: paths.repository,
-        environment: environment,
-        timeout: contract.externalFixtureTimeoutSeconds,
-        sampleMemory: false,
-        timeoutFailureKind: .unknown,
-        timeoutContext: "external fixture build",
-        timeoutRetryLimit: contract.externalFixtureTimeoutRetryLimit
+    let fixtureBuild = try buildExternalFixture(
+        contract: contract,
+        paths: paths,
+        scratch: scratch,
+        environment: environment
     )
     guard fixtureBuild.returnCode == 0 else {
         throw AcceptanceFailure
@@ -275,6 +258,39 @@ func buildProducts(
                 "metallib": testMetal
             ]
         ]
+    )
+}
+
+func buildExternalFixture(
+    contract: BuildContract,
+    paths: WorkspacePaths,
+    scratch: AcceptanceBuildScratch,
+    environment: [String: String],
+    command overrideCommand: [String]? = nil
+) throws -> CommandResult {
+    let command = overrideCommand ?? [
+        "xcrun",
+        "swift",
+        "build",
+        "--package-path",
+        paths.fixture.path,
+        "--scratch-path",
+        scratch.fixture.path,
+        "--force-resolved-versions",
+        "-c",
+        "release",
+        "-j",
+        "4"
+    ]
+    return try runCommand(
+        command,
+        currentDirectory: paths.repository,
+        environment: environment,
+        timeout: contract.externalFixtureTimeoutSeconds,
+        sampleMemory: false,
+        timeoutFailureKind: .unknown,
+        timeoutContext: "external fixture build",
+        timeoutRetryLimit: contract.externalFixtureTimeoutRetryLimit
     )
 }
 

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Build.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Build.swift
@@ -8,12 +8,54 @@ struct BuildProducts {
     let report: JSONObject
 }
 
+// MARK: - AcceptanceBuildScratch
+
+struct AcceptanceBuildScratch {
+    let identity: String
+    let root: URL
+    let package: URL
+    let fixture: URL
+    let moduleCache: URL
+}
+
+func prepareAcceptanceBuildScratch(root: URL, identity: String) throws -> AcceptanceBuildScratch {
+    let identityFile = root.appendingPathComponent("identity")
+    let existingIdentity = try? String(contentsOf: identityFile, encoding: .utf8)
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+
+    if existingIdentity != identity {
+        if FileManager.default.fileExists(atPath: root.path) {
+            try FileManager.default.removeItem(at: root)
+        }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try Data("\(identity)\n".utf8).write(to: identityFile, options: .atomic)
+    }
+
+    return .init(
+        identity: identity,
+        root: root,
+        package: root.appendingPathComponent("package"),
+        fixture: root.appendingPathComponent("fixture"),
+        moduleCache: root.appendingPathComponent("module-cache")
+    )
+}
+
 func buildProducts(
+    contract: BuildContract,
     developerDirectory: URL,
     metalDeveloperDirectory: URL,
     paths: WorkspacePaths
 ) throws -> BuildProducts {
-    let environment = try developerEnvironment(developerDirectory)
+    let metalToolchain = try resolveMetalToolchain(
+        metalDeveloperDirectory: metalDeveloperDirectory,
+        paths: paths
+    )
+    let scratch = try acceptanceBuildScratch(
+        developerDirectory: developerDirectory,
+        paths: paths
+    )
+    var environment = try developerEnvironment(developerDirectory)
+    environment["SWIFTPM_MODULECACHE_OVERRIDE"] = scratch.moduleCache.path
     let releaseBuild = try runCommand(
         [
             "xcrun",
@@ -21,6 +63,8 @@ func buildProducts(
             "build",
             "--package-path",
             paths.package.path,
+            "--scratch-path",
+            scratch.package.path,
             "--force-resolved-versions",
             "-c",
             "release",
@@ -29,8 +73,10 @@ func buildProducts(
         ],
         currentDirectory: paths.repository,
         environment: environment,
-        timeout: 1200,
-        sampleMemory: false
+        timeout: contract.productTimeoutSeconds,
+        sampleMemory: false,
+        timeoutFailureKind: .unknown,
+        timeoutContext: "Swama release build"
     )
     guard releaseBuild.returnCode == 0 else {
         throw AcceptanceFailure.failed("Swama release build failed:\n\(commandFailureSummary(releaseBuild))")
@@ -43,6 +89,8 @@ func buildProducts(
             "build",
             "--package-path",
             paths.fixture.path,
+            "--scratch-path",
+            scratch.fixture.path,
             "--force-resolved-versions",
             "-c",
             "release",
@@ -51,8 +99,11 @@ func buildProducts(
         ],
         currentDirectory: paths.repository,
         environment: environment,
-        timeout: 1200,
-        sampleMemory: false
+        timeout: contract.externalFixtureTimeoutSeconds,
+        sampleMemory: false,
+        timeoutFailureKind: .unknown,
+        timeoutContext: "external fixture build",
+        timeoutRetryLimit: contract.externalFixtureTimeoutRetryLimit
     )
     guard fixtureBuild.returnCode == 0 else {
         throw AcceptanceFailure
@@ -66,6 +117,8 @@ func buildProducts(
             "build",
             "--package-path",
             paths.package.path,
+            "--scratch-path",
+            scratch.package.path,
             "--force-resolved-versions",
             "--build-tests",
             "-j",
@@ -73,8 +126,10 @@ func buildProducts(
         ],
         currentDirectory: paths.repository,
         environment: environment,
-        timeout: 1200,
-        sampleMemory: false
+        timeout: contract.productTimeoutSeconds,
+        sampleMemory: false,
+        timeoutFailureKind: .unknown,
+        timeoutContext: "Swama test build"
     )
     guard testBuild.returnCode == 0 else {
         throw AcceptanceFailure.failed("Swama test build failed:\n\(commandFailureSummary(testBuild))")
@@ -87,6 +142,8 @@ func buildProducts(
             "build",
             "--package-path",
             paths.package.path,
+            "--scratch-path",
+            scratch.package.path,
             "--force-resolved-versions",
             "-c",
             "release",
@@ -102,6 +159,8 @@ func buildProducts(
             "build",
             "--package-path",
             paths.fixture.path,
+            "--scratch-path",
+            scratch.fixture.path,
             "--force-resolved-versions",
             "-c",
             "release",
@@ -117,6 +176,8 @@ func buildProducts(
             "build",
             "--package-path",
             paths.package.path,
+            "--scratch-path",
+            scratch.package.path,
             "--force-resolved-versions",
             "-c",
             "debug",
@@ -133,7 +194,11 @@ func buildProducts(
         throw AcceptanceFailure.unknown("expected build product is missing: \(required.path)")
     }
 
-    let metal = try buildMetallib(metalDeveloperDirectory: metalDeveloperDirectory, paths: paths)
+    let metal = try buildMetallib(
+        toolchain: metalToolchain,
+        packageScratchDirectory: scratch.package,
+        paths: paths
+    )
     defer { metal.remove() }
     let swamaMetal = try installMetallib(metal.library, nextTo: swama)
     let probeMetal = try installMetallib(metal.library, nextTo: probe)
@@ -146,6 +211,8 @@ func buildProducts(
             "test",
             "--package-path",
             paths.package.path,
+            "--scratch-path",
+            scratch.package.path,
             "--force-resolved-versions",
             "--skip-build",
             "-j",
@@ -167,10 +234,38 @@ func buildProducts(
     return .init(
         swama: swama,
         probe: probe,
-        report: [
-            "duration_ms": releaseBuild.durationMilliseconds + fixtureBuild.durationMilliseconds,
+        report: try [
+            "duration_ms": releaseBuild.durationMilliseconds
+                + fixtureBuild.durationMilliseconds
+                + testBuild.durationMilliseconds,
             "swama": swama.path,
             "probe": probe.path,
+            "artifacts": [
+                "swama_sha256": sha256File(swama),
+                "probe_sha256": sha256File(probe),
+                "test_executable_sha256": sha256File(testExecutable)
+            ],
+            "cache": [
+                "identity": scratch.identity,
+                "policy": "single-identity resumable scratch",
+                "root": scratch.root.path,
+                "module_cache": scratch.moduleCache.path
+            ],
+            "phases": [
+                "swama_release": buildPhaseReport(
+                    releaseBuild,
+                    timeoutSeconds: contract.productTimeoutSeconds
+                ),
+                "external_fixture_prebuild": buildPhaseReport(
+                    fixtureBuild,
+                    timeoutSeconds: contract.externalFixtureTimeoutSeconds,
+                    timeoutRetryLimit: contract.externalFixtureTimeoutRetryLimit
+                ),
+                "swama_tests": buildPhaseReport(
+                    testBuild,
+                    timeoutSeconds: contract.productTimeoutSeconds
+                )
+            ],
             "metal_build": metal.provenance,
             "metallib": swamaMetal,
             "probe_metallib": probeMetal,
@@ -181,6 +276,60 @@ func buildProducts(
             ]
         ]
     )
+}
+
+private func acceptanceBuildScratch(
+    developerDirectory: URL,
+    paths: WorkspacePaths
+) throws -> AcceptanceBuildScratch {
+    let environment = try developerEnvironment(developerDirectory)
+    let head = try commandOutput(
+        ["git", "rev-parse", "HEAD"],
+        currentDirectory: paths.repository
+    )
+    let tree = try commandOutput(
+        ["git", "rev-parse", "HEAD^{tree}"],
+        currentDirectory: paths.repository
+    )
+    let swiftVersion = try commandOutput(
+        ["xcrun", "swift", "--version"],
+        currentDirectory: paths.repository,
+        environment: environment
+    )
+    let xcodeVersion = try commandOutput(
+        ["xcodebuild", "-version"],
+        currentDirectory: paths.repository,
+        environment: environment
+    )
+    let packageResolved = try sha256File(paths.package.appendingPathComponent("Package.resolved"))
+    let fixtureResolved = try sha256File(paths.fixture.appendingPathComponent("Package.resolved"))
+    let components = [
+        "head=\(head)",
+        "tree=\(tree)",
+        "developer_dir=\(developerDirectory.standardizedFileURL.path)",
+        "swift=\(swiftVersion)",
+        "xcode=\(xcodeVersion)",
+        "package_resolved=\(packageResolved)",
+        "fixture_resolved=\(fixtureResolved)"
+    ]
+    let identity = sha256(Data(components.joined(separator: "\u{0}").utf8))
+    let root = paths.repository.appendingPathComponent(".build/swama-acceptance")
+    return try prepareAcceptanceBuildScratch(root: root, identity: identity)
+}
+
+private func buildPhaseReport(
+    _ result: CommandResult,
+    timeoutSeconds: Double,
+    timeoutRetryLimit: Int = 0
+) -> JSONObject {
+    [
+        "command": result.command,
+        "duration_ms": result.durationMilliseconds,
+        "timeout_seconds_per_attempt": timeoutSeconds,
+        "timeout_retry_limit": timeoutRetryLimit,
+        "attempt_count": result.attemptCount,
+        "timeout_count": result.timeoutCount
+    ]
 }
 
 func commandFailureSummary(_ result: CommandResult, maximumCharacters: Int = 4000) -> String {

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Contract.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Contract.swift
@@ -4,6 +4,7 @@ import Foundation
 
 struct AcceptanceContract: Codable, Sendable {
     let schemaVersion: Int
+    let build: BuildContract
     let models: [ModelContract]
     let benchmark: BenchmarkContract
     let reliability: ReliabilityContract
@@ -11,6 +12,7 @@ struct AcceptanceContract: Codable, Sendable {
 
     enum CodingKeys: String, CodingKey {
         case schemaVersion = "schema_version"
+        case build
         case models
         case benchmark
         case reliability
@@ -24,6 +26,20 @@ struct AcceptanceContract: Codable, Sendable {
         catch {
             throw AcceptanceFailure.unknown("cannot decode contract \(url.path): \(error)")
         }
+    }
+}
+
+// MARK: - BuildContract
+
+struct BuildContract: Codable, Sendable {
+    let productTimeoutSeconds: Double
+    let externalFixtureTimeoutSeconds: Double
+    let externalFixtureTimeoutRetryLimit: Int
+
+    enum CodingKeys: String, CodingKey {
+        case productTimeoutSeconds = "product_timeout_seconds"
+        case externalFixtureTimeoutSeconds = "external_fixture_timeout_seconds"
+        case externalFixtureTimeoutRetryLimit = "external_fixture_timeout_retry_limit"
     }
 }
 

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/MetalBuilder.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/MetalBuilder.swift
@@ -12,10 +12,21 @@ struct MetalBuildArtifact {
     }
 }
 
-func buildMetallib(
+// MARK: - MetalToolchain
+
+struct MetalToolchain {
+    let developerDirectory: URL
+    let environment: [String: String]
+    let metalVersion: String
+    let metallibVersion: String
+    let metalExecutable: URL
+    let metallibExecutable: URL
+}
+
+func resolveMetalToolchain(
     metalDeveloperDirectory: URL,
     paths: WorkspacePaths
-) throws -> MetalBuildArtifact {
+) throws -> MetalToolchain {
     let environment = try developerEnvironment(metalDeveloperDirectory)
     let metalVersion = try commandOutput(
         ["xcrun", "-sdk", "macosx", "metal", "--version"],
@@ -43,7 +54,24 @@ func buildMetallib(
         throw AcceptanceFailure.unknown("resolved Metal compiler executable is missing")
     }
 
-    let checkout = paths.package.appendingPathComponent(".build/checkouts/mlx-swift")
+    return .init(
+        developerDirectory: metalDeveloperDirectory,
+        environment: environment,
+        metalVersion: metalVersion,
+        metallibVersion: metallibVersion,
+        metalExecutable: metalExecutable,
+        metallibExecutable: metallibExecutable
+    )
+}
+
+func buildMetallib(
+    toolchain: MetalToolchain,
+    packageScratchDirectory: URL,
+    paths: WorkspacePaths
+) throws -> MetalBuildArtifact {
+    let environment = toolchain.environment
+
+    let checkout = packageScratchDirectory.appendingPathComponent("checkouts/mlx-swift")
     let sourceRoot = checkout.appendingPathComponent("Source/Cmlx/mlx-generated/metal")
     let sources = try regularFiles(in: sourceRoot, extensions: ["metal"]).sorted { $0.path < $1.path }
     guard !sources.isEmpty else {
@@ -80,7 +108,9 @@ func buildMetallib(
                 currentDirectory: paths.repository,
                 environment: environment,
                 timeout: 300,
-                sampleMemory: false
+                sampleMemory: false,
+                timeoutFailureKind: .unknown,
+                timeoutContext: "Metal source compilation"
             )
             guard result.returnCode == 0, FileManager.default.fileExists(atPath: air.path) else {
                 throw AcceptanceFailure
@@ -105,25 +135,27 @@ func buildMetallib(
             currentDirectory: paths.repository,
             environment: environment,
             timeout: 300,
-            sampleMemory: false
+            sampleMemory: false,
+            timeoutFailureKind: .unknown,
+            timeoutContext: "metallib link"
         )
         guard linkResult.returnCode == 0, FileManager.default.fileExists(atPath: output.path) else {
             throw AcceptanceFailure.unknown("metallib link failed: \(linkResult.stderr)")
         }
 
-        let normalizedMetalVersion = metalVersion.split(separator: "\n")
+        let normalizedMetalVersion = toolchain.metalVersion.split(separator: "\n")
             .filter { !$0.hasPrefix("InstalledDir:") }
             .joined(separator: "\n")
         return try .init(
             library: output,
             provenance: [
-                "developer_dir": metalDeveloperDirectory.path,
+                "developer_dir": toolchain.developerDirectory.path,
                 "metal_version": normalizedMetalVersion,
-                "metallib_version": metallibVersion,
-                "metal_executable": metalExecutable.path,
-                "metal_executable_sha256": sha256File(metalExecutable),
-                "metallib_executable": metallibExecutable.path,
-                "metallib_executable_sha256": sha256File(metallibExecutable),
+                "metallib_version": toolchain.metallibVersion,
+                "metal_executable": toolchain.metalExecutable.path,
+                "metal_executable_sha256": sha256File(toolchain.metalExecutable),
+                "metallib_executable": toolchain.metallibExecutable.path,
+                "metallib_executable_sha256": sha256File(toolchain.metallibExecutable),
                 "mlx_swift_revision": checkoutRevision,
                 "sources": sourceManifest,
                 "compile_commands": commands,

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/ProcessRunner.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/ProcessRunner.swift
@@ -10,6 +10,12 @@ struct CommandResult: Sendable {
     let stderr: String
     let durationMilliseconds: Double
     let peakResidentBytes: UInt64
+    let attemptCount: Int
+    let timeoutCount: Int
+}
+
+private struct CommandTimeout: Error {
+    let durationMilliseconds: Double
 }
 
 func developerEnvironment(_ developerDirectory: URL) throws -> [String: String] {
@@ -20,8 +26,16 @@ func developerEnvironment(_ developerDirectory: URL) throws -> [String: String] 
         throw AcceptanceFailure.unknown("missing Xcode developer directory: \(developerDirectory.path)")
     }
 
+    let sdk = developerDirectory.appendingPathComponent(
+        "Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
+    )
+    guard FileManager.default.fileExists(atPath: sdk.path) else {
+        throw AcceptanceFailure.unknown("missing macOS SDK in developer directory: \(developerDirectory.path)")
+    }
+
     var environment = ProcessInfo.processInfo.environment
     environment["DEVELOPER_DIR"] = developerDirectory.path
+    environment["SDKROOT"] = sdk.path
     return environment
 }
 
@@ -30,11 +44,70 @@ func runCommand(
     currentDirectory: URL,
     environment: [String: String]? = nil,
     timeout: TimeInterval = 300,
-    sampleMemory: Bool = true
+    sampleMemory: Bool = true,
+    timeoutFailureKind: AcceptanceKind = .failed,
+    timeoutContext: String? = nil,
+    timeoutRetryLimit: Int = 0
 ) throws -> CommandResult {
     guard let executable = command.first else {
         throw AcceptanceFailure.unknown("empty command")
     }
+    guard timeout > 0 else {
+        throw AcceptanceFailure.unknown("command timeout must be positive")
+    }
+    guard timeoutRetryLimit >= 0, timeoutRetryLimit < Int.max else {
+        throw AcceptanceFailure.unknown("command timeout retry limit is outside the supported range")
+    }
+
+    let maximumAttempts = timeoutRetryLimit + 1
+    var elapsedMilliseconds = 0.0
+    for attempt in 1 ... maximumAttempts {
+        do {
+            let result = try runCommandAttempt(
+                command,
+                executable: executable,
+                currentDirectory: currentDirectory,
+                environment: environment,
+                timeout: timeout,
+                sampleMemory: sampleMemory
+            )
+            return .init(
+                command: result.command,
+                returnCode: result.returnCode,
+                stdout: result.stdout,
+                stderr: result.stderr,
+                durationMilliseconds: elapsedMilliseconds + result.durationMilliseconds,
+                peakResidentBytes: result.peakResidentBytes,
+                attemptCount: attempt,
+                timeoutCount: attempt - 1
+            )
+        }
+        catch let commandTimeout as CommandTimeout {
+            elapsedMilliseconds += commandTimeout.durationMilliseconds
+            if attempt == maximumAttempts {
+                let context = timeoutContext.map { "\($0) " } ?? ""
+                let budget = maximumAttempts == 1
+                    ? "after \(timeout)s"
+                    : "after \(maximumAttempts) attempt(s) at \(timeout)s each"
+                throw AcceptanceFailure(
+                    kind: timeoutFailureKind,
+                    message: "\(context)timeout \(budget): \(command.joined(separator: " "))"
+                )
+            }
+        }
+    }
+
+    throw AcceptanceFailure.unknown("command retry loop ended unexpectedly")
+}
+
+private func runCommandAttempt(
+    _ command: [String],
+    executable: String,
+    currentDirectory: URL,
+    environment: [String: String]?,
+    timeout: TimeInterval,
+    sampleMemory: Bool
+) throws -> CommandResult {
 
     let temporary = FileManager.default
         .temporaryDirectory
@@ -82,9 +155,12 @@ func runCommand(
             peak = max(peak, residentBytes(pid: process.processIdentifier))
         }
         if Date() >= deadline {
-            kill(process.processIdentifier, SIGKILL)
+            killProcessTree(process.processIdentifier)
             process.waitUntilExit()
-            throw AcceptanceFailure.failed("timeout after \(timeout)s: \(command.joined(separator: " "))")
+            let duration = start.duration(to: .now)
+            let milliseconds = Double(duration.components.seconds) * 1000
+                + Double(duration.components.attoseconds) / 1_000_000_000_000_000
+            throw CommandTimeout(durationMilliseconds: milliseconds)
         }
         Thread.sleep(forTimeInterval: 0.02)
     }
@@ -108,8 +184,54 @@ func runCommand(
         stdout: stdout,
         stderr: stderr,
         durationMilliseconds: milliseconds,
-        peakResidentBytes: peak
+        peakResidentBytes: peak,
+        attemptCount: 1,
+        timeoutCount: 0
     )
+}
+
+private func killProcessTree(_ root: pid_t) {
+    _ = kill(root, SIGSTOP)
+    let descendants = suspendDescendantProcessIdentifiers(of: root)
+    for pid in descendants.reversed() {
+        _ = kill(pid, SIGKILL)
+    }
+    _ = kill(root, SIGKILL)
+}
+
+private func suspendDescendantProcessIdentifiers(of root: pid_t) -> [pid_t] {
+    var result: [pid_t] = []
+    var pending = [root]
+    while let parent = pending.popLast() {
+        let children = childProcessIdentifiers(of: parent)
+        for child in children {
+            _ = kill(child, SIGSTOP)
+        }
+        result.append(contentsOf: children)
+        pending.append(contentsOf: children)
+    }
+    return result
+}
+
+private func childProcessIdentifiers(of parent: pid_t) -> [pid_t] {
+    let initialCapacity = 32
+    var capacity = initialCapacity
+    while true {
+        var buffer = [pid_t](repeating: 0, count: capacity)
+        let count = Int(proc_listchildpids(
+            parent,
+            &buffer,
+            Int32(buffer.count * MemoryLayout<pid_t>.stride)
+        ))
+        guard count > 0 else {
+            return []
+        }
+
+        if count < capacity {
+            return Array(buffer.prefix(count)).filter { $0 > 0 }
+        }
+        capacity *= 2
+    }
 }
 
 func commandOutput(

--- a/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
+++ b/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 @testable import SwamaAcceptanceKit
 import Testing
@@ -312,6 +313,138 @@ struct AcceptanceTests {
         }
     }
 
+    @Test func developerEnvironmentBindsSDKToSelectedXcode() throws {
+        let temporary = FileManager.default
+            .temporaryDirectory
+            .appendingPathComponent("swama-developer-environment-test-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: temporary) }
+        let xcodebuild = temporary.appendingPathComponent("usr/bin/xcodebuild")
+        let sdk = temporary.appendingPathComponent(
+            "Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
+        )
+        try FileManager.default.createDirectory(
+            at: xcodebuild.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data().write(to: xcodebuild)
+        try FileManager.default.createDirectory(at: sdk, withIntermediateDirectories: true)
+
+        let environment = try developerEnvironment(temporary)
+        #expect(environment["DEVELOPER_DIR"] == temporary.path)
+        #expect(environment["SDKROOT"] == sdk.path)
+    }
+
+    @Test func buildScratchDropsStaleIdentityAndResumesMatchingIdentity() throws {
+        let temporary = FileManager.default
+            .temporaryDirectory
+            .appendingPathComponent("swama-build-scratch-test-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: temporary) }
+        try FileManager.default.createDirectory(at: temporary, withIntermediateDirectories: true)
+
+        let stale = try prepareAcceptanceBuildScratch(root: temporary, identity: "old")
+        let staleArtifact = stale.package.appendingPathComponent("stale-object")
+        try FileManager.default.createDirectory(at: stale.package, withIntermediateDirectories: true)
+        try Data("stale".utf8).write(to: staleArtifact)
+
+        let current = try prepareAcceptanceBuildScratch(root: temporary, identity: "current")
+        #expect(!FileManager.default.fileExists(atPath: staleArtifact.path))
+        let partialArtifact = current.fixture.appendingPathComponent("partial-object")
+        try FileManager.default.createDirectory(at: current.fixture, withIntermediateDirectories: true)
+        try Data("partial".utf8).write(to: partialArtifact)
+
+        let resumed = try prepareAcceptanceBuildScratch(root: temporary, identity: "current")
+        #expect(resumed.identity == "current")
+        #expect(FileManager.default.fileExists(atPath: partialArtifact.path))
+    }
+
+    @Test func buildTimeoutIsUnknownInsteadOfProductFailure() throws {
+        do {
+            _ = try runCommand(
+                ["/bin/sleep", "1"],
+                currentDirectory: FileManager.default.temporaryDirectory,
+                timeout: 0.01,
+                sampleMemory: false,
+                timeoutFailureKind: .unknown,
+                timeoutContext: "external fixture build"
+            )
+            Issue.record("the command must time out")
+        }
+        catch let error as AcceptanceFailure {
+            if case .failed = error.kind {
+                Issue.record("a build timeout is tool UNKNOWN, not product FAIL")
+            }
+            #expect(error.message.contains("external fixture build timeout after 0.01s"))
+        }
+    }
+
+    @Test func externalBuildTimeoutResumesWithoutManualIntervention() throws {
+        let temporary = FileManager.default
+            .temporaryDirectory
+            .appendingPathComponent("swama-build-retry-test-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: temporary) }
+        try FileManager.default.createDirectory(at: temporary, withIntermediateDirectories: true)
+        let marker = temporary.appendingPathComponent("first-attempt")
+
+        let result = try runCommand(
+            [
+                "/bin/sh",
+                "-c",
+                "if [ ! -f \"$1\" ]; then : > \"$1\"; sleep 2; fi",
+                "resumable-build",
+                marker.path
+            ],
+            currentDirectory: temporary,
+            timeout: 0.2,
+            sampleMemory: false,
+            timeoutFailureKind: .unknown,
+            timeoutContext: "external fixture build",
+            timeoutRetryLimit: 1
+        )
+        #expect(result.returnCode == 0)
+        #expect(result.attemptCount == 2)
+        #expect(result.timeoutCount == 1)
+        #expect(result.durationMilliseconds >= 200)
+    }
+
+    @Test func commandTimeoutTerminatesDescendantProcesses() throws {
+        let temporary = FileManager.default
+            .temporaryDirectory
+            .appendingPathComponent("swama-process-tree-test-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: temporary) }
+        try FileManager.default.createDirectory(at: temporary, withIntermediateDirectories: true)
+        let childPIDFile = temporary.appendingPathComponent("child-pid")
+
+        #expect(throws: AcceptanceFailure.self) {
+            _ = try runCommand(
+                [
+                    "/bin/sh",
+                    "-c",
+                    "sleep 5 & echo $! > \"$1\"; wait",
+                    "spawn-child",
+                    childPIDFile.path
+                ],
+                currentDirectory: temporary,
+                timeout: 0.2,
+                sampleMemory: false,
+                timeoutFailureKind: .unknown
+            )
+        }
+        let childPID = try #require(
+            pid_t(String(contentsOf: childPIDFile, encoding: .utf8)
+                .trimmingCharacters(in: .whitespacesAndNewlines))
+        )
+        #expect(kill(childPID, 0) == -1)
+    }
+
+    @Test func contractCarriesSeparateProductAndFixtureBuildBudgets() throws {
+        let paths = try WorkspacePaths.discover(explicit: repositoryRoot.path)
+        let contract = try AcceptanceContract.load(from: paths.contract)
+        #expect(contract.schemaVersion == 3)
+        #expect(contract.build.productTimeoutSeconds == 1200)
+        #expect(contract.build.externalFixtureTimeoutSeconds == 1200)
+        #expect(contract.build.externalFixtureTimeoutRetryLimit == 1)
+    }
+
     @Test func cleanWorktreeCanBeBoundToHead() throws {
         let repository = try temporaryRepository()
         defer { try? FileManager.default.removeItem(at: repository) }
@@ -346,7 +479,9 @@ struct AcceptanceTests {
             stdout: String(repeating: "warning: setup\n", count: 500) + "error: root cause\n",
             stderr: "warning: final warning\n",
             durationMilliseconds: 1,
-            peakResidentBytes: 0
+            peakResidentBytes: 0,
+            attemptCount: 1,
+            timeoutCount: 0
         )
         let summary = commandFailureSummary(result, maximumCharacters: 80)
         #expect(summary.contains("error: root cause"))

--- a/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
+++ b/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
@@ -406,34 +406,117 @@ struct AcceptanceTests {
         #expect(result.durationMilliseconds >= 200)
     }
 
+    @Test func fixtureBuildConsumesContractRetryAndKeepsTimeoutUnknown() throws {
+        let temporary = FileManager.default
+            .temporaryDirectory
+            .appendingPathComponent("swama-fixture-stage-retry-test-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: temporary) }
+        try FileManager.default.createDirectory(at: temporary, withIntermediateDirectories: true)
+        let attemptFile = temporary.appendingPathComponent("attempt-count")
+        let scratch = try prepareAcceptanceBuildScratch(
+            root: temporary.appendingPathComponent("scratch"),
+            identity: "fixture-stage-test"
+        )
+        let contract = BuildContract(
+            productTimeoutSeconds: 1,
+            externalFixtureTimeoutSeconds: 0.05,
+            externalFixtureTimeoutRetryLimit: 1
+        )
+
+        do {
+            _ = try buildExternalFixture(
+                contract: contract,
+                paths: .init(repository: temporary),
+                scratch: scratch,
+                environment: ProcessInfo.processInfo.environment,
+                command: [
+                    "/bin/sh",
+                    "-c",
+                    "count=$(cat \"$1\" 2>/dev/null || echo 0); echo $((count + 1)) > \"$1\"; sleep 1",
+                    "fixture-build",
+                    attemptFile.path
+                ]
+            )
+            Issue.record("the fixture build must exhaust its timeout retry")
+        }
+        catch let error as AcceptanceFailure {
+            if case .failed = error.kind {
+                Issue.record("a fixture build timeout is tool UNKNOWN, not product FAIL")
+            }
+            #expect(error.message.contains("external fixture build timeout after 2 attempt(s) at 0.05s each"))
+        }
+
+        let attempts = try Int(
+            String(contentsOf: attemptFile, encoding: .utf8)
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        )
+        #expect(attempts == 2)
+    }
+
     @Test func commandTimeoutTerminatesDescendantProcesses() throws {
         let temporary = FileManager.default
             .temporaryDirectory
             .appendingPathComponent("swama-process-tree-test-\(UUID().uuidString)")
-        defer { try? FileManager.default.removeItem(at: temporary) }
         try FileManager.default.createDirectory(at: temporary, withIntermediateDirectories: true)
         let childPIDFile = temporary.appendingPathComponent("child-pid")
+        let grandchildPIDFile = temporary.appendingPathComponent("grandchild-pid")
+        let childScript = temporary.appendingPathComponent("spawn-grandchild.sh")
+        let rootScript = temporary.appendingPathComponent("spawn-child.sh")
+        try Data("""
+        #!/bin/sh
+        sleep 5 &
+        echo $! > "$1"
+        wait
+        """.utf8).write(to: childScript)
+        try Data("""
+        #!/bin/sh
+        /bin/sh "$2" "$3" &
+        echo $! > "$1"
+        wait
+        """.utf8).write(to: rootScript)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: rootScript.path
+        )
+        var childPID: pid_t?
+        var grandchildPID: pid_t?
+        defer {
+            if let childPID {
+                _ = kill(childPID, SIGKILL)
+            }
+            if let grandchildPID {
+                _ = kill(grandchildPID, SIGKILL)
+            }
+            try? FileManager.default.removeItem(at: temporary)
+        }
 
         #expect(throws: AcceptanceFailure.self) {
             _ = try runCommand(
                 [
                     "/bin/sh",
-                    "-c",
-                    "sleep 5 & echo $! > \"$1\"; wait",
-                    "spawn-child",
-                    childPIDFile.path
+                    rootScript.path,
+                    childPIDFile.path,
+                    childScript.path,
+                    grandchildPIDFile.path
                 ],
                 currentDirectory: temporary,
-                timeout: 0.2,
+                timeout: 0.5,
                 sampleMemory: false,
                 timeoutFailureKind: .unknown
             )
         }
-        let childPID = try #require(
-            pid_t(String(contentsOf: childPIDFile, encoding: .utf8)
+        let childPIDValue = try #require(
+            Int(String(contentsOf: childPIDFile, encoding: .utf8)
                 .trimmingCharacters(in: .whitespacesAndNewlines))
         )
-        #expect(kill(childPID, 0) == -1)
+        let grandchildPIDValue = try #require(
+            Int(String(contentsOf: grandchildPIDFile, encoding: .utf8)
+                .trimmingCharacters(in: .whitespacesAndNewlines))
+        )
+        childPID = pid_t(childPIDValue)
+        grandchildPID = pid_t(grandchildPIDValue)
+        #expect(kill(pid_t(childPIDValue), 0) == -1)
+        #expect(kill(pid_t(grandchildPIDValue), 0) == -1)
     }
 
     @Test func contractCarriesSeparateProductAndFixtureBuildBudgets() throws {

--- a/Tools/SwamaAcceptance/contract.json
+++ b/Tools/SwamaAcceptance/contract.json
@@ -1,5 +1,10 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
+  "build": {
+    "product_timeout_seconds": 1200,
+    "external_fixture_timeout_seconds": 1200,
+    "external_fixture_timeout_retry_limit": 1
+  },
   "models": [
     {
       "id": "mlx-community/SmolLM-135M-Instruct-4bit",


### PR DESCRIPTION
## Summary

- isolate product, external fixture, and module caches in a provenance-bound scratch directory
- automatically retry a timed-out external fixture build once in the same scratch so partial compilation can resume
- classify build and Metal timeouts as tool `UNKNOWN` while preserving compiler/test failures as product `FAIL`
- terminate the full descendant process tree on timeout and preflight the selected Metal toolchain before long builds

## Safety and verification

- stale default `.build` artifacts cannot satisfy build or `--skip-build` gates
- retry configuration is consumed by the real fixture-build stage and recorded in provenance
- timeout cleanup is covered through a root → child → grandchild process tree
- acceptance harness: 24/24 passed locally and on an independent second Mac
- independent code-semantics review: GO, 0 findings
- independent reverse mutations made both retry wiring and recursive descendant cleanup fail precisely, then returned to 24/24 after restoration

Scope is limited to eight files under `Tools/SwamaAcceptance`; no Swama runtime or public API files changed.
