### PR TITLE
fix: distinguish invalid acceptance JSON types

### DIFF
--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Support.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Support.swift
@@ -1,3 +1,4 @@
+import CoreFoundation
 import CryptoKit
 import Foundation
 
@@ -228,50 +229,61 @@ func lastJSONValue(_ output: String) throws -> Any {
 
 extension [String: Any] {
     func object(_ key: String) throws -> JSONObject {
-        guard let value = self[key] as? JSONObject else {
-            throw AcceptanceFailure.unknown("missing JSON object: \(key)")
-        }
-
-        return value
+        try value(key, expectedType: "object")
     }
 
     func array(_ key: String) throws -> [Any] {
-        guard let value = self[key] as? [Any] else {
-            throw AcceptanceFailure.unknown("missing JSON array: \(key)")
-        }
-
-        return value
+        try value(key, expectedType: "array")
     }
 
     func string(_ key: String) throws -> String {
-        guard let value = self[key] as? String else {
-            throw AcceptanceFailure.unknown("missing JSON string: \(key)")
-        }
-
-        return value
+        try value(key, expectedType: "string")
     }
 
     func integer(_ key: String) throws -> Int {
-        guard let value = self[key] as? NSNumber else {
-            throw AcceptanceFailure.unknown("missing JSON integer: \(key)")
+        let number = try number(key, expectedType: "integer")
+        guard let integer = number as? Int else {
+            throw wrongType(key, expectedType: "integer")
         }
 
-        return value.intValue
+        return integer
     }
 
     func double(_ key: String) throws -> Double {
-        guard let value = self[key] as? NSNumber else {
-            throw AcceptanceFailure.unknown("missing JSON number: \(key)")
-        }
-
-        return value.doubleValue
+        let number = try number(key, expectedType: "number")
+        return number.doubleValue
     }
 
     func boolean(_ key: String) throws -> Bool {
-        guard let value = self[key] as? Bool else {
-            throw AcceptanceFailure.unknown("missing JSON boolean: \(key)")
+        let number: NSNumber = try value(key, expectedType: "boolean")
+        guard CFGetTypeID(number) == CFBooleanGetTypeID() else {
+            throw wrongType(key, expectedType: "boolean")
+        }
+
+        return number.boolValue
+    }
+
+    private func value<Expected>(_ key: String, expectedType: String) throws -> Expected {
+        guard let rawValue = self[key] else {
+            throw AcceptanceFailure.unknown("missing JSON key: \(key); expected \(expectedType)")
+        }
+        guard let value = rawValue as? Expected else {
+            throw wrongType(key, expectedType: expectedType)
         }
 
         return value
+    }
+
+    private func number(_ key: String, expectedType: String) throws -> NSNumber {
+        let number: NSNumber = try value(key, expectedType: expectedType)
+        guard CFGetTypeID(number) != CFBooleanGetTypeID() else {
+            throw wrongType(key, expectedType: expectedType)
+        }
+
+        return number
+    }
+
+    private func wrongType(_ key: String, expectedType: String) -> AcceptanceFailure {
+        .unknown("wrong JSON type for key: \(key); expected \(expectedType)")
     }
 }

--- a/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
+++ b/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
@@ -16,6 +16,47 @@ struct AcceptanceTests {
         }
     }
 
+    @Test func jsonAccessorsDistinguishMissingKeysFromWrongTypes() throws {
+        let key = "value"
+        let accessors: [(expectedType: String, wrongValue: Any, read: (JSONObject) throws -> Void)] = [
+            ("object", [Any](), { _ = try $0.object(key) }),
+            ("array", JSONObject(), { _ = try $0.array(key) }),
+            ("string", NSNumber(value: true), { _ = try $0.string(key) }),
+            ("integer", NSNumber(value: 1.5), { _ = try $0.integer(key) }),
+            ("number", NSNumber(value: true), { _ = try $0.double(key) }),
+            ("boolean", NSNumber(value: 1), { _ = try $0.boolean(key) })
+        ]
+
+        for accessor in accessors {
+            let missing = try #require(
+                acceptanceFailure(from: [:], read: accessor.read)
+            )
+            if case .failed = missing.kind {
+                Issue.record("a missing JSON key must be UNKNOWN")
+            }
+            #expect(missing.message.contains("missing JSON key"))
+            #expect(missing.message.contains(key))
+            #expect(missing.message.contains(accessor.expectedType))
+
+            guard let wrongType = acceptanceFailure(
+                from: [key: accessor.wrongValue],
+                read: accessor.read
+            )
+            else {
+                Issue.record("\(accessor.expectedType) accessor accepted a wrong JSON type")
+                continue
+            }
+
+            if case .failed = wrongType.kind {
+                Issue.record("a wrong JSON type must be UNKNOWN")
+            }
+            #expect(wrongType.message.contains("wrong JSON type"))
+            #expect(wrongType.message.contains(key))
+            #expect(wrongType.message.contains(accessor.expectedType))
+            #expect(wrongType.message != missing.message)
+        }
+    }
+
     @Test func compareDetectsARealPerformanceRegression() throws {
         let paths = try WorkspacePaths.discover(explicit: repositoryRoot.path)
         let contract = try AcceptanceContract.load(from: paths.contract)
@@ -109,7 +150,9 @@ struct AcceptanceTests {
             if case .failed = error.kind {
                 Issue.record("metal identity schema drift is invalid evidence, not a product failure")
             }
-            #expect(error.message == "missing JSON string: metal_version")
+            #expect(error.message.contains("wrong JSON type"))
+            #expect(error.message.contains("metal_version"))
+            #expect(error.message.contains("string"))
         }
     }
 
@@ -578,6 +621,23 @@ struct AcceptanceTests {
             .deletingLastPathComponent()
             .deletingLastPathComponent()
             .deletingLastPathComponent()
+    }
+
+    private func acceptanceFailure(
+        from object: JSONObject,
+        read: (JSONObject) throws -> Void
+    ) -> AcceptanceFailure? {
+        do {
+            try read(object)
+            return nil
+        }
+        catch let error as AcceptanceFailure {
+            return error
+        }
+        catch {
+            Issue.record("unexpected error: \(error)")
+            return nil
+        }
     }
 
     private func syntheticReport(paths: WorkspacePaths) throws -> JSONObject {


### PR DESCRIPTION
## Summary

- distinguish missing JSON keys from present values with the wrong type in the acceptance harness
- validate object, array, string, integer, number, and boolean values with explicit Foundation numeric/boolean handling
- add regression coverage for all six typed accessors

## Validation

- `swift test --package-path Tools/SwamaAcceptance` — 25/25 passed
- focused SwiftFormat lint on the new test block — 0 issues
- independent code review — GO on `5c9a5571012d09c208c324b2c54aff01ef8d77f5`
- second-Mac instrument custody — GO on the same exact

## Scope

Harness-only change in two files; runtime and public APIs remain unchanged.
