### PR TITLE
feat: add bounded content-addressed tokenizer cache

### DIFF
--- a/swama/Sources/SwamaKit/Diagnostics/DiagnosticTokenizerLoader.swift
+++ b/swama/Sources/SwamaKit/Diagnostics/DiagnosticTokenizerLoader.swift
@@ -25,11 +25,22 @@ final class ModelLoadPhaseRecorder: @unchecked Sendable {
 struct DiagnosticTokenizerLoader: TokenizerLoader {
     let upstream: any TokenizerLoader
     let phases: ModelLoadPhaseRecorder
+    let cache: TokenizerCache
+
+    init(
+        upstream: any TokenizerLoader,
+        phases: ModelLoadPhaseRecorder,
+        cache: TokenizerCache = .shared
+    ) {
+        self.upstream = upstream
+        self.phases = phases
+        self.cache = cache
+    }
 
     func load(from directory: URL) async throws -> any Tokenizer {
         let startedAt = DispatchTime.now().uptimeNanoseconds
         do {
-            let tokenizer = try await upstream.load(from: directory)
+            let tokenizer = try await cache.load(from: directory, using: upstream)
             phases.recordTokenizer(milliseconds: elapsedMilliseconds(since: startedAt))
             return tokenizer
         }

--- a/swama/Sources/SwamaKit/Diagnostics/DiagnosticTokenizerLoader.swift
+++ b/swama/Sources/SwamaKit/Diagnostics/DiagnosticTokenizerLoader.swift
@@ -26,21 +26,24 @@ struct DiagnosticTokenizerLoader: TokenizerLoader {
     let upstream: any TokenizerLoader
     let phases: ModelLoadPhaseRecorder
     let cache: TokenizerCache
+    let owner: TokenizerCacheOwner
 
     init(
         upstream: any TokenizerLoader,
         phases: ModelLoadPhaseRecorder,
-        cache: TokenizerCache = .shared
+        cache: TokenizerCache = .shared,
+        owner: TokenizerCacheOwner = .standalone
     ) {
         self.upstream = upstream
         self.phases = phases
         self.cache = cache
+        self.owner = owner
     }
 
     func load(from directory: URL) async throws -> any Tokenizer {
         let startedAt = DispatchTime.now().uptimeNanoseconds
         do {
-            let tokenizer = try await cache.load(from: directory, using: upstream)
+            let tokenizer = try await cache.load(from: directory, using: upstream, owner: owner)
             phases.recordTokenizer(milliseconds: elapsedMilliseconds(since: startedAt))
             return tokenizer
         }

--- a/swama/Sources/SwamaKit/Diagnostics/SwamaDiagnostics.swift
+++ b/swama/Sources/SwamaKit/Diagnostics/SwamaDiagnostics.swift
@@ -1136,6 +1136,51 @@ package enum SwamaDiagnostics {
         }
     }
 
+    package static func hitTokenizerCache(fingerprint: String) {
+        recorder.record(
+            level: .debug,
+            subsystem: "tokenizer",
+            event: .tokenizerCacheHit,
+            data: ["fingerprint": .string(fingerprint)]
+        )
+    }
+
+    package static func missTokenizerCache(fingerprint: String) {
+        recorder.record(
+            level: .debug,
+            subsystem: "tokenizer",
+            event: .tokenizerCacheMiss,
+            data: ["fingerprint": .string(fingerprint)]
+        )
+    }
+
+    package static func evictTokenizerCache(fingerprint: String, reason: String) {
+        recorder.record(
+            level: .debug,
+            subsystem: "tokenizer",
+            event: .tokenizerCacheEvicted,
+            data: [
+                "fingerprint": .string(fingerprint),
+                "reason": .string(reason)
+            ]
+        )
+    }
+
+    package static func rejectTokenizerCache(
+        fingerprint: String,
+        durationMilliseconds: Double
+    ) {
+        recorder.record(
+            level: .warn,
+            subsystem: "tokenizer",
+            event: .tokenizerCacheRejected,
+            durationMs: durationMilliseconds,
+            outcome: .error,
+            error: .init(code: .tokenizerRejected, transient: true),
+            data: ["fingerprint": .string(fingerprint)]
+        )
+    }
+
     package static func startModelLoad(model: String) -> SwamaDiagnosticOperation {
         let operation = recorder.makeOperation()
         recorder.record(

--- a/swama/Sources/SwamaKit/Model/EmbeddingRunner.swift
+++ b/swama/Sources/SwamaKit/Model/EmbeddingRunner.swift
@@ -9,7 +9,7 @@ import Tokenizers
 public func loadEmbeddingModelContainer(modelName: String) async throws -> EmbedderModelContainer {
     try await loadEmbeddingModelContainer(
         modelName: modelName,
-        tokenizerLoader: #huggingFaceTokenizerLoader()
+        tokenizerLoader: CachedTokenizerLoader(upstream: #huggingFaceTokenizerLoader())
     )
 }
 

--- a/swama/Sources/SwamaKit/Model/ModelPool.swift
+++ b/swama/Sources/SwamaKit/Model/ModelPool.swift
@@ -180,6 +180,7 @@ public actor ModelPool {
     public init() {
         memoryHooks = .live
         loadOverrides = nil
+        tokenizerCache = .shared
         // Cache limit and memory management timer are both deferred: the former until MLX is
         // genuinely about to be used (see `ensureCacheLimitConfigured()`), the latter until
         // first model access (see `ensureMemoryManagementStarted()`). Neither may run here --
@@ -191,10 +192,12 @@ public actor ModelPool {
 
     init(
         memoryHooks: ModelPoolMemoryHooks,
-        loadOverrides: ModelPoolLoadOverrides? = nil
+        loadOverrides: ModelPoolLoadOverrides? = nil,
+        tokenizerCache: TokenizerCache = .shared
     ) {
         self.memoryHooks = memoryHooks
         self.loadOverrides = loadOverrides
+        self.tokenizerCache = tokenizerCache
     }
 
     /// Ensures memory management timer is running (called on first model access)
@@ -601,6 +604,7 @@ public actor ModelPool {
         sttRunnerCache.removeAll()
         ttsRunnerCache.removeAll()
         modelUsageInfo.removeAll()
+        tokenizerCache.purge()
 
         // Synchronous completion is part of the contract: when clearCache returns, model owners
         // are gone and MLX cleanup has run. Callers no longer race a detached cleanup Task.
@@ -743,6 +747,7 @@ public actor ModelPool {
     private var vlmRegistryCache: [String: MLXLMCommon.ModelConfiguration]?
     private let memoryHooks: ModelPoolMemoryHooks
     private let loadOverrides: ModelPoolLoadOverrides?
+    private let tokenizerCache: TokenizerCache
 
     private func makeLoadToken(for modelName: String) -> ModelLoadToken {
         nextLoadSequence &+= 1

--- a/swama/Sources/SwamaKit/Model/ModelPool.swift
+++ b/swama/Sources/SwamaKit/Model/ModelPool.swift
@@ -203,6 +203,10 @@ public actor ModelPool {
         self.tokenizerCacheOwner = tokenizerCacheOwner
     }
 
+    deinit {
+        tokenizerCache.purge(owner: tokenizerCacheOwner)
+    }
+
     /// Ensures memory management timer is running (called on first model access)
     private func ensureMemoryManagementStarted() {
         guard memoryManagementTask == nil else {

--- a/swama/Sources/SwamaKit/Model/ModelPool.swift
+++ b/swama/Sources/SwamaKit/Model/ModelPool.swift
@@ -181,6 +181,7 @@ public actor ModelPool {
         memoryHooks = .live
         loadOverrides = nil
         tokenizerCache = .shared
+        tokenizerCacheOwner = .init()
         // Cache limit and memory management timer are both deferred: the former until MLX is
         // genuinely about to be used (see `ensureCacheLimitConfigured()`), the latter until
         // first model access (see `ensureMemoryManagementStarted()`). Neither may run here --
@@ -193,11 +194,13 @@ public actor ModelPool {
     init(
         memoryHooks: ModelPoolMemoryHooks,
         loadOverrides: ModelPoolLoadOverrides? = nil,
-        tokenizerCache: TokenizerCache = .shared
+        tokenizerCache: TokenizerCache = .shared,
+        tokenizerCacheOwner: TokenizerCacheOwner = .init()
     ) {
         self.memoryHooks = memoryHooks
         self.loadOverrides = loadOverrides
         self.tokenizerCache = tokenizerCache
+        self.tokenizerCacheOwner = tokenizerCacheOwner
     }
 
     /// Ensures memory management timer is running (called on first model access)
@@ -604,7 +607,7 @@ public actor ModelPool {
         sttRunnerCache.removeAll()
         ttsRunnerCache.removeAll()
         modelUsageInfo.removeAll()
-        tokenizerCache.purge()
+        tokenizerCache.purge(owner: tokenizerCacheOwner)
 
         // Synchronous completion is part of the contract: when clearCache returns, model owners
         // are gone and MLX cleanup has run. Callers no longer race a detached cleanup Task.
@@ -748,6 +751,7 @@ public actor ModelPool {
     private let memoryHooks: ModelPoolMemoryHooks
     private let loadOverrides: ModelPoolLoadOverrides?
     private let tokenizerCache: TokenizerCache
+    private let tokenizerCacheOwner: TokenizerCacheOwner
 
     private func makeLoadToken(for modelName: String) -> ModelLoadToken {
         nextLoadSequence &+= 1
@@ -1093,7 +1097,9 @@ public actor ModelPool {
             modelName: modelName,
             tokenizerLoader: DiagnosticTokenizerLoader(
                 upstream: #huggingFaceTokenizerLoader(),
-                phases: diagnosticPhases
+                phases: diagnosticPhases,
+                cache: tokenizerCache,
+                owner: tokenizerCacheOwner
             )
         )
         return EmbeddingRunner(container: container)
@@ -1145,7 +1151,9 @@ public actor ModelPool {
         do {
             let tokenizerLoader = DiagnosticTokenizerLoader(
                 upstream: #huggingFaceTokenizerLoader(),
-                phases: diagnosticPhases
+                phases: diagnosticPhases,
+                cache: tokenizerCache,
+                owner: tokenizerCacheOwner
             )
             if isVLM {
                 return try await VLMModelFactory.shared.loadContainer(

--- a/swama/Sources/SwamaKit/Model/TokenizerCache.swift
+++ b/swama/Sources/SwamaKit/Model/TokenizerCache.swift
@@ -138,6 +138,18 @@ struct TokenizerCacheDiagnostics: Sendable {
     let reject: @Sendable (String, Double) -> Void
 }
 
+// MARK: - TokenizerCacheOwner
+
+struct TokenizerCacheOwner: Hashable, Sendable {
+    static let standalone: Self = .init()
+
+    init() {
+        id = .init()
+    }
+
+    private let id: UUID
+}
+
 // MARK: - TokenizerCache
 
 final class TokenizerCache: @unchecked Sendable {
@@ -156,7 +168,8 @@ final class TokenizerCache: @unchecked Sendable {
     /// or the coalescing table.
     func load(
         from directory: URL,
-        using upstream: any TokenizerLoader
+        using upstream: any TokenizerLoader,
+        owner: TokenizerCacheOwner = .standalone
     ) async throws -> any Tokenizer {
         try Task.checkCancellation()
         let startedAt = DispatchTime.now().uptimeNanoseconds
@@ -186,7 +199,8 @@ final class TokenizerCache: @unchecked Sendable {
         let (acquisition, newTask) = acquire(
             fingerprint: fingerprint,
             directory: directory,
-            upstream: upstream
+            upstream: upstream,
+            owner: owner
         )
         switch acquisition {
         case let .ready(tokenizer):
@@ -229,22 +243,56 @@ final class TokenizerCache: @unchecked Sendable {
         }
     }
 
-    func purge() {
-        let (fingerprints, pendingLoads) = lock.withLock { () -> ([String], [PendingLoad]) in
-            let fingerprints = ready.keys.sorted()
-            let pendingLoads = Array(pending.values)
-            ready.removeAll()
-            pending.removeAll()
-            return (fingerprints, pendingLoads)
+    func purge(owner: TokenizerCacheOwner = .standalone) {
+        let (fingerprints, tasks, waiters) = lock.withLock {
+            () -> ([String], [Task<CompletedLoad, Error>], [Waiter]) in
+            var fingerprints: [String] = []
+            for fingerprint in Array(ready.keys) {
+                guard var entry = ready[fingerprint] else {
+                    continue
+                }
+
+                entry.owners.remove(owner)
+                if entry.owners.isEmpty {
+                    ready.removeValue(forKey: fingerprint)
+                    fingerprints.append(fingerprint)
+                }
+                else {
+                    ready[fingerprint] = entry
+                }
+            }
+
+            var tasks: [Task<CompletedLoad, Error>] = []
+            var removedWaiters: [Waiter] = []
+            for fingerprint in Array(pending.keys) {
+                guard var pendingLoad = pending[fingerprint] else {
+                    continue
+                }
+
+                let ownerWaiters = pendingLoad.waiters.values.filter { $0.owner == owner }
+                removedWaiters.append(contentsOf: ownerWaiters)
+                for waiter in ownerWaiters {
+                    pendingLoad.waiters.removeValue(forKey: waiter.id)
+                }
+                if pendingLoad.waiters.isEmpty {
+                    pending.removeValue(forKey: fingerprint)
+                    tasks.append(pendingLoad.task)
+                }
+                else {
+                    pending[fingerprint] = pendingLoad
+                }
+            }
+
+            return (fingerprints.sorted(), tasks, removedWaiters)
         }
         for fingerprint in fingerprints {
             diagnostics.evict(fingerprint, "explicit")
         }
-        for pendingLoad in pendingLoads {
-            pendingLoad.task.cancel()
-            for waiter in pendingLoad.waiters.values {
-                waiter.resolve(.failure(CancellationError()))
-            }
+        for task in tasks {
+            task.cancel()
+        }
+        for waiter in waiters {
+            waiter.resolve(.failure(CancellationError()))
         }
     }
 
@@ -270,6 +318,7 @@ final class TokenizerCache: @unchecked Sendable {
     private struct ReadyEntry: Sendable {
         let tokenizer: any Tokenizer
         var lastAccess: UInt64
+        var owners: Set<TokenizerCacheOwner>
     }
 
     private struct CompletedLoad: Sendable {
@@ -294,17 +343,19 @@ final class TokenizerCache: @unchecked Sendable {
     private func acquire(
         fingerprint: TokenizerInputFingerprint,
         directory: URL,
-        upstream: any TokenizerLoader
+        upstream: any TokenizerLoader,
+        owner: TokenizerCacheOwner
     ) -> (Acquisition, Task<CompletedLoad, Error>?) {
         lock.withLock {
             if var entry = ready[fingerprint.digest] {
                 accessSequence &+= 1
                 entry.lastAccess = accessSequence
+                entry.owners.insert(owner)
                 ready[fingerprint.digest] = entry
                 return (.ready(entry.tokenizer), nil)
             }
 
-            let waiter = Waiter()
+            let waiter = Waiter(owner: owner)
             if var pendingLoad = pending[fingerprint.digest] {
                 pendingLoad.waiters[waiter.id] = waiter
                 pending[fingerprint.digest] = pendingLoad
@@ -369,7 +420,8 @@ final class TokenizerCache: @unchecked Sendable {
                 accessSequence &+= 1
                 ready[fingerprint.digest] = .init(
                     tokenizer: completed.tokenizer,
-                    lastAccess: accessSequence
+                    lastAccess: accessSequence,
+                    owners: Set(waiters.map(\.owner))
                 )
                 evictedFingerprints = evictToBudgetLocked()
             }
@@ -440,7 +492,12 @@ final class TokenizerCache: @unchecked Sendable {
     }
 
     private final class Waiter: @unchecked Sendable {
+        init(owner: TokenizerCacheOwner) {
+            self.owner = owner
+        }
+
         let id: UUID = .init()
+        let owner: TokenizerCacheOwner
 
         func value(onCancel: @escaping @Sendable () -> Void) async throws -> CompletedLoad {
             do {
@@ -523,16 +580,19 @@ enum TokenizerCacheError: Error {
 struct CachedTokenizerLoader: TokenizerLoader {
     init(
         upstream: any TokenizerLoader,
-        cache: TokenizerCache = .shared
+        cache: TokenizerCache = .shared,
+        owner: TokenizerCacheOwner = .standalone
     ) {
         self.upstream = upstream
         self.cache = cache
+        self.owner = owner
     }
 
     func load(from directory: URL) async throws -> any Tokenizer {
-        try await cache.load(from: directory, using: upstream)
+        try await cache.load(from: directory, using: upstream, owner: owner)
     }
 
     private let upstream: any TokenizerLoader
     private let cache: TokenizerCache
+    private let owner: TokenizerCacheOwner
 }

--- a/swama/Sources/SwamaKit/Model/TokenizerCache.swift
+++ b/swama/Sources/SwamaKit/Model/TokenizerCache.swift
@@ -1,0 +1,316 @@
+import CryptoKit
+import Foundation
+import MLXLMCommon
+
+// MARK: - TokenizerInputFingerprint
+
+/// Content identity for every local file the pinned tokenizer loader currently reads, plus the
+/// common split-vocabulary files that a future compatible loader may consult. File names,
+/// presence/absence, sizes, and bytes all participate; the model name and directory path do not,
+/// so byte-identical tokenizers can be shared safely across model directories.
+struct TokenizerInputFingerprint: Equatable, Hashable, Sendable {
+    static let fileNames = [
+        "added_tokens.json",
+        "chat_template.jinja",
+        "chat_template.json",
+        "config.json",
+        "merges.txt",
+        "special_tokens_map.json",
+        "tokenizer.json",
+        "tokenizer_config.json",
+        "vocab.json"
+    ]
+
+    let digest: String
+    let byteCount: Int64
+
+    static func calculate(in directory: URL) throws -> Self {
+        var hasher = SHA256()
+        var byteCount: Int64 = 0
+
+        for fileName in fileNames {
+            hasher.update(data: Data(fileName.utf8))
+            hasher.update(data: Data([0]))
+            let file = directory.appendingPathComponent(fileName)
+            guard FileManager.default.fileExists(atPath: file.path) else {
+                hasher.update(data: Data([0]))
+                continue
+            }
+
+            let attributes = try FileManager.default.attributesOfItem(atPath: file.path)
+            guard attributes[.type] as? FileAttributeType == .typeRegular,
+                  let size = attributes[.size] as? NSNumber
+            else {
+                throw TokenizerFingerprintError.inputIsNotARegularFile(fileName)
+            }
+
+            hasher.update(data: Data([1]))
+            var bigEndianSize = size.uint64Value.bigEndian
+            withUnsafeBytes(of: &bigEndianSize) { hasher.update(bufferPointer: $0) }
+            byteCount = try adding(byteCount, Int64(bitPattern: size.uint64Value))
+
+            let handle = try FileHandle(forReadingFrom: file)
+            defer { try? handle.close() }
+            while let data = try handle.read(upToCount: 1024 * 1024), !data.isEmpty {
+                hasher.update(data: data)
+            }
+        }
+
+        return .init(
+            digest: hasher.finalize().map { String(format: "%02x", $0) }.joined(),
+            byteCount: byteCount
+        )
+    }
+
+    static func rejectionDigest(for directory: URL) -> String {
+        let payload = Data("tokenizer-rejected\0\(directory.standardizedFileURL.path)".utf8)
+        return SHA256.hash(data: payload).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func adding(_ lhs: Int64, _ rhs: Int64) throws -> Int64 {
+        let (sum, overflow) = lhs.addingReportingOverflow(rhs)
+        guard !overflow, rhs >= 0 else {
+            throw TokenizerFingerprintError.inputSizeOverflow
+        }
+
+        return sum
+    }
+}
+
+// MARK: - TokenizerFingerprintError
+
+private enum TokenizerFingerprintError: Error {
+    case inputIsNotARegularFile(String)
+    case inputSizeOverflow
+}
+
+// MARK: - TokenizerCacheConfiguration
+
+struct TokenizerCacheConfiguration: Sendable {
+    static let live: Self = .init(
+        maximumEntries: 4,
+        maximumInputBytes: 64 * 1024 * 1024
+    )
+
+    let maximumEntries: Int
+    let maximumInputBytes: Int64
+}
+
+// MARK: - TokenizerCacheDiagnostics
+
+struct TokenizerCacheDiagnostics: Sendable {
+    static let live: Self = .init(
+        hit: { SwamaDiagnostics.hitTokenizerCache(fingerprint: $0) },
+        miss: { SwamaDiagnostics.missTokenizerCache(fingerprint: $0) },
+        evict: { SwamaDiagnostics.evictTokenizerCache(fingerprint: $0, reason: $1) },
+        reject: { SwamaDiagnostics.rejectTokenizerCache(fingerprint: $0, durationMilliseconds: $1) }
+    )
+
+    static let disabled: Self = .init(
+        hit: { _ in },
+        miss: { _ in },
+        evict: { _, _ in },
+        reject: { _, _ in }
+    )
+
+    let hit: @Sendable (String) -> Void
+    let miss: @Sendable (String) -> Void
+    let evict: @Sendable (String, String) -> Void
+    let reject: @Sendable (String, Double) -> Void
+}
+
+// MARK: - TokenizerCache
+
+actor TokenizerCache {
+    static let shared: TokenizerCache = .init(configuration: .live, diagnostics: .live)
+
+    init(
+        configuration: TokenizerCacheConfiguration,
+        diagnostics: TokenizerCacheDiagnostics = .live
+    ) {
+        self.configuration = configuration
+        self.diagnostics = diagnostics
+    }
+
+    /// Loads through a content-addressed, process-local cache. Fingerprinting intentionally occurs
+    /// before entering the actor so callers hashing distinct directories do not serialize behind
+    /// one another. A failed fingerprint or an over-budget input fails open to the upstream loader
+    /// without entering either the ready cache or the coalescing table.
+    nonisolated func load(
+        from directory: URL,
+        using upstream: any TokenizerLoader
+    ) async throws -> any Tokenizer {
+        let startedAt = DispatchTime.now().uptimeNanoseconds
+        let fingerprint: TokenizerInputFingerprint
+        do {
+            fingerprint = try TokenizerInputFingerprint.calculate(in: directory)
+        }
+        catch {
+            diagnostics.reject(
+                TokenizerInputFingerprint.rejectionDigest(for: directory),
+                elapsedMilliseconds(since: startedAt)
+            )
+            return try await upstream.load(from: directory)
+        }
+
+        return try await load(
+            fingerprint: fingerprint,
+            directory: directory,
+            upstream: upstream,
+            startedAt: startedAt
+        )
+    }
+
+    func purge() {
+        for fingerprint in ready.keys.sorted() {
+            diagnostics.evict(fingerprint, "explicit")
+        }
+        ready.removeAll()
+        for pendingLoad in pending.values {
+            pendingLoad.task.cancel()
+        }
+        pending.removeAll()
+    }
+
+    #if DEBUG
+        func entryCountForTesting() -> Int {
+            ready.count
+        }
+    #endif
+
+    private struct ReadyEntry: Sendable {
+        let tokenizer: any Tokenizer
+        var lastAccess: UInt64
+    }
+
+    private struct CompletedLoad: Sendable {
+        let tokenizer: any Tokenizer
+        let fingerprintAfterLoad: TokenizerInputFingerprint?
+    }
+
+    private struct PendingLoad: Sendable {
+        let sequence: UInt64
+        let task: Task<CompletedLoad, Error>
+        let startedAt: UInt64
+    }
+
+    private let configuration: TokenizerCacheConfiguration
+    private let diagnostics: TokenizerCacheDiagnostics
+    private var ready: [String: ReadyEntry] = [:]
+    private var pending: [String: PendingLoad] = [:]
+    private var accessSequence: UInt64 = 0
+    private var loadSequence: UInt64 = 0
+
+    private func load(
+        fingerprint: TokenizerInputFingerprint,
+        directory: URL,
+        upstream: any TokenizerLoader,
+        startedAt: UInt64
+    ) async throws -> any Tokenizer {
+        guard configuration.maximumEntries > 0,
+              configuration.maximumInputBytes > 0,
+              fingerprint.byteCount <= configuration.maximumInputBytes
+        else {
+            diagnostics.reject(fingerprint.digest, elapsedMilliseconds(since: startedAt))
+            return try await upstream.load(from: directory)
+        }
+
+        if var entry = ready[fingerprint.digest] {
+            accessSequence &+= 1
+            entry.lastAccess = accessSequence
+            ready[fingerprint.digest] = entry
+            diagnostics.hit(fingerprint.digest)
+            return entry.tokenizer
+        }
+
+        if let pendingLoad = pending[fingerprint.digest] {
+            diagnostics.hit(fingerprint.digest)
+            return try await pendingLoad.task.value.tokenizer
+        }
+
+        loadSequence &+= 1
+        let sequence = loadSequence
+        let task = Task.detached { () throws -> CompletedLoad in
+            let tokenizer = try await upstream.load(from: directory)
+            let fingerprintAfterLoad = try? TokenizerInputFingerprint.calculate(in: directory)
+            return .init(tokenizer: tokenizer, fingerprintAfterLoad: fingerprintAfterLoad)
+        }
+        let pendingLoad = PendingLoad(
+            sequence: sequence,
+            task: task,
+            startedAt: startedAt
+        )
+        pending[fingerprint.digest] = pendingLoad
+        diagnostics.miss(fingerprint.digest)
+
+        do {
+            let completed = try await task.value
+            guard pending[fingerprint.digest]?.sequence == sequence else {
+                return completed.tokenizer
+            }
+
+            pending.removeValue(forKey: fingerprint.digest)
+
+            guard completed.fingerprintAfterLoad == fingerprint else {
+                diagnostics.reject(
+                    fingerprint.digest,
+                    elapsedMilliseconds(since: pendingLoad.startedAt)
+                )
+                return completed.tokenizer
+            }
+
+            accessSequence &+= 1
+            ready[fingerprint.digest] = .init(
+                tokenizer: completed.tokenizer,
+                lastAccess: accessSequence
+            )
+            evictToBudget()
+            return completed.tokenizer
+        }
+        catch {
+            if pending[fingerprint.digest]?.sequence == sequence {
+                pending.removeValue(forKey: fingerprint.digest)
+            }
+            throw error
+        }
+    }
+
+    private func evictToBudget() {
+        while ready.count > configuration.maximumEntries,
+              let victim = ready.min(by: { lhs, rhs in
+                  if lhs.value.lastAccess == rhs.value.lastAccess {
+                      lhs.key < rhs.key
+                  }
+                  else {
+                      lhs.value.lastAccess < rhs.value.lastAccess
+                  }
+              })
+        {
+            ready.removeValue(forKey: victim.key)
+            diagnostics.evict(victim.key, "budget")
+        }
+    }
+
+    private nonisolated func elapsedMilliseconds(since startedAt: UInt64) -> Double {
+        Double(DispatchTime.now().uptimeNanoseconds - startedAt) / 1_000_000
+    }
+}
+
+// MARK: - CachedTokenizerLoader
+
+struct CachedTokenizerLoader: TokenizerLoader {
+    init(
+        upstream: any TokenizerLoader,
+        cache: TokenizerCache = .shared
+    ) {
+        self.upstream = upstream
+        self.cache = cache
+    }
+
+    func load(from directory: URL) async throws -> any Tokenizer {
+        try await cache.load(from: directory, using: upstream)
+    }
+
+    private let upstream: any TokenizerLoader
+    private let cache: TokenizerCache
+}

--- a/swama/Sources/SwamaKit/Model/TokenizerCache.swift
+++ b/swama/Sources/SwamaKit/Model/TokenizerCache.swift
@@ -6,8 +6,10 @@ import MLXLMCommon
 
 /// Content identity for every local file the pinned tokenizer loader currently reads, plus the
 /// common split-vocabulary files that a future compatible loader may consult. File names,
-/// presence/absence, sizes, and bytes all participate; the model name and directory path do not,
-/// so byte-identical tokenizers can be shared safely across model directories.
+/// presence/absence, sizes, and bytes all participate except for `config.json`: the pinned loader
+/// uses only its parsed `model_type` to select a tokenizer fallback, so unrelated model-shape fields
+/// are deliberately excluded. The model name and directory path do not participate, allowing equal
+/// tokenizer inputs to be shared safely across model directories.
 struct TokenizerInputFingerprint: Equatable, Hashable, Sendable {
     static let fileNames = [
         "added_tokens.json",
@@ -45,9 +47,25 @@ struct TokenizerInputFingerprint: Equatable, Hashable, Sendable {
             }
 
             hasher.update(data: Data([1]))
+            byteCount = try adding(byteCount, Int64(bitPattern: size.uint64Value))
+            if fileName == "config.json" {
+                let data = try Data(contentsOf: file)
+                guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                    throw TokenizerFingerprintError.invalidModelConfiguration
+                }
+
+                if let modelType = object["model_type"] as? String {
+                    hasher.update(data: Data([1]))
+                    hasher.update(data: Data(modelType.utf8))
+                }
+                else {
+                    hasher.update(data: Data([0]))
+                }
+                continue
+            }
+
             var bigEndianSize = size.uint64Value.bigEndian
             withUnsafeBytes(of: &bigEndianSize) { hasher.update(bufferPointer: $0) }
-            byteCount = try adding(byteCount, Int64(bitPattern: size.uint64Value))
 
             let handle = try FileHandle(forReadingFrom: file)
             defer { try? handle.close() }
@@ -80,6 +98,7 @@ struct TokenizerInputFingerprint: Equatable, Hashable, Sendable {
 // MARK: - TokenizerFingerprintError
 
 private enum TokenizerFingerprintError: Error {
+    case invalidModelConfiguration
     case inputIsNotARegularFile(String)
     case inputSizeOverflow
 }
@@ -121,7 +140,7 @@ struct TokenizerCacheDiagnostics: Sendable {
 
 // MARK: - TokenizerCache
 
-actor TokenizerCache {
+final class TokenizerCache: @unchecked Sendable {
     static let shared: TokenizerCache = .init(configuration: .live, diagnostics: .live)
 
     init(
@@ -132,14 +151,14 @@ actor TokenizerCache {
         self.diagnostics = diagnostics
     }
 
-    /// Loads through a content-addressed, process-local cache. Fingerprinting intentionally occurs
-    /// before entering the actor so callers hashing distinct directories do not serialize behind
-    /// one another. A failed fingerprint or an over-budget input fails open to the upstream loader
-    /// without entering either the ready cache or the coalescing table.
-    nonisolated func load(
+    /// Loads through a content-addressed, process-local cache. A failed fingerprint or an
+    /// over-budget input fails open to the upstream loader without entering either the ready cache
+    /// or the coalescing table.
+    func load(
         from directory: URL,
         using upstream: any TokenizerLoader
     ) async throws -> any Tokenizer {
+        try Task.checkCancellation()
         let startedAt = DispatchTime.now().uptimeNanoseconds
         let fingerprint: TokenizerInputFingerprint
         do {
@@ -148,35 +167,105 @@ actor TokenizerCache {
         catch {
             diagnostics.reject(
                 TokenizerInputFingerprint.rejectionDigest(for: directory),
-                elapsedMilliseconds(since: startedAt)
+                Self.elapsedMilliseconds(since: startedAt)
             )
+            try Task.checkCancellation()
+            return try await upstream.load(from: directory)
+        }
+        try Task.checkCancellation()
+
+        guard configuration.maximumEntries > 0,
+              configuration.maximumInputBytes > 0,
+              fingerprint.byteCount <= configuration.maximumInputBytes
+        else {
+            diagnostics.reject(fingerprint.digest, Self.elapsedMilliseconds(since: startedAt))
+            try Task.checkCancellation()
             return try await upstream.load(from: directory)
         }
 
-        return try await load(
+        let (acquisition, newTask) = acquire(
             fingerprint: fingerprint,
             directory: directory,
-            upstream: upstream,
-            startedAt: startedAt
+            upstream: upstream
         )
+        switch acquisition {
+        case let .ready(tokenizer):
+            diagnostics.hit(fingerprint.digest)
+            return tokenizer
+
+        case let .waiting(sequence, waiter):
+            if let newTask {
+                diagnostics.miss(fingerprint.digest)
+                observe(
+                    newTask,
+                    fingerprint: fingerprint,
+                    sequence: sequence,
+                    startedAt: startedAt
+                )
+            }
+            else {
+                diagnostics.hit(fingerprint.digest)
+            }
+
+            let completed = try await waiter.value {
+                self.cancelWaiter(
+                    fingerprint: fingerprint.digest,
+                    sequence: sequence,
+                    waiterID: waiter.id
+                )
+            }
+            try Task.checkCancellation()
+            let fingerprintAfterWaiting = try? TokenizerInputFingerprint.calculate(in: directory)
+            try Task.checkCancellation()
+            guard fingerprintAfterWaiting == fingerprint else {
+                diagnostics.reject(
+                    fingerprint.digest,
+                    Self.elapsedMilliseconds(since: startedAt)
+                )
+                throw TokenizerCacheError.inputsChangedDuringLoad
+            }
+
+            return completed.tokenizer
+        }
     }
 
     func purge() {
-        for fingerprint in ready.keys.sorted() {
+        let (fingerprints, pendingLoads) = lock.withLock { () -> ([String], [PendingLoad]) in
+            let fingerprints = ready.keys.sorted()
+            let pendingLoads = Array(pending.values)
+            ready.removeAll()
+            pending.removeAll()
+            return (fingerprints, pendingLoads)
+        }
+        for fingerprint in fingerprints {
             diagnostics.evict(fingerprint, "explicit")
         }
-        ready.removeAll()
-        for pendingLoad in pending.values {
+        for pendingLoad in pendingLoads {
             pendingLoad.task.cancel()
+            for waiter in pendingLoad.waiters.values {
+                waiter.resolve(.failure(CancellationError()))
+            }
         }
-        pending.removeAll()
     }
 
     #if DEBUG
         func entryCountForTesting() -> Int {
-            ready.count
+            lock.withLock { ready.count }
+        }
+
+        func pendingCountForTesting() -> Int {
+            lock.withLock { pending.count }
+        }
+
+        func waiterCountForTesting() -> Int {
+            lock.withLock { pending.values.reduce(0) { $0 + $1.waiters.count } }
         }
     #endif
+
+    private enum Acquisition {
+        case ready(any Tokenizer)
+        case waiting(sequence: UInt64, waiter: Waiter)
+    }
 
     private struct ReadyEntry: Sendable {
         let tokenizer: any Tokenizer
@@ -191,91 +280,145 @@ actor TokenizerCache {
     private struct PendingLoad: Sendable {
         let sequence: UInt64
         let task: Task<CompletedLoad, Error>
-        let startedAt: UInt64
+        var waiters: [UUID: Waiter]
     }
 
     private let configuration: TokenizerCacheConfiguration
     private let diagnostics: TokenizerCacheDiagnostics
+    private let lock: NSLock = .init()
     private var ready: [String: ReadyEntry] = [:]
     private var pending: [String: PendingLoad] = [:]
     private var accessSequence: UInt64 = 0
     private var loadSequence: UInt64 = 0
 
-    private func load(
+    private func acquire(
         fingerprint: TokenizerInputFingerprint,
         directory: URL,
-        upstream: any TokenizerLoader,
-        startedAt: UInt64
-    ) async throws -> any Tokenizer {
-        guard configuration.maximumEntries > 0,
-              configuration.maximumInputBytes > 0,
-              fingerprint.byteCount <= configuration.maximumInputBytes
-        else {
-            diagnostics.reject(fingerprint.digest, elapsedMilliseconds(since: startedAt))
-            return try await upstream.load(from: directory)
-        }
-
-        if var entry = ready[fingerprint.digest] {
-            accessSequence &+= 1
-            entry.lastAccess = accessSequence
-            ready[fingerprint.digest] = entry
-            diagnostics.hit(fingerprint.digest)
-            return entry.tokenizer
-        }
-
-        if let pendingLoad = pending[fingerprint.digest] {
-            diagnostics.hit(fingerprint.digest)
-            return try await pendingLoad.task.value.tokenizer
-        }
-
-        loadSequence &+= 1
-        let sequence = loadSequence
-        let task = Task.detached { () throws -> CompletedLoad in
-            let tokenizer = try await upstream.load(from: directory)
-            let fingerprintAfterLoad = try? TokenizerInputFingerprint.calculate(in: directory)
-            return .init(tokenizer: tokenizer, fingerprintAfterLoad: fingerprintAfterLoad)
-        }
-        let pendingLoad = PendingLoad(
-            sequence: sequence,
-            task: task,
-            startedAt: startedAt
-        )
-        pending[fingerprint.digest] = pendingLoad
-        diagnostics.miss(fingerprint.digest)
-
-        do {
-            let completed = try await task.value
-            guard pending[fingerprint.digest]?.sequence == sequence else {
-                return completed.tokenizer
+        upstream: any TokenizerLoader
+    ) -> (Acquisition, Task<CompletedLoad, Error>?) {
+        lock.withLock {
+            if var entry = ready[fingerprint.digest] {
+                accessSequence &+= 1
+                entry.lastAccess = accessSequence
+                ready[fingerprint.digest] = entry
+                return (.ready(entry.tokenizer), nil)
             }
 
-            pending.removeValue(forKey: fingerprint.digest)
-
-            guard completed.fingerprintAfterLoad == fingerprint else {
-                diagnostics.reject(
-                    fingerprint.digest,
-                    elapsedMilliseconds(since: pendingLoad.startedAt)
-                )
-                return completed.tokenizer
+            let waiter = Waiter()
+            if var pendingLoad = pending[fingerprint.digest] {
+                pendingLoad.waiters[waiter.id] = waiter
+                pending[fingerprint.digest] = pendingLoad
+                return (.waiting(sequence: pendingLoad.sequence, waiter: waiter), nil)
             }
 
-            accessSequence &+= 1
-            ready[fingerprint.digest] = .init(
-                tokenizer: completed.tokenizer,
-                lastAccess: accessSequence
+            loadSequence &+= 1
+            let sequence = loadSequence
+            let task = Task.detached { () throws -> CompletedLoad in
+                let tokenizer = try await upstream.load(from: directory)
+                let fingerprintAfterLoad = try? TokenizerInputFingerprint.calculate(in: directory)
+                return .init(tokenizer: tokenizer, fingerprintAfterLoad: fingerprintAfterLoad)
+            }
+            pending[fingerprint.digest] = .init(
+                sequence: sequence,
+                task: task,
+                waiters: [waiter.id: waiter]
             )
-            evictToBudget()
-            return completed.tokenizer
-        }
-        catch {
-            if pending[fingerprint.digest]?.sequence == sequence {
-                pending.removeValue(forKey: fingerprint.digest)
-            }
-            throw error
+            return (.waiting(sequence: sequence, waiter: waiter), task)
         }
     }
 
-    private func evictToBudget() {
+    private func observe(
+        _ task: Task<CompletedLoad, Error>,
+        fingerprint: TokenizerInputFingerprint,
+        sequence: UInt64,
+        startedAt: UInt64
+    ) {
+        Task.detached { [self] in
+            let result = await task.result
+            complete(
+                result,
+                fingerprint: fingerprint,
+                sequence: sequence,
+                startedAt: startedAt
+            )
+        }
+    }
+
+    private func complete(
+        _ result: Result<CompletedLoad, Error>,
+        fingerprint: TokenizerInputFingerprint,
+        sequence: UInt64,
+        startedAt: UInt64
+    ) {
+        var finalResult = result
+        var waiters: [Waiter] = []
+        var evictedFingerprints: [String] = []
+        var rejected = false
+
+        lock.lock()
+        guard let pendingLoad = pending[fingerprint.digest], pendingLoad.sequence == sequence else {
+            lock.unlock()
+            return
+        }
+
+        pending.removeValue(forKey: fingerprint.digest)
+        waiters = Array(pendingLoad.waiters.values)
+
+        if case let .success(completed) = result {
+            if completed.fingerprintAfterLoad == fingerprint {
+                accessSequence &+= 1
+                ready[fingerprint.digest] = .init(
+                    tokenizer: completed.tokenizer,
+                    lastAccess: accessSequence
+                )
+                evictedFingerprints = evictToBudgetLocked()
+            }
+            else {
+                rejected = true
+                finalResult = .failure(TokenizerCacheError.inputsChangedDuringLoad)
+            }
+        }
+        lock.unlock()
+
+        if rejected {
+            diagnostics.reject(
+                fingerprint.digest,
+                Self.elapsedMilliseconds(since: startedAt)
+            )
+        }
+        for evictedFingerprint in evictedFingerprints {
+            diagnostics.evict(evictedFingerprint, "budget")
+        }
+        for waiter in waiters {
+            waiter.resolve(finalResult)
+        }
+    }
+
+    private func cancelWaiter(
+        fingerprint: String,
+        sequence: UInt64,
+        waiterID: UUID
+    ) {
+        var taskToCancel: Task<CompletedLoad, Error>?
+        lock.withLock {
+            guard var pendingLoad = pending[fingerprint], pendingLoad.sequence == sequence else {
+                return
+            }
+
+            pendingLoad.waiters.removeValue(forKey: waiterID)
+            if pendingLoad.waiters.isEmpty {
+                pending.removeValue(forKey: fingerprint)
+                taskToCancel = pendingLoad.task
+            }
+            else {
+                pending[fingerprint] = pendingLoad
+            }
+        }
+        taskToCancel?.cancel()
+    }
+
+    private func evictToBudgetLocked() -> [String] {
+        var fingerprints: [String] = []
         while ready.count > configuration.maximumEntries,
               let victim = ready.min(by: { lhs, rhs in
                   if lhs.value.lastAccess == rhs.value.lastAccess {
@@ -287,13 +430,92 @@ actor TokenizerCache {
               })
         {
             ready.removeValue(forKey: victim.key)
-            diagnostics.evict(victim.key, "budget")
+            fingerprints.append(victim.key)
         }
+        return fingerprints
     }
 
-    private nonisolated func elapsedMilliseconds(since startedAt: UInt64) -> Double {
+    private static func elapsedMilliseconds(since startedAt: UInt64) -> Double {
         Double(DispatchTime.now().uptimeNanoseconds - startedAt) / 1_000_000
     }
+
+    private final class Waiter: @unchecked Sendable {
+        let id: UUID = .init()
+
+        func value(onCancel: @escaping @Sendable () -> Void) async throws -> CompletedLoad {
+            do {
+                try Task.checkCancellation()
+                return try await withTaskCancellationHandler {
+                    try await withCheckedThrowingContinuation { continuation in
+                        let immediate = lock.withLock { () -> Result<CompletedLoad, Error>? in
+                            if let result {
+                                return result
+                            }
+                            if cancelled {
+                                return .failure(CancellationError())
+                            }
+                            self.continuation = continuation
+                            return nil
+                        }
+                        if let immediate {
+                            continuation.resume(with: immediate)
+                        }
+                    }
+                } onCancel: {
+                    if self.cancel() {
+                        onCancel()
+                    }
+                }
+            }
+            catch is CancellationError {
+                if cancel() {
+                    onCancel()
+                }
+                throw CancellationError()
+            }
+        }
+
+        func resolve(_ result: Result<CompletedLoad, Error>) {
+            let continuation = lock.withLock { () -> CheckedContinuation<CompletedLoad, Error>? in
+                guard self.result == nil, !cancelled else {
+                    return nil
+                }
+
+                self.result = result
+                let continuation = self.continuation
+                self.continuation = nil
+                return continuation
+            }
+            continuation?.resume(with: result)
+        }
+
+        private func cancel() -> Bool {
+            let (didCancel, continuation) = lock.withLock {
+                () -> (Bool, CheckedContinuation<CompletedLoad, Error>?) in
+                guard result == nil, !cancelled else {
+                    return (false, nil)
+                }
+
+                cancelled = true
+                let continuation = self.continuation
+                self.continuation = nil
+                return (true, continuation)
+            }
+            continuation?.resume(throwing: CancellationError())
+            return didCancel
+        }
+
+        private let lock: NSLock = .init()
+        private var continuation: CheckedContinuation<CompletedLoad, Error>?
+        private var result: Result<CompletedLoad, Error>?
+        private var cancelled = false
+    }
+}
+
+// MARK: - TokenizerCacheError
+
+enum TokenizerCacheError: Error {
+    case inputsChangedDuringLoad
 }
 
 // MARK: - CachedTokenizerLoader

--- a/swama/Tests/SwamaKitTests/TokenizerCacheTests.swift
+++ b/swama/Tests/SwamaKitTests/TokenizerCacheTests.swift
@@ -1,0 +1,502 @@
+import Foundation
+import MLXLMCommon
+@testable import SwamaKit
+import Testing
+
+// MARK: - TokenizerCacheTests
+
+@Suite("Bounded tokenizer cache", .serialized)
+struct TokenizerCacheTests {
+    @Test func identicalInputsAcrossDirectoriesCoalesceAndShare() async throws {
+        let fixture = try TokenizerFixture()
+        defer { fixture.remove() }
+        let first = try fixture.directory(named: "first")
+        let second = try fixture.directory(named: "second")
+        let loader = CountingTokenizerLoader(delay: .milliseconds(100))
+        let cache = TokenizerCache(
+            configuration: .init(maximumEntries: 4, maximumInputBytes: 1_000_000),
+            diagnostics: .disabled
+        )
+
+        async let firstValue = cache.load(from: first, using: loader)
+        async let secondValue = cache.load(from: second, using: loader)
+        let values = try await [firstValue, secondValue]
+
+        #expect(await loader.calls == 1)
+        #expect(values.compactMap { ($0 as? StubTokenizer)?.identifier } == ["load-1", "load-1"])
+
+        _ = try await cache.load(from: first, using: loader)
+        #expect(await loader.calls == 1)
+    }
+
+    @Test func diagnosticLoaderUsesTheCacheAndTimesHitsAsWellAsMisses() async throws {
+        let fixture = try TokenizerFixture()
+        defer { fixture.remove() }
+        let directory = try fixture.directory(named: "diagnostic-loader")
+        let upstream = CountingTokenizerLoader()
+        let cache = TokenizerCache(
+            configuration: .init(maximumEntries: 4, maximumInputBytes: 1_000_000),
+            diagnostics: .disabled
+        )
+        let missPhases = ModelLoadPhaseRecorder()
+        let hitPhases = ModelLoadPhaseRecorder()
+
+        _ = try await DiagnosticTokenizerLoader(
+            upstream: upstream,
+            phases: missPhases,
+            cache: cache
+        ).load(from: directory)
+        _ = try await DiagnosticTokenizerLoader(
+            upstream: upstream,
+            phases: hitPhases,
+            cache: cache
+        ).load(from: directory)
+
+        #expect(await upstream.calls == 1)
+        #expect(missPhases.phases.tokenizerMs != nil)
+        #expect(hitPhases.phases.tokenizerMs != nil)
+    }
+
+    @Test func everyDeclaredTokenizerInputChangesIdentity() async throws {
+        let fixture = try TokenizerFixture()
+        defer { fixture.remove() }
+        let loader = CountingTokenizerLoader()
+        let cache = TokenizerCache(
+            configuration: .init(
+                maximumEntries: expectedTokenizerInputFileNames.count + 1,
+                maximumInputBytes: 1_000_000
+            ),
+            diagnostics: .disabled
+        )
+        let baseline = try fixture.directory(named: "baseline")
+        _ = try await cache.load(from: baseline, using: loader)
+
+        #expect(TokenizerInputFingerprint.fileNames == expectedTokenizerInputFileNames)
+        for fileName in expectedTokenizerInputFileNames {
+            let changed = try fixture.directory(named: "changed-\(fileName.replacingOccurrences(of: ".", with: "-"))")
+            try Data("changed \(fileName)".utf8).write(to: changed.appendingPathComponent(fileName))
+            _ = try await cache.load(from: changed, using: loader)
+        }
+
+        #expect(await loader.calls == expectedTokenizerInputFileNames.count + 1)
+    }
+
+    @Test func missingAndEmptyOptionalInputsHaveDifferentIdentities() async throws {
+        let fixture = try TokenizerFixture()
+        defer { fixture.remove() }
+        let missing = try fixture.directory(named: "missing")
+        let empty = try fixture.directory(named: "empty")
+        try FileManager.default.removeItem(at: missing.appendingPathComponent("merges.txt"))
+        try Data().write(to: empty.appendingPathComponent("merges.txt"))
+        let loader = CountingTokenizerLoader()
+        let cache = TokenizerCache(
+            configuration: .init(maximumEntries: 4, maximumInputBytes: 1_000_000),
+            diagnostics: .disabled
+        )
+
+        _ = try await cache.load(from: missing, using: loader)
+        _ = try await cache.load(from: empty, using: loader)
+
+        #expect(await loader.calls == 2)
+    }
+
+    @Test func sameSizeContentChangeCannotReuseThePriorEntry() async throws {
+        let fixture = try TokenizerFixture()
+        defer { fixture.remove() }
+        let directory = try fixture.directory(named: "same-size-change")
+        let tokenizerFile = directory.appendingPathComponent("tokenizer.json")
+        let original = try Data(contentsOf: tokenizerFile)
+        let loader = CountingTokenizerLoader()
+        let cache = TokenizerCache(
+            configuration: .init(maximumEntries: 4, maximumInputBytes: 1_000_000),
+            diagnostics: .disabled
+        )
+
+        _ = try await cache.load(from: directory, using: loader)
+        try Data(repeating: 0x78, count: original.count).write(to: tokenizerFile)
+        _ = try await cache.load(from: directory, using: loader)
+
+        #expect(await loader.calls == 2)
+    }
+
+    @Test func modelWeightsAndGenerationPolicyDoNotSplitIdenticalTokenizers() async throws {
+        let fixture = try TokenizerFixture()
+        defer { fixture.remove() }
+        let first = try fixture.directory(named: "first")
+        let second = try fixture.directory(named: "second")
+        for (fileName, firstValue, secondValue) in [
+            ("generation_config.json", "first-stop-policy", "second-stop-policy"),
+            ("model.safetensors", "first-weights", "second-weights"),
+            ("preprocessor_config.json", "first-vision", "second-vision"),
+            (".swama-meta.json", "first-metadata", "second-metadata")
+        ] {
+            try Data(firstValue.utf8).write(to: first.appendingPathComponent(fileName))
+            try Data(secondValue.utf8).write(to: second.appendingPathComponent(fileName))
+        }
+        let loader = CountingTokenizerLoader(delay: .milliseconds(100))
+        let cache = TokenizerCache(
+            configuration: .init(maximumEntries: 4, maximumInputBytes: 1_000_000),
+            diagnostics: .disabled
+        )
+
+        async let firstValue = cache.load(from: first, using: loader)
+        async let secondValue = cache.load(from: second, using: loader)
+        _ = try await [firstValue, secondValue]
+
+        #expect(await loader.calls == 1)
+    }
+
+    @Test func failedLoadsAreNeverCached() async throws {
+        let fixture = try TokenizerFixture()
+        defer { fixture.remove() }
+        let directory = try fixture.directory(named: "failure")
+        let loader = CountingTokenizerLoader(failuresRemaining: 1)
+        let cache = TokenizerCache(
+            configuration: .init(maximumEntries: 4, maximumInputBytes: 1_000_000),
+            diagnostics: .disabled
+        )
+
+        await #expect(throws: StubLoaderError.self) {
+            _ = try await cache.load(from: directory, using: loader)
+        }
+        _ = try await cache.load(from: directory, using: loader)
+        _ = try await cache.load(from: directory, using: loader)
+
+        #expect(await loader.calls == 2)
+    }
+
+    @Test func leastRecentlyUsedEntryIsEvictedAndExplicitPurgeClearsTheRest() async throws {
+        let fixture = try TokenizerFixture()
+        defer { fixture.remove() }
+        let first = try fixture.directory(named: "first", seed: "first")
+        let second = try fixture.directory(named: "second", seed: "second")
+        let third = try fixture.directory(named: "third", seed: "third")
+        let loader = CountingTokenizerLoader()
+        let cache = TokenizerCache(
+            configuration: .init(maximumEntries: 2, maximumInputBytes: 1_000_000),
+            diagnostics: .disabled
+        )
+
+        _ = try await cache.load(from: first, using: loader)
+        _ = try await cache.load(from: second, using: loader)
+        _ = try await cache.load(from: first, using: loader) // first is now most-recently used
+        _ = try await cache.load(from: third, using: loader) // second is evicted
+        _ = try await cache.load(from: second, using: loader)
+        #expect(await loader.calls == 4)
+        #expect(await cache.entryCountForTesting() == 2)
+
+        await cache.purge()
+        #expect(await cache.entryCountForTesting() == 0)
+        _ = try await cache.load(from: second, using: loader)
+        #expect(await loader.calls == 5)
+    }
+
+    @Test func purgeInvalidatesAnInFlightLoadInsteadOfResurrectingIt() async throws {
+        let fixture = try TokenizerFixture()
+        defer { fixture.remove() }
+        let directory = try fixture.directory(named: "in-flight")
+        let loader = CountingTokenizerLoader(delay: .milliseconds(200))
+        let cache = TokenizerCache(
+            configuration: .init(maximumEntries: 4, maximumInputBytes: 1_000_000),
+            diagnostics: .disabled
+        )
+
+        let first = Task { try await cache.load(from: directory, using: loader) }
+        while await loader.calls == 0 {
+            await Task.yield()
+        }
+        await cache.purge()
+        _ = try await first.value
+        #expect(await cache.entryCountForTesting() == 0)
+
+        _ = try await cache.load(from: directory, using: loader)
+        #expect(await loader.calls == 2)
+    }
+
+    @Test func inputsChangedDuringLoadAreReturnedButNeverCachedUnderTheOldFingerprint() async throws {
+        let fixture = try TokenizerFixture()
+        defer { fixture.remove() }
+        let directory = try fixture.directory(named: "changing")
+        let loader = MutatingTokenizerLoader(fileName: "tokenizer_config.json")
+        let cache = TokenizerCache(
+            configuration: .init(maximumEntries: 4, maximumInputBytes: 1_000_000),
+            diagnostics: .disabled
+        )
+
+        _ = try await cache.load(from: directory, using: loader)
+        #expect(await cache.entryCountForTesting() == 0)
+        _ = try await cache.load(from: directory, using: loader)
+        _ = try await cache.load(from: directory, using: loader)
+
+        #expect(await loader.calls == 2)
+        #expect(await cache.entryCountForTesting() == 1)
+    }
+
+    @Test func oversizedInputsLoadWithoutEnteringTheCache() async throws {
+        let fixture = try TokenizerFixture()
+        defer { fixture.remove() }
+        let directory = try fixture.directory(named: "oversized")
+        let loader = CountingTokenizerLoader()
+        let cache = TokenizerCache(
+            configuration: .init(maximumEntries: 4, maximumInputBytes: 1),
+            diagnostics: .disabled
+        )
+
+        _ = try await cache.load(from: directory, using: loader)
+        _ = try await cache.load(from: directory, using: loader)
+
+        #expect(await loader.calls == 2)
+        #expect(await cache.entryCountForTesting() == 0)
+    }
+
+    @Test func purgeReleasesTheTokenizerOwner() async throws {
+        let fixture = try TokenizerFixture()
+        defer { fixture.remove() }
+        let directory = try fixture.directory(named: "lifetime")
+        var lifetime: TokenizerLifetime? = TokenizerLifetime()
+        let loader = try LifetimeTokenizerLoader(lifetime: #require(lifetime))
+        let cache = TokenizerCache(
+            configuration: .init(maximumEntries: 1, maximumInputBytes: 1_000_000),
+            diagnostics: .disabled
+        )
+        weak let weakLifetime = lifetime
+        lifetime = nil
+
+        var tokenizer: (any MLXLMCommon.Tokenizer)? = try await cache.load(from: directory, using: loader)
+        #expect(weakLifetime != nil)
+        tokenizer = nil
+        _ = tokenizer
+        await cache.purge()
+
+        #expect(weakLifetime == nil)
+    }
+
+    @Test func diagnosticsEmitHitMissEvictionAndRejectionWithoutPaths() async throws {
+        let fixture = try TokenizerFixture()
+        defer { fixture.remove() }
+        let first = try fixture.directory(named: "first", seed: "first")
+        let second = try fixture.directory(named: "second", seed: "second")
+        let sink = TokenizerDiagnosticSink()
+        let recorder = SwamaDiagnosticRecorder(
+            enabled: true,
+            primaryWrite: { sink.append($0) },
+            fallbackWrite: { sink.append($0) }
+        )
+        recorder.start(mode: .cli)
+        let previous = SwamaDiagnostics.installRecorderForTesting(recorder)
+        defer { SwamaDiagnostics.restoreRecorderForTesting(previous) }
+
+        let loader = CountingTokenizerLoader()
+        let cache = TokenizerCache(
+            configuration: .init(maximumEntries: 1, maximumInputBytes: 1_000_000),
+            diagnostics: .live
+        )
+        _ = try await cache.load(from: first, using: loader) // miss
+        _ = try await cache.load(from: first, using: loader) // hit
+        _ = try await cache.load(from: second, using: loader) // miss + budget eviction
+        await cache.purge() // explicit eviction
+
+        let rejectingCache = TokenizerCache(
+            configuration: .init(maximumEntries: 1, maximumInputBytes: 1),
+            diagnostics: .live
+        )
+        _ = try await rejectingCache.load(from: first, using: loader)
+        recorder.stop(outcome: .ok)
+        recorder.flush()
+
+        let events = try diagnosticEvents(from: sink.data)
+        let tokenizerEvents = events.filter { $0.subsystem == "tokenizer" }
+        #expect(tokenizerEvents.map(\.event) == [
+            .tokenizerCacheMiss,
+            .tokenizerCacheHit,
+            .tokenizerCacheMiss,
+            .tokenizerCacheEvicted,
+            .tokenizerCacheEvicted,
+            .tokenizerCacheRejected
+        ])
+        #expect(tokenizerEvents.allSatisfy { event in
+            guard case let .string(fingerprint)? = event.data?["fingerprint"] else {
+                return false
+            }
+
+            return fingerprint.count == 64 && !sink.text.contains(fixture.root.path)
+        })
+        #expect(SwamaDiagnostics.isValidSnapshot(sink.data))
+    }
+}
+
+// MARK: - StubLoaderError
+
+private enum StubLoaderError: Error {
+    case injected
+}
+
+// MARK: - StubTokenizer
+
+private struct StubTokenizer: MLXLMCommon.Tokenizer {
+    let identifier: String
+
+    func encode(text _: String, addSpecialTokens _: Bool) -> [Int] { [identifier.count] }
+    func decode(tokenIds _: [Int], skipSpecialTokens _: Bool) -> String { identifier }
+    func convertTokenToId(_: String) -> Int? { nil }
+    func convertIdToToken(_: Int) -> String? { nil }
+    var bosToken: String? { nil }
+    var eosToken: String? { nil }
+    var unknownToken: String? { nil }
+    func applyChatTemplate(
+        messages _: [[String: any Sendable]],
+        tools _: [[String: any Sendable]]?,
+        additionalContext _: [String: any Sendable]?
+    ) throws -> [Int] { [] }
+}
+
+// MARK: - CountingTokenizerLoader
+
+private actor CountingTokenizerLoader: TokenizerLoader {
+    init(failuresRemaining: Int = 0, delay: Duration? = nil) {
+        self.failuresRemaining = failuresRemaining
+        self.delay = delay
+    }
+
+    var calls: Int { callCount }
+
+    func load(from _: URL) async throws -> any MLXLMCommon.Tokenizer {
+        callCount += 1
+        let current = callCount
+        if failuresRemaining > 0 {
+            failuresRemaining -= 1
+            throw StubLoaderError.injected
+        }
+        if let delay {
+            try? await Task.sleep(for: delay)
+        }
+        return StubTokenizer(identifier: "load-\(current)")
+    }
+
+    private var callCount = 0
+    private var failuresRemaining: Int
+    private let delay: Duration?
+}
+
+// MARK: - MutatingTokenizerLoader
+
+private actor MutatingTokenizerLoader: TokenizerLoader {
+    init(fileName: String) {
+        self.fileName = fileName
+    }
+
+    var calls: Int { callCount }
+
+    func load(from directory: URL) async throws -> any MLXLMCommon.Tokenizer {
+        callCount += 1
+        if callCount == 1 {
+            try Data("mutated-during-load".utf8).write(to: directory.appendingPathComponent(fileName))
+        }
+        return StubTokenizer(identifier: "load-\(callCount)")
+    }
+
+    private let fileName: String
+    private var callCount = 0
+}
+
+// MARK: - TokenizerLifetime
+
+private final class TokenizerLifetime: @unchecked Sendable {}
+
+// MARK: - LifetimeTokenizer
+
+private struct LifetimeTokenizer: MLXLMCommon.Tokenizer {
+    let lifetime: TokenizerLifetime
+
+    func encode(text _: String, addSpecialTokens _: Bool) -> [Int] { [] }
+    func decode(tokenIds _: [Int], skipSpecialTokens _: Bool) -> String { "" }
+    func convertTokenToId(_: String) -> Int? { nil }
+    func convertIdToToken(_: Int) -> String? { nil }
+    var bosToken: String? { nil }
+    var eosToken: String? { nil }
+    var unknownToken: String? { nil }
+    func applyChatTemplate(
+        messages _: [[String: any Sendable]],
+        tools _: [[String: any Sendable]]?,
+        additionalContext _: [String: any Sendable]?
+    ) throws -> [Int] { [] }
+}
+
+// MARK: - LifetimeTokenizerLoader
+
+private actor LifetimeTokenizerLoader: TokenizerLoader {
+    init(lifetime: TokenizerLifetime) {
+        self.lifetime = lifetime
+    }
+
+    func load(from _: URL) async throws -> any MLXLMCommon.Tokenizer {
+        let value = try #require(lifetime)
+        lifetime = nil
+        return LifetimeTokenizer(lifetime: value)
+    }
+
+    private var lifetime: TokenizerLifetime?
+}
+
+// MARK: - TokenizerDiagnosticSink
+
+private final class TokenizerDiagnosticSink: @unchecked Sendable {
+    var data: Data { lock.withLock { storage } }
+    var text: String { String(decoding: data, as: UTF8.self) }
+
+    func append(_ data: Data) {
+        lock.withLock { storage.append(data) }
+    }
+
+    private let lock: NSLock = .init()
+    private var storage: Data = .init()
+}
+
+// MARK: - TokenizerFixture
+
+private struct TokenizerFixture {
+    let root: URL
+
+    init() throws {
+        root = FileManager.default
+            .temporaryDirectory
+            .appendingPathComponent("swama-tokenizer-cache-tests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    }
+
+    func directory(named name: String, seed: String = "shared") throws -> URL {
+        let directory = root.appendingPathComponent(name)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        for fileName in expectedTokenizerInputFileNames {
+            try Data("\(seed):\(fileName)".utf8).write(to: directory.appendingPathComponent(fileName))
+        }
+        return directory
+    }
+
+    func remove() {
+        try? FileManager.default.removeItem(at: root)
+    }
+}
+
+private let expectedTokenizerInputFileNames = [
+    "added_tokens.json",
+    "chat_template.jinja",
+    "chat_template.json",
+    "config.json",
+    "merges.txt",
+    "special_tokens_map.json",
+    "tokenizer.json",
+    "tokenizer_config.json",
+    "vocab.json"
+]
+
+private func diagnosticEvents(from data: Data) throws -> [SwamaDiagnosticEvent] {
+    switch SwamaDiagnosticTimeline.parse(data) {
+    case let .valid(events):
+        events
+    case .degraded:
+        throw StubLoaderError.injected
+    case .unknown:
+        throw StubLoaderError.injected
+    }
+}

--- a/swama/Tests/SwamaKitTests/TokenizerCacheTests.swift
+++ b/swama/Tests/SwamaKitTests/TokenizerCacheTests.swift
@@ -535,6 +535,39 @@ struct TokenizerCacheTests {
         #expect(cache.entryCountForTesting() == 0)
     }
 
+    @Test func releasingAModelPoolReleasesItsTokenizerOwnership() async throws {
+        let fixture = try TokenizerFixture()
+        defer { fixture.remove() }
+        let directory = try fixture.directory(named: "released-pool")
+        var lifetime: TokenizerLifetime? = TokenizerLifetime()
+        let loader = try LifetimeTokenizerLoader(lifetime: #require(lifetime))
+        let cache = TokenizerCache(
+            configuration: .init(maximumEntries: 1, maximumInputBytes: 1_000_000),
+            diagnostics: .disabled
+        )
+        let owner = TokenizerCacheOwner()
+        var tokenizer: (any MLXLMCommon.Tokenizer)? = try await cache.load(
+            from: directory,
+            using: loader,
+            owner: owner
+        )
+        weak let weakLifetime = lifetime
+        lifetime = nil
+        tokenizer = nil
+        _ = tokenizer
+
+        var pool: ModelPool? = ModelPool(
+            memoryHooks: .init(activeMemory: { 0 }, clearCache: {}),
+            tokenizerCache: cache,
+            tokenizerCacheOwner: owner
+        )
+        #expect(pool != nil)
+        pool = nil
+
+        #expect(weakLifetime == nil)
+        #expect(cache.entryCountForTesting() == 0)
+    }
+
     @Test func diagnosticsEmitHitMissEvictionAndRejectionWithoutPaths() async throws {
         let fixture = try TokenizerFixture()
         defer { fixture.remove() }

--- a/swama/Tests/SwamaKitTests/TokenizerCacheTests.swift
+++ b/swama/Tests/SwamaKitTests/TokenizerCacheTests.swift
@@ -459,7 +459,12 @@ struct TokenizerCacheTests {
             configuration: .init(maximumEntries: 1, maximumInputBytes: 1_000_000),
             diagnostics: .disabled
         )
-        var tokenizer: (any MLXLMCommon.Tokenizer)? = try await cache.load(from: directory, using: loader)
+        let owner = TokenizerCacheOwner()
+        var tokenizer: (any MLXLMCommon.Tokenizer)? = try await cache.load(
+            from: directory,
+            using: loader,
+            owner: owner
+        )
         lifetime = nil
         tokenizer = nil
         _ = tokenizer
@@ -470,12 +475,64 @@ struct TokenizerCacheTests {
                 activeMemory: { 0 },
                 clearCache: { observation.recordCleanup() }
             ),
-            tokenizerCache: cache
+            tokenizerCache: cache,
+            tokenizerCacheOwner: owner
         )
         await pool.clearCache()
 
         #expect(observation.wasReleasedBeforeCleanup)
         #expect(!observation.isAlive)
+    }
+
+    @Test func clearingOneModelPoolDoesNotCancelAStandaloneTokenizerLoad() async throws {
+        let fixture = try TokenizerFixture()
+        defer { fixture.remove() }
+        let directory = try fixture.directory(named: "standalone-load")
+        let loader = SuspendedTokenizerLoader()
+        let sharedCache = TokenizerCache(
+            configuration: .init(maximumEntries: 2, maximumInputBytes: 1_000_000),
+            diagnostics: .disabled
+        )
+        let standalone = Task {
+            try await sharedCache.load(from: directory, using: loader)
+        }
+        await loader.waitUntilStarted()
+
+        let unrelatedPool = ModelPool(
+            memoryHooks: .init(activeMemory: { 0 }, clearCache: {}),
+            tokenizerCache: sharedCache
+        )
+        await unrelatedPool.clearCache()
+
+        #expect(sharedCache.pendingCountForTesting() == 1)
+        #expect(sharedCache.waiterCountForTesting() == 1)
+        await loader.release()
+        let tokenizer = try await standalone.value
+        #expect((tokenizer as? StubTokenizer)?.identifier == "load-1")
+        #expect(await loader.wasCancelled == false)
+    }
+
+    @Test func ownerScopedPurgePreservesCrossOwnerHits() async throws {
+        let fixture = try TokenizerFixture()
+        defer { fixture.remove() }
+        let directory = try fixture.directory(named: "cross-owner")
+        let loader = CountingTokenizerLoader()
+        let cache = TokenizerCache(
+            configuration: .init(maximumEntries: 1, maximumInputBytes: 1_000_000),
+            diagnostics: .disabled
+        )
+        let firstOwner = TokenizerCacheOwner()
+        let secondOwner = TokenizerCacheOwner()
+
+        _ = try await cache.load(from: directory, using: loader, owner: firstOwner)
+        _ = try await cache.load(from: directory, using: loader, owner: secondOwner)
+        cache.purge(owner: firstOwner)
+        _ = try await cache.load(from: directory, using: loader, owner: secondOwner)
+
+        #expect(await loader.calls == 1)
+        #expect(cache.entryCountForTesting() == 1)
+        cache.purge(owner: secondOwner)
+        #expect(cache.entryCountForTesting() == 0)
     }
 
     @Test func diagnosticsEmitHitMissEvictionAndRejectionWithoutPaths() async throws {

--- a/swama/Tests/SwamaKitTests/TokenizerCacheTests.swift
+++ b/swama/Tests/SwamaKitTests/TokenizerCacheTests.swift
@@ -74,7 +74,10 @@ struct TokenizerCacheTests {
         #expect(TokenizerInputFingerprint.fileNames == expectedTokenizerInputFileNames)
         for fileName in expectedTokenizerInputFileNames {
             let changed = try fixture.directory(named: "changed-\(fileName.replacingOccurrences(of: ".", with: "-"))")
-            try Data("changed \(fileName)".utf8).write(to: changed.appendingPathComponent(fileName))
+            let data = fileName == "config.json"
+                ? Data(#"{"model_type":"changed-model"}"#.utf8)
+                : Data("changed \(fileName)".utf8)
+            try data.write(to: changed.appendingPathComponent(fileName))
             _ = try await cache.load(from: changed, using: loader)
         }
 
@@ -119,6 +122,29 @@ struct TokenizerCacheTests {
         #expect(await loader.calls == 2)
     }
 
+    @Test func invalidModelConfigurationNeverFallsBackToAnOldEntry() async throws {
+        let fixture = try TokenizerFixture()
+        defer { fixture.remove() }
+        let directory = try fixture.directory(named: "invalid-config")
+        let loader = ConfigurationValidatingTokenizerLoader()
+        let cache = TokenizerCache(
+            configuration: .init(maximumEntries: 4, maximumInputBytes: 1_000_000),
+            diagnostics: .disabled
+        )
+
+        _ = try await cache.load(from: directory, using: loader)
+        try Data("not valid json".utf8).write(to: directory.appendingPathComponent("config.json"))
+        await #expect(throws: StubLoaderError.self) {
+            _ = try await cache.load(from: directory, using: loader)
+        }
+        await #expect(throws: StubLoaderError.self) {
+            _ = try await cache.load(from: directory, using: loader)
+        }
+
+        #expect(await loader.calls == 3)
+        #expect(cache.entryCountForTesting() == 1)
+    }
+
     @Test func modelWeightsAndGenerationPolicyDoNotSplitIdenticalTokenizers() async throws {
         let fixture = try TokenizerFixture()
         defer { fixture.remove() }
@@ -133,6 +159,28 @@ struct TokenizerCacheTests {
             try Data(firstValue.utf8).write(to: first.appendingPathComponent(fileName))
             try Data(secondValue.utf8).write(to: second.appendingPathComponent(fileName))
         }
+        let loader = CountingTokenizerLoader(delay: .milliseconds(100))
+        let cache = TokenizerCache(
+            configuration: .init(maximumEntries: 4, maximumInputBytes: 1_000_000),
+            diagnostics: .disabled
+        )
+
+        async let firstValue = cache.load(from: first, using: loader)
+        async let secondValue = cache.load(from: second, using: loader)
+        _ = try await [firstValue, secondValue]
+
+        #expect(await loader.calls == 1)
+    }
+
+    @Test func unrelatedModelConfigurationFieldsDoNotSplitTheSameModelType() async throws {
+        let fixture = try TokenizerFixture()
+        defer { fixture.remove() }
+        let first = try fixture.directory(named: "first")
+        let second = try fixture.directory(named: "second")
+        try Data(#"{"model_type":"shared-model","hidden_size":128}"#.utf8)
+            .write(to: first.appendingPathComponent("config.json"))
+        try Data(#"{"model_type":"shared-model","hidden_size":4096}"#.utf8)
+            .write(to: second.appendingPathComponent("config.json"))
         let loader = CountingTokenizerLoader(delay: .milliseconds(100))
         let cache = TokenizerCache(
             configuration: .init(maximumEntries: 4, maximumInputBytes: 1_000_000),
@@ -183,10 +231,10 @@ struct TokenizerCacheTests {
         _ = try await cache.load(from: third, using: loader) // second is evicted
         _ = try await cache.load(from: second, using: loader)
         #expect(await loader.calls == 4)
-        #expect(await cache.entryCountForTesting() == 2)
+        #expect(cache.entryCountForTesting() == 2)
 
-        await cache.purge()
-        #expect(await cache.entryCountForTesting() == 0)
+        cache.purge()
+        #expect(cache.entryCountForTesting() == 0)
         _ = try await cache.load(from: second, using: loader)
         #expect(await loader.calls == 5)
     }
@@ -205,15 +253,142 @@ struct TokenizerCacheTests {
         while await loader.calls == 0 {
             await Task.yield()
         }
-        await cache.purge()
-        _ = try await first.value
-        #expect(await cache.entryCountForTesting() == 0)
+        cache.purge()
+        await #expect(throws: CancellationError.self) { _ = try await first.value }
+        #expect(cache.entryCountForTesting() == 0)
 
         _ = try await cache.load(from: directory, using: loader)
         #expect(await loader.calls == 2)
     }
 
-    @Test func inputsChangedDuringLoadAreReturnedButNeverCachedUnderTheOldFingerprint() async throws {
+    @Test func producerInputDriftRejectsEveryCrossDirectoryWaiter() async throws {
+        let fixture = try TokenizerFixture()
+        defer { fixture.remove() }
+        let firstDirectory = try fixture.directory(named: "first")
+        let secondDirectory = try fixture.directory(named: "second")
+        let loader = SuspendedTokenizerLoader(mutateFileName: "tokenizer_config.json")
+        let cache = TokenizerCache(
+            configuration: .init(maximumEntries: 4, maximumInputBytes: 1_000_000),
+            diagnostics: .disabled
+        )
+
+        let first = Task { try await cache.load(from: firstDirectory, using: loader) }
+        await loader.waitUntilStarted()
+        let second = Task { try await cache.load(from: secondDirectory, using: loader) }
+        while cache.waiterCountForTesting() < 2 {
+            await Task.yield()
+        }
+        await loader.release()
+
+        await #expect(throws: TokenizerCacheError.self) { _ = try await first.value }
+        await #expect(throws: TokenizerCacheError.self) { _ = try await second.value }
+        #expect(cache.entryCountForTesting() == 0)
+    }
+
+    @Test func waiterInputDriftRejectsOnlyThatWaiter() async throws {
+        let fixture = try TokenizerFixture()
+        defer { fixture.remove() }
+        let producerDirectory = try fixture.directory(named: "producer")
+        let changedWaiterDirectory = try fixture.directory(named: "changed-waiter")
+        let loader = SuspendedTokenizerLoader()
+        let cache = TokenizerCache(
+            configuration: .init(maximumEntries: 4, maximumInputBytes: 1_000_000),
+            diagnostics: .disabled
+        )
+
+        let producer = Task { try await cache.load(from: producerDirectory, using: loader) }
+        await loader.waitUntilStarted()
+        let changedWaiter = Task { try await cache.load(from: changedWaiterDirectory, using: loader) }
+        while cache.waiterCountForTesting() < 2 {
+            await Task.yield()
+        }
+        try Data("changed-waiter-input".utf8)
+            .write(to: changedWaiterDirectory.appendingPathComponent("tokenizer_config.json"))
+        await loader.release()
+
+        _ = try await producer.value
+        await #expect(throws: TokenizerCacheError.self) { _ = try await changedWaiter.value }
+        #expect(cache.entryCountForTesting() == 1)
+    }
+
+    @Test func cancellingTheOnlyWaiterReturnsPromptlyAndDropsThePendingLoad() async throws {
+        let fixture = try TokenizerFixture()
+        defer { fixture.remove() }
+        let directory = try fixture.directory(named: "cancel-only")
+        let loader = SuspendedTokenizerLoader()
+        let cache = TokenizerCache(
+            configuration: .init(maximumEntries: 4, maximumInputBytes: 1_000_000),
+            diagnostics: .disabled
+        )
+        let outcome = TokenizerLoadOutcome()
+        let task = Task {
+            do {
+                _ = try await cache.load(from: directory, using: loader)
+                await outcome.record(.value)
+            }
+            catch is CancellationError {
+                await outcome.record(.cancelled)
+            }
+            catch {
+                await outcome.record(.otherError)
+            }
+        }
+        await loader.waitUntilStarted()
+
+        task.cancel()
+        try await waitForOutcome(outcome, timeout: .milliseconds(100))
+        #expect(await outcome.value == .cancelled)
+        #expect(cache.pendingCountForTesting() == 0)
+        await loader.release()
+        await loader.waitUntilFinished()
+        #expect(await loader.wasCancelled)
+        await task.value
+    }
+
+    @Test func cancellingOneWaiterDoesNotKillTheSharedLoadForAnotherWaiter() async throws {
+        let fixture = try TokenizerFixture()
+        defer { fixture.remove() }
+        let firstDirectory = try fixture.directory(named: "first")
+        let secondDirectory = try fixture.directory(named: "second")
+        let loader = SuspendedTokenizerLoader()
+        let cache = TokenizerCache(
+            configuration: .init(maximumEntries: 4, maximumInputBytes: 1_000_000),
+            diagnostics: .disabled
+        )
+        let cancelledOutcome = TokenizerLoadOutcome()
+        let first = Task {
+            do {
+                _ = try await cache.load(from: firstDirectory, using: loader)
+                await cancelledOutcome.record(.value)
+            }
+            catch is CancellationError {
+                await cancelledOutcome.record(.cancelled)
+            }
+            catch {
+                await cancelledOutcome.record(.otherError)
+            }
+        }
+        await loader.waitUntilStarted()
+        let second = Task { try await cache.load(from: secondDirectory, using: loader) }
+        while cache.waiterCountForTesting() < 2 {
+            await Task.yield()
+        }
+
+        first.cancel()
+        try await waitForOutcome(cancelledOutcome, timeout: .milliseconds(100))
+        #expect(await cancelledOutcome.value == .cancelled)
+        #expect(cache.pendingCountForTesting() == 1)
+        #expect(cache.waiterCountForTesting() == 1)
+        await loader.release()
+        _ = try await second.value
+        await first.value
+
+        #expect(await loader.calls == 1)
+        #expect(await !(loader.wasCancelled))
+        #expect(cache.entryCountForTesting() == 1)
+    }
+
+    @Test func inputsChangedDuringLoadAreRejectedAndNeverCachedUnderTheOldFingerprint() async throws {
         let fixture = try TokenizerFixture()
         defer { fixture.remove() }
         let directory = try fixture.directory(named: "changing")
@@ -223,13 +398,15 @@ struct TokenizerCacheTests {
             diagnostics: .disabled
         )
 
-        _ = try await cache.load(from: directory, using: loader)
-        #expect(await cache.entryCountForTesting() == 0)
+        await #expect(throws: TokenizerCacheError.self) {
+            _ = try await cache.load(from: directory, using: loader)
+        }
+        #expect(cache.entryCountForTesting() == 0)
         _ = try await cache.load(from: directory, using: loader)
         _ = try await cache.load(from: directory, using: loader)
 
         #expect(await loader.calls == 2)
-        #expect(await cache.entryCountForTesting() == 1)
+        #expect(cache.entryCountForTesting() == 1)
     }
 
     @Test func oversizedInputsLoadWithoutEnteringTheCache() async throws {
@@ -246,7 +423,7 @@ struct TokenizerCacheTests {
         _ = try await cache.load(from: directory, using: loader)
 
         #expect(await loader.calls == 2)
-        #expect(await cache.entryCountForTesting() == 0)
+        #expect(cache.entryCountForTesting() == 0)
     }
 
     @Test func purgeReleasesTheTokenizerOwner() async throws {
@@ -266,9 +443,39 @@ struct TokenizerCacheTests {
         #expect(weakLifetime != nil)
         tokenizer = nil
         _ = tokenizer
-        await cache.purge()
+        cache.purge()
 
         #expect(weakLifetime == nil)
+    }
+
+    @Test func modelPoolGlobalClearReleasesTokenizerBeforeMLXCleanup() async throws {
+        let fixture = try TokenizerFixture()
+        defer { fixture.remove() }
+        let directory = try fixture.directory(named: "pool-clear")
+        var lifetime: TokenizerLifetime? = TokenizerLifetime()
+        let observation = try TokenizerCleanupObservation(lifetime: #require(lifetime))
+        let loader = try LifetimeTokenizerLoader(lifetime: #require(lifetime))
+        let cache = TokenizerCache(
+            configuration: .init(maximumEntries: 1, maximumInputBytes: 1_000_000),
+            diagnostics: .disabled
+        )
+        var tokenizer: (any MLXLMCommon.Tokenizer)? = try await cache.load(from: directory, using: loader)
+        lifetime = nil
+        tokenizer = nil
+        _ = tokenizer
+        #expect(observation.isAlive)
+
+        let pool = ModelPool(
+            memoryHooks: .init(
+                activeMemory: { 0 },
+                clearCache: { observation.recordCleanup() }
+            ),
+            tokenizerCache: cache
+        )
+        await pool.clearCache()
+
+        #expect(observation.wasReleasedBeforeCleanup)
+        #expect(!observation.isAlive)
     }
 
     @Test func diagnosticsEmitHitMissEvictionAndRejectionWithoutPaths() async throws {
@@ -294,7 +501,7 @@ struct TokenizerCacheTests {
         _ = try await cache.load(from: first, using: loader) // miss
         _ = try await cache.load(from: first, using: loader) // hit
         _ = try await cache.load(from: second, using: loader) // miss + budget eviction
-        await cache.purge() // explicit eviction
+        cache.purge() // explicit eviction
 
         let rejectingCache = TokenizerCache(
             configuration: .init(maximumEntries: 1, maximumInputBytes: 1),
@@ -323,12 +530,43 @@ struct TokenizerCacheTests {
         })
         #expect(SwamaDiagnostics.isValidSnapshot(sink.data))
     }
+
+    @Test func diagnosticSinkFailureNeverChangesTheTokenizerResult() async throws {
+        let fixture = try TokenizerFixture()
+        defer { fixture.remove() }
+        let directory = try fixture.directory(named: "diagnostic-failure")
+        let fallback = TokenizerDiagnosticSink()
+        let recorder = SwamaDiagnosticRecorder(
+            enabled: true,
+            primaryWrite: { _ in throw StubLoaderError.injected },
+            fallbackWrite: { fallback.append($0) }
+        )
+        recorder.start(mode: .cli)
+        let previous = SwamaDiagnostics.installRecorderForTesting(recorder)
+        defer { SwamaDiagnostics.restoreRecorderForTesting(previous) }
+        let loader = CountingTokenizerLoader()
+        let cache = TokenizerCache(
+            configuration: .init(maximumEntries: 1, maximumInputBytes: 1_000_000),
+            diagnostics: .live
+        )
+
+        let miss = try await cache.load(from: directory, using: loader)
+        let hit = try await cache.load(from: directory, using: loader)
+        recorder.stop(outcome: .ok)
+        recorder.flush()
+
+        #expect((miss as? StubTokenizer)?.identifier == "load-1")
+        #expect((hit as? StubTokenizer)?.identifier == "load-1")
+        #expect(await loader.calls == 1)
+        #expect(!fallback.data.isEmpty)
+    }
 }
 
 // MARK: - StubLoaderError
 
 private enum StubLoaderError: Error {
     case injected
+    case invalidConfiguration
 }
 
 // MARK: - StubTokenizer
@@ -378,6 +616,24 @@ private actor CountingTokenizerLoader: TokenizerLoader {
     private let delay: Duration?
 }
 
+// MARK: - ConfigurationValidatingTokenizerLoader
+
+private actor ConfigurationValidatingTokenizerLoader: TokenizerLoader {
+    var calls: Int { callCount }
+
+    func load(from directory: URL) async throws -> any MLXLMCommon.Tokenizer {
+        callCount += 1
+        let data = try Data(contentsOf: directory.appendingPathComponent("config.json"))
+        guard (try? JSONSerialization.jsonObject(with: data)) != nil else {
+            throw StubLoaderError.invalidConfiguration
+        }
+
+        return StubTokenizer(identifier: "load-\(callCount)")
+    }
+
+    private var callCount = 0
+}
+
 // MARK: - MutatingTokenizerLoader
 
 private actor MutatingTokenizerLoader: TokenizerLoader {
@@ -399,9 +655,104 @@ private actor MutatingTokenizerLoader: TokenizerLoader {
     private var callCount = 0
 }
 
+// MARK: - SuspendedTokenizerLoader
+
+private actor SuspendedTokenizerLoader: TokenizerLoader {
+    init(mutateFileName: String? = nil) {
+        self.mutateFileName = mutateFileName
+    }
+
+    var calls: Int { callCount }
+    var wasCancelled: Bool { observedCancellation }
+
+    func load(from directory: URL) async throws -> any MLXLMCommon.Tokenizer {
+        callCount += 1
+        let current = callCount
+        await withCheckedContinuation { continuation in
+            if released {
+                continuation.resume()
+            }
+            else {
+                releaseContinuation = continuation
+            }
+        }
+        observedCancellation = Task.isCancelled
+        if let mutateFileName {
+            try Data("mutated-by-producer".utf8).write(to: directory.appendingPathComponent(mutateFileName))
+        }
+        finished = true
+        return StubTokenizer(identifier: "load-\(current)")
+    }
+
+    func waitUntilStarted() async {
+        while callCount == 0 {
+            await Task.yield()
+        }
+    }
+
+    func release() {
+        released = true
+        let continuation = releaseContinuation
+        releaseContinuation = nil
+        continuation?.resume()
+    }
+
+    func waitUntilFinished() async {
+        while !finished {
+            await Task.yield()
+        }
+    }
+
+    private let mutateFileName: String?
+    private var callCount = 0
+    private var released = false
+    private var observedCancellation = false
+    private var finished = false
+    private var releaseContinuation: CheckedContinuation<Void, Never>?
+}
+
+// MARK: - TokenizerLoadOutcome
+
+private actor TokenizerLoadOutcome {
+    enum Value: Equatable {
+        case cancelled
+        case otherError
+        case value
+    }
+
+    var value: Value? { storedValue }
+
+    func record(_ value: Value) {
+        storedValue = value
+    }
+
+    private var storedValue: Value?
+}
+
 // MARK: - TokenizerLifetime
 
 private final class TokenizerLifetime: @unchecked Sendable {}
+
+// MARK: - TokenizerCleanupObservation
+
+private final class TokenizerCleanupObservation: @unchecked Sendable {
+    init(lifetime: TokenizerLifetime) {
+        self.lifetime = lifetime
+    }
+
+    var isAlive: Bool { lock.withLock { lifetime != nil } }
+    var wasReleasedBeforeCleanup: Bool { lock.withLock { releasedBeforeCleanup } }
+
+    func recordCleanup() {
+        lock.withLock {
+            releasedBeforeCleanup = lifetime == nil
+        }
+    }
+
+    private let lock: NSLock = .init()
+    private weak var lifetime: TokenizerLifetime?
+    private var releasedBeforeCleanup = false
+}
 
 // MARK: - LifetimeTokenizer
 
@@ -468,7 +819,10 @@ private struct TokenizerFixture {
         let directory = root.appendingPathComponent(name)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         for fileName in expectedTokenizerInputFileNames {
-            try Data("\(seed):\(fileName)".utf8).write(to: directory.appendingPathComponent(fileName))
+            let data = fileName == "config.json"
+                ? Data(#"{"model_type":"\#(seed)-model"}"#.utf8)
+                : Data("\(seed):\(fileName)".utf8)
+            try data.write(to: directory.appendingPathComponent(fileName))
         }
         return directory
     }
@@ -489,6 +843,27 @@ private let expectedTokenizerInputFileNames = [
     "tokenizer_config.json",
     "vocab.json"
 ]
+
+private func waitForOutcome(
+    _ outcome: TokenizerLoadOutcome,
+    timeout: Duration
+) async throws {
+    let clock = ContinuousClock()
+    let deadline = clock.now.advanced(by: timeout)
+    while await outcome.value == nil {
+        guard clock.now < deadline else {
+            throw TokenizerCacheTestError.timeout
+        }
+
+        try await Task.sleep(for: .milliseconds(2))
+    }
+}
+
+// MARK: - TokenizerCacheTestError
+
+private enum TokenizerCacheTestError: Error {
+    case timeout
+}
 
 private func diagnosticEvents(from data: Data) throws -> [SwamaDiagnosticEvent] {
     switch SwamaDiagnosticTimeline.parse(data) {


### PR DESCRIPTION
## Summary

- add a package-internal, process-local content-addressed tokenizer cache with a four-entry LRU bound
- fingerprint the pinned tokenizer loader's effective inputs, sharing equal Qwen tokenizer content across model directories while excluding unrelated model weights/config fields
- coalesce concurrent loads without caching failures; reject input drift; make waiter cancellation prompt and last-waiter-only
- scope shared entries and pending waiters by owner so one `ModelPool` clear/deinit cannot disrupt another pool or standalone load
- emit bounded `tokenizer.cache.hit/miss/evicted/rejected` diagnostics without paths or prompts

No public API, target, Package manifest, routing, or inference-concurrency change.

## Evidence

- final head: `31656661390a1dd85638ead754b90e67f703e6bb`
- base: `09e6f26c58128cb9235c3d098d8785b17ddddba4`
- feature patch SHA-256: `9ca494eb4825f6f33eb6ae9df35d8bd56a3d370649933b922c1ec5c1c3203aa3`
- author: tokenizer tests 24/24; full Swift tests 171/171; stable-Xcode release; acceptance harness 25/25; SwiftFormat/diff-check
- independent code review: GO/0 on the byte-identical feature patch, reviewer-augmented 26/26, ownership/cancellation reverse mutations red and restored
- independent second-Mac custody: GO on this exact/tree; real Qwen3-1.7B miss followed by Qwen3-4B hit; diagnostics/privacy and owner isolation/share gates green; baseline-of-record SHA `18a8e5dc…`

The full Swift test run still uses the existing #130 tracked-metallib workaround; this PR does not claim to solve resource packaging.
