### PR TITLE
Add fail-closed stable Core contract guards

### DIFF
--- a/Tools/SwamaAcceptance/Package.resolved
+++ b/Tools/SwamaAcceptance/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "originHash" : "103a4e9002d72dced4ae212dc3e112d34b59640bffb60a3e429cabd7478219bb",
+  "pins" : [
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
+      "state" : {
+        "revision" : "79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Tools/SwamaAcceptance/Package.swift
+++ b/Tools/SwamaAcceptance/Package.swift
@@ -7,9 +7,19 @@ let package = Package(
     products: [
         .executable(name: "swama-acceptance", targets: ["SwamaAcceptance"])
     ],
+    dependencies: [
+        .package(
+            url: "https://github.com/swiftlang/swift-syntax.git",
+            revision: "79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1"
+        )
+    ],
     targets: [
         .target(
             name: "SwamaAcceptanceKit",
+            dependencies: [
+                .product(name: "SwiftParser", package: "swift-syntax"),
+                .product(name: "SwiftSyntax", package: "swift-syntax")
+            ],
             path: "Sources/SwamaAcceptanceKit"
         ),
         .executableTarget(

--- a/Tools/SwamaAcceptance/README.md
+++ b/Tools/SwamaAcceptance/README.md
@@ -100,11 +100,14 @@ stage may be red while an earlier migration stage is green:
 - `core-boundary` requires the `SwamaCore` product/target. It invokes SwiftPM's
   compiler symbol-graph dump and rejects every public declaration or
   conformance that references a module outside Swift, Foundation, and
-  SwamaCore. It also walks the resolved SwiftPM product/target graph across
-  package boundaries and rejects a transitive MLX Audio product. `@inlinable`
-  and `@usableFromInline` are forbidden in the stable target so unchecked
-  implementation reachability cannot escape the compiler-derived declaration
-  boundary.
+  SwamaCore. Source imports are read from a revision-pinned SwiftParser syntax
+  tree, including every conditional-compilation branch; malformed syntax or a
+  selected Swift toolchain outside the pinned parser's 6.3 language release is
+  `UNKNOWN`. The gate also walks the resolved SwiftPM product/target graph
+  across package boundaries and rejects a transitive MLX Audio product.
+  `@inlinable` and `@usableFromInline` are forbidden in the stable target so
+  unchecked implementation reachability cannot escape the compiler-derived
+  declaration boundary.
 - `consumer-boundary` additionally requires the external fixture to depend on
   and import only `SwamaCore`, with its sole filesystem dependency resolving
   to this workspace's exact `swama` package and no remote/upstream package or

--- a/Tools/SwamaAcceptance/README.md
+++ b/Tools/SwamaAcceptance/README.md
@@ -106,7 +106,9 @@ stage may be red while an earlier migration stage is green:
   implementation reachability cannot escape the compiler-derived declaration
   boundary.
 - `consumer-boundary` additionally requires the external fixture to depend on
-  and import only `SwamaCore`, with no remote/upstream package or product.
+  and import only `SwamaCore`, with its sole filesystem dependency resolving
+  to this workspace's exact `swama` package and no remote/upstream package or
+  product.
 
 Absence of `SwamaCore` is a structured `unmet` result, never an empty-symbol
 success. The compiler manifest records symbol kind, path, declaration

--- a/Tools/SwamaAcceptance/README.md
+++ b/Tools/SwamaAcceptance/README.md
@@ -82,3 +82,40 @@ Reports contain a canonical JSON self-hash. This detects accidental edits and
 truncation; it is not authentication because anyone can edit and reseal a
 report. The baseline of record must therefore be generated and retained by an
 independent reviewer. An author-generated baseline cannot replace it.
+
+## Staged Core contract guards
+
+The architecture command has three intentionally separate stages. A later
+stage may be red while an earlier migration stage is green:
+
+```bash
+"$HARNESS" architecture --repo-root "$PWD" --stage legacy-ratchet
+"$HARNESS" architecture --repo-root "$PWD" --stage core-boundary
+"$HARNESS" architecture --repo-root "$PWD" --stage consumer-boundary
+```
+
+- `legacy-ratchet` prevents new shell-framework imports and new known public
+  MLX leaks in `SwamaKit`. It also reports the future consumer and parity goals
+  as explicitly unmet without failing the accepted legacy stage.
+- `core-boundary` requires the `SwamaCore` product/target. It invokes SwiftPM's
+  compiler symbol-graph dump and rejects every public declaration or
+  conformance that references a module outside Swift, Foundation, and
+  SwamaCore. It also walks the SwiftPM target dependency graph and rejects a
+  transitive MLX Audio product. `@inlinable` and `@usableFromInline` are
+  forbidden in the stable target so unchecked implementation reachability
+  cannot escape the compiler-derived declaration boundary.
+- `consumer-boundary` additionally requires the external fixture to depend on
+  and import only `SwamaCore`, with no remote/upstream package or product.
+
+Absence of `SwamaCore` is a structured `unmet` result, never an empty-symbol
+success. The compiler manifest records symbol kind, path, declaration
+fragments, conformances, referenced modules, violations, and a non-zero graph
+count so later API snapshots can be reviewed and compared.
+
+The contract also freezes a fail-closed semantic-parity record schema for the
+future Core/CLI/HTTP comparison. Each record has an exact route, contiguous
+ordered text/tool events, and exactly one terminal outcome: response,
+cancelled, or stable error code. Unknown keys, routes, event types, terminal
+kinds, finish reasons, malformed tool calls, and inconsistent usage totals are
+invalid evidence (`UNKNOWN`), not a passing comparison. Runtime production of
+all three routes remains explicitly unmet until the consumer adapter PRs land.

--- a/Tools/SwamaAcceptance/README.md
+++ b/Tools/SwamaAcceptance/README.md
@@ -100,10 +100,11 @@ stage may be red while an earlier migration stage is green:
 - `core-boundary` requires the `SwamaCore` product/target. It invokes SwiftPM's
   compiler symbol-graph dump and rejects every public declaration or
   conformance that references a module outside Swift, Foundation, and
-  SwamaCore. It also walks the SwiftPM target dependency graph and rejects a
-  transitive MLX Audio product. `@inlinable` and `@usableFromInline` are
-  forbidden in the stable target so unchecked implementation reachability
-  cannot escape the compiler-derived declaration boundary.
+  SwamaCore. It also walks the resolved SwiftPM product/target graph across
+  package boundaries and rejects a transitive MLX Audio product. `@inlinable`
+  and `@usableFromInline` are forbidden in the stable target so unchecked
+  implementation reachability cannot escape the compiler-derived declaration
+  boundary.
 - `consumer-boundary` additionally requires the external fixture to depend on
   and import only `SwamaCore`, with no remote/upstream package or product.
 
@@ -117,5 +118,7 @@ future Core/CLI/HTTP comparison. Each record has an exact route, contiguous
 ordered text/tool events, and exactly one terminal outcome: response,
 cancelled, or stable error code. Unknown keys, routes, event types, terminal
 kinds, finish reasons, malformed tool calls, and inconsistent usage totals are
-invalid evidence (`UNKNOWN`), not a passing comparison. Runtime production of
-all three routes remains explicitly unmet until the consumer adapter PRs land.
+invalid evidence (`UNKNOWN`), not a passing comparison. Tool-call `arguments`
+are canonical JSON objects in both streamed events and terminal responses.
+Runtime production of all three routes remains explicitly unmet until the
+consumer adapter PRs land.

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Architecture.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Architecture.swift
@@ -64,6 +64,13 @@ func swiftImportedModules(
     }
 
     func stringClosingLength(at start: Int, rawHashCount: Int, quoteCount: Int) -> Int? {
+        if rawHashCount > 0, start > rawHashCount {
+            let hashStart = start - rawHashCount
+            let hasEscapeHashes = characters[hashStart ..< start].allSatisfy { $0 == "#" }
+            if hasEscapeHashes, characters[hashStart - 1] == "\\" {
+                return nil
+            }
+        }
         for offset in 0 ..< quoteCount
             where !characters.indices.contains(start + offset) || characters[start + offset] != "\""
         {
@@ -85,17 +92,40 @@ func swiftImportedModules(
             rawHashCount += 1
             cursor += 1
         }
-        guard rawHashCount > 0,
-              characters.indices.contains(cursor),
+        guard characters.indices.contains(cursor),
               characters[cursor] == "/"
         else {
             return nil
+        }
+
+        if rawHashCount == 0 {
+            let trimmed = statement.trimmingCharacters(in: .whitespaces)
+            let expressionPrefixes = "=([{,:;!&|?"
+            let expressionKeywords: Set<String> = [
+                "await", "case", "consume", "copy", "discard", "in", "return", "throw", "try", "yield"
+            ]
+            let lastWord = trimmed.split { !$0.isLetter && !$0.isNumber && $0 != "_" }.last.map(String.init)
+            guard trimmed.isEmpty
+                || trimmed.last.map(expressionPrefixes.contains) == true
+                || lastWord.map(expressionKeywords.contains) == true
+            else {
+                return nil
+            }
         }
 
         return (rawHashCount, rawHashCount + 1)
     }
 
     func regexClosingLength(at start: Int, rawHashCount: Int) -> Int? {
+        var cursor = start
+        var precedingBackslashes = 0
+        while cursor > 0, characters[cursor - 1] == "\\" {
+            precedingBackslashes += 1
+            cursor -= 1
+        }
+        guard precedingBackslashes.isMultiple(of: 2) else {
+            return nil
+        }
         guard characters.indices.contains(start), characters[start] == "/" else {
             return nil
         }

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Architecture.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Architecture.swift
@@ -17,6 +17,103 @@ func swiftImportedModule(in line: String, matching expression: NSRegularExpressi
     return String(line[moduleRange])
 }
 
+func swiftImportedModules(
+    in source: String,
+    matching expression: NSRegularExpression
+) -> [(module: String, line: Int)] {
+    enum LexicalState {
+        case normal
+        case string
+        case lineComment
+        case blockComment(depth: Int)
+    }
+
+    let characters = Array(source)
+    var state = LexicalState.normal
+    var statement = ""
+    var statementLine = 1
+    var line = 1
+    var index = 0
+    var declarations: [(module: String, line: Int)] = []
+
+    func appendStatement() {
+        if let module = swiftImportedModule(in: statement, matching: expression) {
+            declarations.append((module, statementLine))
+        }
+        statement = ""
+        statementLine = line
+    }
+
+    while index < characters.count {
+        let character = characters[index]
+        let next = characters.indices.contains(index + 1) ? characters[index + 1] : nil
+        switch state {
+        case .normal:
+            if character == "/", next == "/" {
+                state = .lineComment
+                index += 1
+            }
+            else if character == "/", next == "*" {
+                statement.append(" ")
+                state = .blockComment(depth: 1)
+                index += 1
+            }
+            else if character == "\"" {
+                statement.append(character)
+                state = .string
+            }
+            else if character == ";" {
+                appendStatement()
+            }
+            else if character == "\n" {
+                appendStatement()
+                line += 1
+                statementLine = line
+            }
+            else {
+                statement.append(character)
+            }
+
+        case .string:
+            statement.append(character)
+            if character == "\\", next != nil {
+                index += 1
+                statement.append(characters[index])
+            }
+            else if character == "\"" {
+                state = .normal
+            }
+            if character == "\n" {
+                line += 1
+            }
+
+        case .lineComment:
+            if character == "\n" {
+                appendStatement()
+                line += 1
+                statementLine = line
+                state = .normal
+            }
+
+        case let .blockComment(depth):
+            if character == "/", next == "*" {
+                state = .blockComment(depth: depth + 1)
+                index += 1
+            }
+            else if character == "*", next == "/" {
+                state = depth == 1 ? .normal : .blockComment(depth: depth - 1)
+                index += 1
+            }
+            else if character == "\n" {
+                line += 1
+            }
+        }
+        index += 1
+    }
+    appendStatement()
+    return declarations
+}
+
 // MARK: - ArchitectureStage
 
 enum ArchitectureStage: String, Sendable {
@@ -143,17 +240,12 @@ private func imports(
 
     for file in try regularFiles(in: root, extensions: ["swift"]).sorted(by: { $0.path < $1.path }) {
         let text = try String(contentsOf: file, encoding: .utf8)
-        for (index, line) in text.split(separator: "\n", omittingEmptySubsequences: false).enumerated() {
-            let value = String(line)
-            guard let module = swiftImportedModule(in: value, matching: expression) else {
-                continue
-            }
-
-            if forbidden.contains(module) {
+        for declaration in swiftImportedModules(in: text, matching: expression) {
+            if forbidden.contains(declaration.module) {
                 hits.append([
                     "file": relativePath(file, to: repository),
-                    "line": index + 1,
-                    "module": module
+                    "line": declaration.line,
+                    "module": declaration.module
                 ])
             }
         }

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Architecture.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Architecture.swift
@@ -74,14 +74,16 @@ private final class SwiftImportCollector: SyntaxVisitor {
     }
 
     override func visit(_ node: ImportDeclSyntax) -> SyntaxVisitorContinueKind {
-        guard let first = node.path.first, !first.name.text.isEmpty else {
+        guard let first = node.path.first,
+              let identifier = Identifier(first.name),
+              !identifier.name.isEmpty
+        else {
             encounteredInvalidImport = true
             return .skipChildren
         }
 
-        let module = first.name.text
         let location = converter.location(for: node.importKeyword.positionAfterSkippingLeadingTrivia)
-        declarations.append((module, location.line))
+        declarations.append((identifier.name, location.line))
         return .skipChildren
     }
 }

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Architecture.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Architecture.swift
@@ -45,6 +45,7 @@ func architectureReport(
     if let coreGuards {
         report["external_consumer_boundary"] = try externalConsumerBoundaryReport(
             fixture: paths.fixture,
+            expectedPackage: paths.package,
             contract: coreGuards,
             developerDirectory: developerDirectory
         )

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Architecture.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Architecture.swift
@@ -45,7 +45,8 @@ func architectureReport(
     if let coreGuards {
         report["external_consumer_boundary"] = try externalConsumerBoundaryReport(
             fixture: paths.fixture,
-            contract: coreGuards
+            contract: coreGuards,
+            developerDirectory: developerDirectory
         )
         report["semantic_parity_schema"] = paritySchemaReport(coreGuards.parity)
     }

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Architecture.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Architecture.swift
@@ -23,7 +23,8 @@ func swiftImportedModules(
 ) -> [(module: String, line: Int)] {
     enum LexicalState {
         case normal
-        case string
+        case string(rawHashCount: Int, quoteCount: Int)
+        case regex(rawHashCount: Int)
         case lineComment
         case blockComment(depth: Int)
     }
@@ -44,6 +45,75 @@ func swiftImportedModules(
         statementLine = line
     }
 
+    func stringOpening(at start: Int) -> (rawHashCount: Int, quoteCount: Int, length: Int)? {
+        var cursor = start
+        var rawHashCount = 0
+        while characters.indices.contains(cursor), characters[cursor] == "#" {
+            rawHashCount += 1
+            cursor += 1
+        }
+        guard characters.indices.contains(cursor), characters[cursor] == "\"" else {
+            return nil
+        }
+
+        let hasTripleQuote = characters.indices.contains(cursor + 2)
+            && characters[cursor + 1] == "\""
+            && characters[cursor + 2] == "\""
+        let quoteCount = hasTripleQuote ? 3 : 1
+        return (rawHashCount, quoteCount, rawHashCount + quoteCount)
+    }
+
+    func stringClosingLength(at start: Int, rawHashCount: Int, quoteCount: Int) -> Int? {
+        for offset in 0 ..< quoteCount
+            where !characters.indices.contains(start + offset) || characters[start + offset] != "\""
+        {
+            return nil
+        }
+        let hashStart = start + quoteCount
+        for offset in 0 ..< rawHashCount
+            where !characters.indices.contains(hashStart + offset) || characters[hashStart + offset] != "#"
+        {
+            return nil
+        }
+        return quoteCount + rawHashCount
+    }
+
+    func regexOpening(at start: Int) -> (rawHashCount: Int, length: Int)? {
+        var cursor = start
+        var rawHashCount = 0
+        while characters.indices.contains(cursor), characters[cursor] == "#" {
+            rawHashCount += 1
+            cursor += 1
+        }
+        guard rawHashCount > 0,
+              characters.indices.contains(cursor),
+              characters[cursor] == "/"
+        else {
+            return nil
+        }
+
+        return (rawHashCount, rawHashCount + 1)
+    }
+
+    func regexClosingLength(at start: Int, rawHashCount: Int) -> Int? {
+        guard characters.indices.contains(start), characters[start] == "/" else {
+            return nil
+        }
+
+        for offset in 0 ..< rawHashCount
+            where !characters.indices.contains(start + 1 + offset) || characters[start + 1 + offset] != "#"
+        {
+            return nil
+        }
+        return rawHashCount + 1
+    }
+
+    func appendCharacters(from start: Int, count: Int) {
+        for offset in 0 ..< count {
+            statement.append(characters[start + offset])
+        }
+    }
+
     while index < characters.count {
         let character = characters[index]
         let next = characters.indices.contains(index + 1) ? characters[index + 1] : nil
@@ -58,9 +128,18 @@ func swiftImportedModules(
                 state = .blockComment(depth: 1)
                 index += 1
             }
-            else if character == "\"" {
-                statement.append(character)
-                state = .string
+            else if let opening = stringOpening(at: index) {
+                appendCharacters(from: index, count: opening.length)
+                state = .string(
+                    rawHashCount: opening.rawHashCount,
+                    quoteCount: opening.quoteCount
+                )
+                index += opening.length - 1
+            }
+            else if let opening = regexOpening(at: index) {
+                appendCharacters(from: index, count: opening.length)
+                state = .regex(rawHashCount: opening.rawHashCount)
+                index += opening.length - 1
             }
             else if character == ";" {
                 appendStatement()
@@ -74,14 +153,36 @@ func swiftImportedModules(
                 statement.append(character)
             }
 
-        case .string:
-            statement.append(character)
-            if character == "\\", next != nil {
+        case let .string(rawHashCount, quoteCount):
+            if rawHashCount == 0, character == "\\", next != nil {
+                statement.append(character)
                 index += 1
                 statement.append(characters[index])
             }
-            else if character == "\"" {
+            else if let closingLength = stringClosingLength(
+                at: index,
+                rawHashCount: rawHashCount,
+                quoteCount: quoteCount
+            ) {
+                appendCharacters(from: index, count: closingLength)
                 state = .normal
+                index += closingLength - 1
+            }
+            else {
+                statement.append(character)
+            }
+            if character == "\n" {
+                line += 1
+            }
+
+        case let .regex(rawHashCount):
+            if let closingLength = regexClosingLength(at: index, rawHashCount: rawHashCount) {
+                appendCharacters(from: index, count: closingLength)
+                state = .normal
+                index += closingLength - 1
+            }
+            else {
+                statement.append(character)
             }
             if character == "\n" {
                 line += 1

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Architecture.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Architecture.swift
@@ -22,12 +22,15 @@ func swiftImportedModule(in line: String, matching expression: NSRegularExpressi
 enum ArchitectureStage: String, Sendable {
     case legacyRatchet = "legacy-ratchet"
     case coreBoundary = "core-boundary"
+    case consumerBoundary = "consumer-boundary"
 }
 
 func architectureReport(
     contract: ArchitectureContract,
+    coreGuards: CoreGuardContract? = nil,
     stage: ArchitectureStage,
-    paths: WorkspacePaths
+    paths: WorkspacePaths,
+    developerDirectory: URL = URL(fileURLWithPath: "/Applications/Xcode.app/Contents/Developer")
 ) throws -> JSONObject {
     let packageManifest = try String(contentsOf: paths.package.appendingPathComponent("Package.swift"), encoding: .utf8)
     let swamaKit = paths.package.appendingPathComponent("Sources/SwamaKit")
@@ -39,6 +42,13 @@ func architectureReport(
         "legacy_forbidden_imports": legacyImports,
         "legacy_public_mlx_leaks": legacyLeaks
     ]
+    if let coreGuards {
+        report["external_consumer_boundary"] = try externalConsumerBoundaryReport(
+            fixture: paths.fixture,
+            contract: coreGuards
+        )
+        report["semantic_parity_schema"] = paritySchemaReport(coreGuards.parity)
+    }
 
     switch stage {
     case .legacyRatchet:
@@ -64,16 +74,55 @@ func architectureReport(
         report["removed_public_mlx_leaks"] = removedLeaks
         report["passed"] = newImports.isEmpty && newLeaks.isEmpty
 
-    case .coreBoundary:
+    case .consumerBoundary,
+         .coreBoundary:
         let coreRoot = paths.package.appendingPathComponent("Sources/\(contract.goalCoreTarget)")
         let coreImports = try imports(in: coreRoot, forbidden: forbidden, repository: paths.repository)
-        let coreLeaks = try publicMLXLeaks(in: coreRoot, repository: paths.repository)
         let targetPresent = packageManifest.contains("name: \"\(contract.goalCoreTarget)\"")
             && FileManager.default.fileExists(atPath: coreRoot.path)
         report["core_target_present"] = targetPresent
         report["core_forbidden_imports"] = coreImports
-        report["core_public_mlx_leaks"] = coreLeaks
-        report["passed"] = targetPresent && coreImports.isEmpty && coreLeaks.isEmpty
+        let compiler: JSONObject
+        let dependencies: JSONObject
+        if targetPresent, let coreGuards {
+            compiler = try compilerPublicAPIReport(
+                target: contract.goalCoreTarget,
+                paths: paths,
+                developerDirectory: developerDirectory,
+                contract: coreGuards
+            )
+            dependencies = try coreTargetDependencyReport(
+                target: contract.goalCoreTarget,
+                paths: paths,
+                developerDirectory: developerDirectory,
+                contract: coreGuards
+            )
+        }
+        else {
+            compiler = [
+                "status": "unmet",
+                "reason": "target \(contract.goalCoreTarget) is absent",
+                "passed": false
+            ]
+            dependencies = [
+                "status": "unmet",
+                "reason": "target \(contract.goalCoreTarget) is absent",
+                "passed": false
+            ]
+        }
+        report["compiler_public_api"] = compiler
+        report["core_target_dependencies"] = dependencies
+        let corePassed = targetPresent
+            && coreImports.isEmpty
+            && compiler["passed"] as? Bool == true
+            && dependencies["passed"] as? Bool == true
+        if stage == .consumerBoundary {
+            let consumerPassed = (report["external_consumer_boundary"] as? JSONObject)?["passed"] as? Bool == true
+            report["passed"] = corePassed && consumerPassed
+        }
+        else {
+            report["passed"] = corePassed
+        }
     }
     return report
 }

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Architecture.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Architecture.swift
@@ -13,11 +13,46 @@ func compilerImportedModules(
 
     let sentinelModule = "__SwamaAcceptanceImportSentinel"
     let source = try String(contentsOf: file, encoding: .utf8)
+    let expandedSource = sourceRemovingConditionalCompilationDirectives(source)
+    let inputs = expandedSource == source ? [source] : [source, expandedSource]
+    var declarations: [(module: String, line: Int, offset: Int)] = []
+    var seen: Set<String> = []
+
+    for input in inputs {
+        for declaration in try compilerImportedModules(
+            in: input,
+            sourceFile: file,
+            swift: swift,
+            developerDirectory: developerDirectory,
+            sentinelModule: sentinelModule
+        ) {
+            let key = "\(declaration.offset)\u{0}\(declaration.module)"
+            if seen.insert(key).inserted {
+                declarations.append(declaration)
+            }
+        }
+    }
+
+    return declarations
+        .sorted { lhs, rhs in
+            lhs.offset == rhs.offset ? lhs.module < rhs.module : lhs.offset < rhs.offset
+        }
+        .map { ($0.module, $0.line) }
+}
+
+private func compilerImportedModules(
+    in source: String,
+    sourceFile: URL,
+    swift: URL,
+    developerDirectory: URL,
+    sentinelModule: String
+) throws -> [(module: String, line: Int, offset: Int)] {
+    let compilerSource = "\(source)\nimport \(sentinelModule)\n"
     let compilerInput = FileManager.default
         .temporaryDirectory
         .appendingPathComponent("swama-imports-\(UUID().uuidString).swift")
     defer { try? FileManager.default.removeItem(at: compilerInput) }
-    try Data("\(source)\nimport \(sentinelModule)\n".utf8).write(to: compilerInput, options: .atomic)
+    try Data(compilerSource.utf8).write(to: compilerInput, options: .atomic)
 
     let result = try runCommand(
         [
@@ -36,12 +71,15 @@ func compilerImportedModules(
     )
     guard result.returnCode == 0 else {
         throw AcceptanceFailure.unknown(
-            "cannot parse Swift imports in \(file.lastPathComponent):\n\(commandFailureSummary(result))"
+            "cannot parse Swift imports in \(sourceFile.lastPathComponent):\n\(commandFailureSummary(result))"
         )
     }
 
     do {
-        let declarations = try parseCompilerImportAST(result.stdout)
+        let declarations = try parseCompilerImportAST(
+            result.stdout,
+            sentinelModule: sentinelModule
+        )
         guard declarations.count(where: { $0.module == sentinelModule }) == 1 else {
             throw AcceptanceFailure.unknown("Swift import parser omitted or duplicated its sentinel")
         }
@@ -50,27 +88,32 @@ func compilerImportedModules(
     }
     catch {
         throw AcceptanceFailure.unknown(
-            "cannot interpret Swift import AST for \(file.lastPathComponent): \(error)"
+            "cannot interpret Swift import AST for \(sourceFile.lastPathComponent): \(error)"
         )
     }
 }
 
-func parseCompilerImportAST(_ output: String) throws -> [(module: String, line: Int)] {
-    guard isCompleteCompilerAST(output) else {
-        throw AcceptanceFailure.unknown("Swift import parser emitted incomplete or noisy AST output")
-    }
+func parseCompilerImportAST(
+    _ output: String,
+    sentinelModule: String
+) throws -> [(module: String, line: Int, offset: Int)] {
+    try validateCompilerImportAST(output, sentinelModule: sentinelModule)
 
     let moduleExpression = try NSRegularExpression(pattern: #"module="([^"]+)""#)
-    let lineExpression = try NSRegularExpression(
-        pattern: #"range=\[.*:(\d+):\d+ - line:\d+:\d+\]"#
+    let rangeExpression = try NSRegularExpression(
+        pattern: #"range=\[.*:(\d+):(\d+) - line:\d+:\d+\]"#
     )
-    var declarations: [(module: String, line: Int)] = []
+    var declarations: [(module: String, line: Int, offset: Int)] = []
     for outputLine in output.split(separator: "\n").map(String.init)
         where outputLine.contains("(import_decl")
     {
         guard let module = regexCapture(moduleExpression, in: outputLine, group: 1),
-              let lineValue = regexCapture(lineExpression, in: outputLine, group: 1),
+              let lineValue = regexCapture(rangeExpression, in: outputLine, group: 1),
+              let columnValue = regexCapture(rangeExpression, in: outputLine, group: 2),
               let line = Int(lineValue),
+              let column = Int(columnValue),
+              line > 0,
+              column > 0,
               let rootModule = module.split(separator: ".").first.map(String.init)
         else {
             throw AcceptanceFailure.unknown(
@@ -78,14 +121,49 @@ func parseCompilerImportAST(_ output: String) throws -> [(module: String, line: 
             )
         }
 
-        declarations.append((rootModule, line))
+        let (lineOffset, lineOverflow) = line.multipliedReportingOverflow(by: 1_000_000)
+        let (offset, columnOverflow) = lineOffset.addingReportingOverflow(column)
+        guard !lineOverflow, !columnOverflow else {
+            throw AcceptanceFailure.unknown("Swift import parser emitted an overflowing source location")
+        }
+
+        declarations.append((rootModule, line, offset))
     }
     return declarations
 }
 
-private func isCompleteCompilerAST(_ output: String) -> Bool {
-    let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
-    return trimmed.hasPrefix("(source_file") && trimmed.hasSuffix(")")
+private func validateCompilerImportAST(
+    _ output: String,
+    sentinelModule: String
+) throws {
+    var lines = output.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+    while lines.last?.isEmpty == true {
+        lines.removeLast()
+    }
+    guard let first = lines.first, first.hasPrefix("(source_file ") else {
+        throw AcceptanceFailure.unknown("Swift import parser emitted a missing or noisy source_file root")
+    }
+    guard lines.dropFirst().allSatisfy({ !$0.hasPrefix("(") }) else {
+        throw AcceptanceFailure.unknown("Swift import parser emitted an additional top-level record")
+    }
+
+    let sentinelField = "module=\"\(sentinelModule)\""
+    guard output.components(separatedBy: sentinelField).count == 2 else {
+        throw AcceptanceFailure.unknown("Swift import parser omitted or duplicated its sentinel")
+    }
+
+    let escapedSentinel = NSRegularExpression.escapedPattern(for: sentinelModule)
+    let sentinelExpression = try NSRegularExpression(
+        pattern: #"^\s+\(import_decl .* module=""# + escapedSentinel + #""\)\)$"#
+    )
+    guard let last = lines.last else {
+        throw AcceptanceFailure.unknown("Swift import parser emitted an empty AST")
+    }
+
+    let lastRange = NSRange(last.startIndex ..< last.endIndex, in: last)
+    guard sentinelExpression.firstMatch(in: last, range: lastRange)?.range == lastRange else {
+        throw AcceptanceFailure.unknown("Swift import parser emitted a truncated or noisy AST suffix")
+    }
 }
 
 private func regexCapture(
@@ -101,6 +179,46 @@ private func regexCapture(
     }
 
     return String(text[capture])
+}
+
+func sourceRemovingConditionalCompilationDirectives(_ source: String) -> String {
+    var bytes = Array(source.utf8)
+    var lineStart = 0
+    while lineStart < bytes.count {
+        var lineEnd = lineStart
+        while lineEnd < bytes.count, bytes[lineEnd] != 0x0A, bytes[lineEnd] != 0x0D {
+            lineEnd += 1
+        }
+
+        var tokenStart = lineStart
+        while tokenStart < lineEnd, bytes[tokenStart] == 0x20 || bytes[tokenStart] == 0x09 {
+            tokenStart += 1
+        }
+        let directiveTokens = ["#elseif", "#endif", "#else", "#if"]
+        let isDirective = directiveTokens.contains { token in
+            let tokenBytes = Array(token.utf8)
+            guard tokenStart + tokenBytes.count <= lineEnd,
+                  Array(bytes[tokenStart ..< tokenStart + tokenBytes.count]) == tokenBytes
+            else {
+                return false
+            }
+
+            let boundary = tokenStart + tokenBytes.count
+            return boundary == lineEnd || bytes[boundary] == 0x20 || bytes[boundary] == 0x09
+        }
+        if isDirective {
+            for index in lineStart ..< lineEnd {
+                bytes[index] = 0x20
+            }
+        }
+
+        lineStart = lineEnd
+        while lineStart < bytes.count, bytes[lineStart] == 0x0A || bytes[lineStart] == 0x0D {
+            lineStart += 1
+        }
+    }
+
+    return String(decoding: bytes, as: UTF8.self)
 }
 
 // MARK: - ArchitectureStage

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Architecture.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Architecture.swift
@@ -1,248 +1,106 @@
 import Foundation
 
-/// Import attributes are open-ended (`@_exported`, `@_spi(...)`, etc.), so match their
-/// grammar rather than enumerating spellings. Access modifiers and scoped-import kinds are
-/// finite parts of the Swift import declaration grammar.
-let swiftImportDeclarationPattern =
-    #"^\s*(?:@[A-Za-z_][A-Za-z0-9_]*(?:\([^)]*\))?\s+)*(?:(?:private|fileprivate|internal|package|public|open)\s+)?import\s+(?:(?:typealias|struct|class|enum|protocol|let|var|func|macro)\s+)?([A-Za-z_][A-Za-z0-9_]*)\b"#
+func compilerImportedModules(
+    in file: URL,
+    developerDirectory: URL
+) throws -> [(module: String, line: Int)] {
+    let swift = developerDirectory.appendingPathComponent(
+        "Toolchains/XcodeDefault.xctoolchain/usr/bin/swift"
+    )
+    guard FileManager.default.isExecutableFile(atPath: swift.path) else {
+        throw AcceptanceFailure.unknown("missing Swift frontend: \(swift.path)")
+    }
 
-func swiftImportedModule(in line: String, matching expression: NSRegularExpression) -> String? {
-    let range = NSRange(line.startIndex ..< line.endIndex, in: line)
-    guard let match = expression.firstMatch(in: line, range: range),
-          let moduleRange = Range(match.range(at: 1), in: line)
+    let sentinelModule = "__SwamaAcceptanceImportSentinel"
+    let source = try String(contentsOf: file, encoding: .utf8)
+    let compilerInput = FileManager.default
+        .temporaryDirectory
+        .appendingPathComponent("swama-imports-\(UUID().uuidString).swift")
+    defer { try? FileManager.default.removeItem(at: compilerInput) }
+    try Data("\(source)\nimport \(sentinelModule)\n".utf8).write(to: compilerInput, options: .atomic)
+
+    let result = try runCommand(
+        [
+            swift.path,
+            "-frontend",
+            "-dump-parse",
+            "-enable-bare-slash-regex",
+            compilerInput.path
+        ],
+        currentDirectory: compilerInput.deletingLastPathComponent(),
+        environment: developerEnvironment(developerDirectory),
+        timeout: 30,
+        sampleMemory: false,
+        timeoutFailureKind: .unknown,
+        timeoutContext: "Swift import parser"
+    )
+    guard result.returnCode == 0 else {
+        throw AcceptanceFailure.unknown(
+            "cannot parse Swift imports in \(file.lastPathComponent):\n\(commandFailureSummary(result))"
+        )
+    }
+
+    do {
+        let declarations = try parseCompilerImportAST(result.stdout)
+        guard declarations.count(where: { $0.module == sentinelModule }) == 1 else {
+            throw AcceptanceFailure.unknown("Swift import parser omitted or duplicated its sentinel")
+        }
+
+        return declarations.filter { $0.module != sentinelModule }
+    }
+    catch {
+        throw AcceptanceFailure.unknown(
+            "cannot interpret Swift import AST for \(file.lastPathComponent): \(error)"
+        )
+    }
+}
+
+func parseCompilerImportAST(_ output: String) throws -> [(module: String, line: Int)] {
+    guard isCompleteCompilerAST(output) else {
+        throw AcceptanceFailure.unknown("Swift import parser emitted incomplete or noisy AST output")
+    }
+
+    let moduleExpression = try NSRegularExpression(pattern: #"module="([^"]+)""#)
+    let lineExpression = try NSRegularExpression(
+        pattern: #"range=\[.*:(\d+):\d+ - line:\d+:\d+\]"#
+    )
+    var declarations: [(module: String, line: Int)] = []
+    for outputLine in output.split(separator: "\n").map(String.init)
+        where outputLine.contains("(import_decl")
+    {
+        guard let module = regexCapture(moduleExpression, in: outputLine, group: 1),
+              let lineValue = regexCapture(lineExpression, in: outputLine, group: 1),
+              let line = Int(lineValue),
+              let rootModule = module.split(separator: ".").first.map(String.init)
+        else {
+            throw AcceptanceFailure.unknown(
+                "Swift import parser emitted an unsupported import declaration: \(outputLine)"
+            )
+        }
+
+        declarations.append((rootModule, line))
+    }
+    return declarations
+}
+
+private func isCompleteCompilerAST(_ output: String) -> Bool {
+    let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.hasPrefix("(source_file") && trimmed.hasSuffix(")")
+}
+
+private func regexCapture(
+    _ expression: NSRegularExpression,
+    in text: String,
+    group: Int
+) -> String? {
+    let range = NSRange(text.startIndex ..< text.endIndex, in: text)
+    guard let match = expression.firstMatch(in: text, range: range),
+          let capture = Range(match.range(at: group), in: text)
     else {
         return nil
     }
 
-    return String(line[moduleRange])
-}
-
-func swiftImportedModules(
-    in source: String,
-    matching expression: NSRegularExpression
-) -> [(module: String, line: Int)] {
-    enum LexicalState {
-        case normal
-        case string(rawHashCount: Int, quoteCount: Int)
-        case regex(rawHashCount: Int)
-        case lineComment
-        case blockComment(depth: Int)
-    }
-
-    let characters = Array(source)
-    var state = LexicalState.normal
-    var statement = ""
-    var statementLine = 1
-    var line = 1
-    var index = 0
-    var declarations: [(module: String, line: Int)] = []
-
-    func appendStatement() {
-        if let module = swiftImportedModule(in: statement, matching: expression) {
-            declarations.append((module, statementLine))
-        }
-        statement = ""
-        statementLine = line
-    }
-
-    func stringOpening(at start: Int) -> (rawHashCount: Int, quoteCount: Int, length: Int)? {
-        var cursor = start
-        var rawHashCount = 0
-        while characters.indices.contains(cursor), characters[cursor] == "#" {
-            rawHashCount += 1
-            cursor += 1
-        }
-        guard characters.indices.contains(cursor), characters[cursor] == "\"" else {
-            return nil
-        }
-
-        let hasTripleQuote = characters.indices.contains(cursor + 2)
-            && characters[cursor + 1] == "\""
-            && characters[cursor + 2] == "\""
-        let quoteCount = hasTripleQuote ? 3 : 1
-        return (rawHashCount, quoteCount, rawHashCount + quoteCount)
-    }
-
-    func stringClosingLength(at start: Int, rawHashCount: Int, quoteCount: Int) -> Int? {
-        if rawHashCount > 0, start > rawHashCount {
-            let hashStart = start - rawHashCount
-            let hasEscapeHashes = characters[hashStart ..< start].allSatisfy { $0 == "#" }
-            if hasEscapeHashes, characters[hashStart - 1] == "\\" {
-                return nil
-            }
-        }
-        for offset in 0 ..< quoteCount
-            where !characters.indices.contains(start + offset) || characters[start + offset] != "\""
-        {
-            return nil
-        }
-        let hashStart = start + quoteCount
-        for offset in 0 ..< rawHashCount
-            where !characters.indices.contains(hashStart + offset) || characters[hashStart + offset] != "#"
-        {
-            return nil
-        }
-        return quoteCount + rawHashCount
-    }
-
-    func regexOpening(at start: Int) -> (rawHashCount: Int, length: Int)? {
-        var cursor = start
-        var rawHashCount = 0
-        while characters.indices.contains(cursor), characters[cursor] == "#" {
-            rawHashCount += 1
-            cursor += 1
-        }
-        guard characters.indices.contains(cursor),
-              characters[cursor] == "/"
-        else {
-            return nil
-        }
-
-        if rawHashCount == 0 {
-            let trimmed = statement.trimmingCharacters(in: .whitespaces)
-            let expressionPrefixes = "=([{,:;!&|?"
-            let expressionKeywords: Set<String> = [
-                "await", "case", "consume", "copy", "discard", "in", "return", "throw", "try", "yield"
-            ]
-            let lastWord = trimmed.split { !$0.isLetter && !$0.isNumber && $0 != "_" }.last.map(String.init)
-            guard trimmed.isEmpty
-                || trimmed.last.map(expressionPrefixes.contains) == true
-                || lastWord.map(expressionKeywords.contains) == true
-            else {
-                return nil
-            }
-        }
-
-        return (rawHashCount, rawHashCount + 1)
-    }
-
-    func regexClosingLength(at start: Int, rawHashCount: Int) -> Int? {
-        var cursor = start
-        var precedingBackslashes = 0
-        while cursor > 0, characters[cursor - 1] == "\\" {
-            precedingBackslashes += 1
-            cursor -= 1
-        }
-        guard precedingBackslashes.isMultiple(of: 2) else {
-            return nil
-        }
-        guard characters.indices.contains(start), characters[start] == "/" else {
-            return nil
-        }
-
-        for offset in 0 ..< rawHashCount
-            where !characters.indices.contains(start + 1 + offset) || characters[start + 1 + offset] != "#"
-        {
-            return nil
-        }
-        return rawHashCount + 1
-    }
-
-    func appendCharacters(from start: Int, count: Int) {
-        for offset in 0 ..< count {
-            statement.append(characters[start + offset])
-        }
-    }
-
-    while index < characters.count {
-        let character = characters[index]
-        let next = characters.indices.contains(index + 1) ? characters[index + 1] : nil
-        switch state {
-        case .normal:
-            if character == "/", next == "/" {
-                state = .lineComment
-                index += 1
-            }
-            else if character == "/", next == "*" {
-                statement.append(" ")
-                state = .blockComment(depth: 1)
-                index += 1
-            }
-            else if let opening = stringOpening(at: index) {
-                appendCharacters(from: index, count: opening.length)
-                state = .string(
-                    rawHashCount: opening.rawHashCount,
-                    quoteCount: opening.quoteCount
-                )
-                index += opening.length - 1
-            }
-            else if let opening = regexOpening(at: index) {
-                appendCharacters(from: index, count: opening.length)
-                state = .regex(rawHashCount: opening.rawHashCount)
-                index += opening.length - 1
-            }
-            else if character == ";" {
-                appendStatement()
-            }
-            else if character == "\n" {
-                appendStatement()
-                line += 1
-                statementLine = line
-            }
-            else {
-                statement.append(character)
-            }
-
-        case let .string(rawHashCount, quoteCount):
-            if rawHashCount == 0, character == "\\", next != nil {
-                statement.append(character)
-                index += 1
-                statement.append(characters[index])
-            }
-            else if let closingLength = stringClosingLength(
-                at: index,
-                rawHashCount: rawHashCount,
-                quoteCount: quoteCount
-            ) {
-                appendCharacters(from: index, count: closingLength)
-                state = .normal
-                index += closingLength - 1
-            }
-            else {
-                statement.append(character)
-            }
-            if character == "\n" {
-                line += 1
-            }
-
-        case let .regex(rawHashCount):
-            if let closingLength = regexClosingLength(at: index, rawHashCount: rawHashCount) {
-                appendCharacters(from: index, count: closingLength)
-                state = .normal
-                index += closingLength - 1
-            }
-            else {
-                statement.append(character)
-            }
-            if character == "\n" {
-                line += 1
-            }
-
-        case .lineComment:
-            if character == "\n" {
-                appendStatement()
-                line += 1
-                statementLine = line
-                state = .normal
-            }
-
-        case let .blockComment(depth):
-            if character == "/", next == "*" {
-                state = .blockComment(depth: depth + 1)
-                index += 1
-            }
-            else if character == "*", next == "/" {
-                state = depth == 1 ? .normal : .blockComment(depth: depth - 1)
-                index += 1
-            }
-            else if character == "\n" {
-                line += 1
-            }
-        }
-        index += 1
-    }
-    appendStatement()
-    return declarations
+    return String(text[capture])
 }
 
 // MARK: - ArchitectureStage
@@ -263,7 +121,12 @@ func architectureReport(
     let packageManifest = try String(contentsOf: paths.package.appendingPathComponent("Package.swift"), encoding: .utf8)
     let swamaKit = paths.package.appendingPathComponent("Sources/SwamaKit")
     let forbidden = Set(contract.goalForbiddenImports)
-    let legacyImports = try imports(in: swamaKit, forbidden: forbidden, repository: paths.repository)
+    let legacyImports = try imports(
+        in: swamaKit,
+        forbidden: forbidden,
+        repository: paths.repository,
+        developerDirectory: developerDirectory
+    )
     let legacyLeaks = try publicMLXLeaks(in: swamaKit, repository: paths.repository)
     var report: JSONObject = [
         "stage": stage.rawValue,
@@ -307,7 +170,12 @@ func architectureReport(
     case .consumerBoundary,
          .coreBoundary:
         let coreRoot = paths.package.appendingPathComponent("Sources/\(contract.goalCoreTarget)")
-        let coreImports = try imports(in: coreRoot, forbidden: forbidden, repository: paths.repository)
+        let coreImports = try imports(
+            in: coreRoot,
+            forbidden: forbidden,
+            repository: paths.repository,
+            developerDirectory: developerDirectory
+        )
         let targetPresent = packageManifest.contains("name: \"\(contract.goalCoreTarget)\"")
             && FileManager.default.fileExists(atPath: coreRoot.path)
         report["core_target_present"] = targetPresent
@@ -360,18 +228,17 @@ func architectureReport(
 private func imports(
     in root: URL,
     forbidden: Set<String>,
-    repository: URL
+    repository: URL,
+    developerDirectory: URL
 ) throws -> [JSONObject] {
     guard FileManager.default.fileExists(atPath: root.path) else {
         return []
     }
 
-    let expression = try NSRegularExpression(pattern: swiftImportDeclarationPattern)
     var hits: [JSONObject] = []
 
     for file in try regularFiles(in: root, extensions: ["swift"]).sorted(by: { $0.path < $1.path }) {
-        let text = try String(contentsOf: file, encoding: .utf8)
-        for declaration in swiftImportedModules(in: text, matching: expression) {
+        for declaration in try compilerImportedModules(in: file, developerDirectory: developerDirectory) {
             if forbidden.contains(declaration.module) {
                 hits.append([
                     "file": relativePath(file, to: repository),

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Architecture.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Architecture.swift
@@ -1,224 +1,89 @@
 import Foundation
+import SwiftParser
+import SwiftSyntax
 
 func compilerImportedModules(
     in file: URL,
     developerDirectory: URL
 ) throws -> [(module: String, line: Int)] {
+    try validateSwiftParserToolchain(developerDirectory)
+    let source = try String(contentsOf: file, encoding: .utf8)
+    return try parsedSwiftImports(source: source, file: file)
+}
+
+private func validateSwiftParserToolchain(_ developerDirectory: URL) throws {
     let swift = developerDirectory.appendingPathComponent(
         "Toolchains/XcodeDefault.xctoolchain/usr/bin/swift"
     )
     guard FileManager.default.isExecutableFile(atPath: swift.path) else {
-        throw AcceptanceFailure.unknown("missing Swift frontend: \(swift.path)")
+        throw AcceptanceFailure.unknown("missing Swift 6.3 toolchain for SwiftParser: \(swift.path)")
     }
-
-    let sentinelModule = "__SwamaAcceptanceImportSentinel"
-    let source = try String(contentsOf: file, encoding: .utf8)
-    let expandedSource = sourceRemovingConditionalCompilationDirectives(source)
-    let inputs = expandedSource == source ? [source] : [source, expandedSource]
-    var declarations: [(module: String, line: Int, offset: Int)] = []
-    var seen: Set<String> = []
-
-    for input in inputs {
-        for declaration in try compilerImportedModules(
-            in: input,
-            sourceFile: file,
-            swift: swift,
-            developerDirectory: developerDirectory,
-            sentinelModule: sentinelModule
-        ) {
-            let key = "\(declaration.offset)\u{0}\(declaration.module)"
-            if seen.insert(key).inserted {
-                declarations.append(declaration)
-            }
-        }
-    }
-
-    return declarations
-        .sorted { lhs, rhs in
-            lhs.offset == rhs.offset ? lhs.module < rhs.module : lhs.offset < rhs.offset
-        }
-        .map { ($0.module, $0.line) }
-}
-
-private func compilerImportedModules(
-    in source: String,
-    sourceFile: URL,
-    swift: URL,
-    developerDirectory: URL,
-    sentinelModule: String
-) throws -> [(module: String, line: Int, offset: Int)] {
-    let compilerSource = "\(source)\nimport \(sentinelModule)\n"
-    let compilerInput = FileManager.default
-        .temporaryDirectory
-        .appendingPathComponent("swama-imports-\(UUID().uuidString).swift")
-    defer { try? FileManager.default.removeItem(at: compilerInput) }
-    try Data(compilerSource.utf8).write(to: compilerInput, options: .atomic)
 
     let result = try runCommand(
-        [
-            swift.path,
-            "-frontend",
-            "-dump-parse",
-            "-enable-bare-slash-regex",
-            compilerInput.path
-        ],
-        currentDirectory: compilerInput.deletingLastPathComponent(),
+        [swift.path, "--version"],
+        currentDirectory: FileManager.default.temporaryDirectory,
         environment: developerEnvironment(developerDirectory),
-        timeout: 30,
+        timeout: 10,
         sampleMemory: false,
         timeoutFailureKind: .unknown,
-        timeoutContext: "Swift import parser"
+        timeoutContext: "SwiftParser toolchain identity"
     )
     guard result.returnCode == 0 else {
         throw AcceptanceFailure.unknown(
-            "cannot parse Swift imports in \(sourceFile.lastPathComponent):\n\(commandFailureSummary(result))"
+            "cannot identify selected Swift toolchain:\n\(commandFailureSummary(result))"
         )
     }
 
-    do {
-        let declarations = try parseCompilerImportAST(
-            result.stdout,
-            sentinelModule: sentinelModule
-        )
-        guard declarations.count(where: { $0.module == sentinelModule }) == 1 else {
-            throw AcceptanceFailure.unknown("Swift import parser omitted or duplicated its sentinel")
-        }
-
-        return declarations.filter { $0.module != sentinelModule }
-    }
-    catch {
+    let versionExpression = try NSRegularExpression(pattern: #"\bSwift version 6\.3(?:\.\d+)?\b"#)
+    let range = NSRange(result.stdout.startIndex ..< result.stdout.endIndex, in: result.stdout)
+    guard versionExpression.firstMatch(in: result.stdout, range: range) != nil else {
         throw AcceptanceFailure.unknown(
-            "cannot interpret Swift import AST for \(sourceFile.lastPathComponent): \(error)"
+            "SwiftParser revision requires selected Swift 6.3; got: \(result.stdout.trimmingCharacters(in: .whitespacesAndNewlines))"
         )
     }
 }
 
-func parseCompilerImportAST(
-    _ output: String,
-    sentinelModule: String
-) throws -> [(module: String, line: Int, offset: Int)] {
-    try validateCompilerImportAST(output, sentinelModule: sentinelModule)
-
-    let moduleExpression = try NSRegularExpression(pattern: #"module="([^"]+)""#)
-    let rangeExpression = try NSRegularExpression(
-        pattern: #"range=\[.*:(\d+):(\d+) - line:\d+:\d+\]"#
-    )
-    var declarations: [(module: String, line: Int, offset: Int)] = []
-    for outputLine in output.split(separator: "\n").map(String.init)
-        where outputLine.contains("(import_decl")
-    {
-        guard let module = regexCapture(moduleExpression, in: outputLine, group: 1),
-              let lineValue = regexCapture(rangeExpression, in: outputLine, group: 1),
-              let columnValue = regexCapture(rangeExpression, in: outputLine, group: 2),
-              let line = Int(lineValue),
-              let column = Int(columnValue),
-              line > 0,
-              column > 0,
-              let rootModule = module.split(separator: ".").first.map(String.init)
-        else {
-            throw AcceptanceFailure.unknown(
-                "Swift import parser emitted an unsupported import declaration: \(outputLine)"
-            )
-        }
-
-        let (lineOffset, lineOverflow) = line.multipliedReportingOverflow(by: 1_000_000)
-        let (offset, columnOverflow) = lineOffset.addingReportingOverflow(column)
-        guard !lineOverflow, !columnOverflow else {
-            throw AcceptanceFailure.unknown("Swift import parser emitted an overflowing source location")
-        }
-
-        declarations.append((rootModule, line, offset))
+func parsedSwiftImports(
+    source: String,
+    file: URL
+) throws -> [(module: String, line: Int)] {
+    let tree = Parser.parse(source: source)
+    guard !tree.hasError else {
+        throw AcceptanceFailure.unknown("cannot parse Swift imports in \(file.lastPathComponent)")
     }
-    return declarations
+
+    let collector = SwiftImportCollector(file: file, tree: tree)
+    collector.walk(tree)
+    guard !collector.encounteredInvalidImport else {
+        throw AcceptanceFailure.unknown("SwiftParser emitted an import without a module")
+    }
+
+    return collector.declarations
 }
 
-private func validateCompilerImportAST(
-    _ output: String,
-    sentinelModule: String
-) throws {
-    var lines = output.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
-    while lines.last?.isEmpty == true {
-        lines.removeLast()
-    }
-    guard let first = lines.first, first.hasPrefix("(source_file ") else {
-        throw AcceptanceFailure.unknown("Swift import parser emitted a missing or noisy source_file root")
-    }
-    guard lines.dropFirst().allSatisfy({ !$0.hasPrefix("(") }) else {
-        throw AcceptanceFailure.unknown("Swift import parser emitted an additional top-level record")
+// MARK: - SwiftImportCollector
+
+private final class SwiftImportCollector: SyntaxVisitor {
+    private let converter: SourceLocationConverter
+    fileprivate var declarations: [(module: String, line: Int)] = []
+    fileprivate var encounteredInvalidImport = false
+
+    init(file: URL, tree: SourceFileSyntax) {
+        converter = SourceLocationConverter(fileName: file.path, tree: tree)
+        super.init(viewMode: .sourceAccurate)
     }
 
-    let sentinelField = "module=\"\(sentinelModule)\""
-    guard output.components(separatedBy: sentinelField).count == 2 else {
-        throw AcceptanceFailure.unknown("Swift import parser omitted or duplicated its sentinel")
-    }
-
-    let escapedSentinel = NSRegularExpression.escapedPattern(for: sentinelModule)
-    let sentinelExpression = try NSRegularExpression(
-        pattern: #"^\s+\(import_decl .* module=""# + escapedSentinel + #""\)\)$"#
-    )
-    guard let last = lines.last else {
-        throw AcceptanceFailure.unknown("Swift import parser emitted an empty AST")
-    }
-
-    let lastRange = NSRange(last.startIndex ..< last.endIndex, in: last)
-    guard sentinelExpression.firstMatch(in: last, range: lastRange)?.range == lastRange else {
-        throw AcceptanceFailure.unknown("Swift import parser emitted a truncated or noisy AST suffix")
-    }
-}
-
-private func regexCapture(
-    _ expression: NSRegularExpression,
-    in text: String,
-    group: Int
-) -> String? {
-    let range = NSRange(text.startIndex ..< text.endIndex, in: text)
-    guard let match = expression.firstMatch(in: text, range: range),
-          let capture = Range(match.range(at: group), in: text)
-    else {
-        return nil
-    }
-
-    return String(text[capture])
-}
-
-func sourceRemovingConditionalCompilationDirectives(_ source: String) -> String {
-    var bytes = Array(source.utf8)
-    var lineStart = 0
-    while lineStart < bytes.count {
-        var lineEnd = lineStart
-        while lineEnd < bytes.count, bytes[lineEnd] != 0x0A, bytes[lineEnd] != 0x0D {
-            lineEnd += 1
+    override func visit(_ node: ImportDeclSyntax) -> SyntaxVisitorContinueKind {
+        guard let first = node.path.first, !first.name.text.isEmpty else {
+            encounteredInvalidImport = true
+            return .skipChildren
         }
 
-        var tokenStart = lineStart
-        while tokenStart < lineEnd, bytes[tokenStart] == 0x20 || bytes[tokenStart] == 0x09 {
-            tokenStart += 1
-        }
-        let directiveTokens = ["#elseif", "#endif", "#else", "#if"]
-        let isDirective = directiveTokens.contains { token in
-            let tokenBytes = Array(token.utf8)
-            guard tokenStart + tokenBytes.count <= lineEnd,
-                  Array(bytes[tokenStart ..< tokenStart + tokenBytes.count]) == tokenBytes
-            else {
-                return false
-            }
-
-            let boundary = tokenStart + tokenBytes.count
-            return boundary == lineEnd || bytes[boundary] == 0x20 || bytes[boundary] == 0x09
-        }
-        if isDirective {
-            for index in lineStart ..< lineEnd {
-                bytes[index] = 0x20
-            }
-        }
-
-        lineStart = lineEnd
-        while lineStart < bytes.count, bytes[lineStart] == 0x0A || bytes[lineStart] == 0x0D {
-            lineStart += 1
-        }
+        let module = first.name.text
+        let location = converter.location(for: node.importKeyword.positionAfterSkippingLeadingTrivia)
+        declarations.append((module, location.line))
+        return .skipChildren
     }
-
-    return String(decoding: bytes, as: UTF8.self)
 }
 
 // MARK: - ArchitectureStage

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Baseline.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Baseline.swift
@@ -13,8 +13,10 @@ func runBaseline(
     environment["SWAMA_PROMPT_CACHE"] = "0"
     let architecture = try architectureReport(
         contract: contract.architecture,
+        coreGuards: contract.coreGuards,
         stage: architectureStage,
-        paths: paths
+        paths: paths,
+        developerDirectory: developerDirectory
     )
     guard architecture["passed"] as? Bool == true else {
         throw AcceptanceFailure.failed("architecture gate failed")

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/CLI.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/CLI.swift
@@ -14,8 +14,10 @@ public enum AcceptanceCLI {
             case .architecture:
                 let report = try architectureReport(
                     contract: contract.architecture,
+                    coreGuards: contract.coreGuards,
                     stage: arguments.stage,
-                    paths: paths
+                    paths: paths,
+                    developerDirectory: URL(fileURLWithPath: arguments.developerDirectory)
                 )
                 try writeStandardOutput(report)
                 return report["passed"] as? Bool == true ? 0 : 1

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Contract.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Contract.swift
@@ -9,6 +9,7 @@ struct AcceptanceContract: Codable, Sendable {
     let benchmark: BenchmarkContract
     let reliability: ReliabilityContract
     let architecture: ArchitectureContract
+    let coreGuards: CoreGuardContract
 
     enum CodingKeys: String, CodingKey {
         case schemaVersion = "schema_version"
@@ -17,6 +18,7 @@ struct AcceptanceContract: Codable, Sendable {
         case benchmark
         case reliability
         case architecture
+        case coreGuards = "core_guards"
     }
 
     static func load(from url: URL) throws -> Self {
@@ -26,6 +28,46 @@ struct AcceptanceContract: Codable, Sendable {
         catch {
             throw AcceptanceFailure.unknown("cannot decode contract \(url.path): \(error)")
         }
+    }
+}
+
+// MARK: - CoreGuardContract
+
+struct CoreGuardContract: Codable, Sendable {
+    let schemaVersion: Int
+    let compilerTimeoutSeconds: Double
+    let allowedPublicModules: [String]
+    let fixtureProduct: String
+    let fixtureAllowedImports: [String]
+    let forbiddenTransitiveProducts: [String]
+    let parity: ParityContract
+
+    enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case compilerTimeoutSeconds = "compiler_timeout_seconds"
+        case allowedPublicModules = "allowed_public_modules"
+        case fixtureProduct = "fixture_product"
+        case fixtureAllowedImports = "fixture_allowed_imports"
+        case forbiddenTransitiveProducts = "forbidden_transitive_products"
+        case parity
+    }
+}
+
+// MARK: - ParityContract
+
+struct ParityContract: Codable, Sendable {
+    let schemaVersion: Int
+    let requiredRoutes: [String]
+    let eventTypes: [String]
+    let terminalKinds: [String]
+    let finishReasons: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case requiredRoutes = "required_routes"
+        case eventTypes = "event_types"
+        case terminalKinds = "terminal_kinds"
+        case finishReasons = "finish_reasons"
     }
 }
 

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/CoreContractGuards.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/CoreContractGuards.swift
@@ -436,7 +436,7 @@ private final class PreciseIdentifierModuleResolver {
 
         let mangledNames = swiftIdentifiers.map { "$s\($0.dropFirst(2))" }
         let result = try runCommand(
-            [demangler.path] + mangledNames,
+            [demangler.path, "--expand", "--tree-only"] + mangledNames,
             currentDirectory: FileManager.default.temporaryDirectory,
             timeout: 30,
             sampleMemory: false,
@@ -502,55 +502,89 @@ func parseBatchDemanglerOutput(
     }
 
     let lines = output.dropLast().split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
-    guard lines.count == mangledNames.count else {
-        throw AcceptanceFailure.unknown(
-            "Swift demangler batch returned \(lines.count) records for \(mangledNames.count) inputs"
-        )
-    }
-
-    return try zip(zip(preciseIdentifiers, mangledNames), lines).map { pair, line in
-        let (preciseIdentifier, mangled) = pair
-        let prefix = "\(mangled) ---> "
-        guard line.hasPrefix(prefix) else {
+    var lineIndex = 0
+    var modules: [String?] = []
+    for (preciseIdentifier, mangled) in zip(preciseIdentifiers, mangledNames) {
+        guard lineIndex < lines.count,
+              lines[lineIndex] == "Demangling for \(mangled)"
+        else {
             throw AcceptanceFailure.unknown(
                 "Swift demangler batch returned a reordered or unsupported record"
             )
         }
 
-        let demangled = String(line.dropFirst(prefix.count))
-        guard !demangled.isEmpty else {
-            throw AcceptanceFailure.unknown("Swift demangler batch returned an empty record")
-        }
-        guard demangled != mangled else {
-            return nil
+        lineIndex += 1
+
+        guard lineIndex < lines.count else {
+            throw AcceptanceFailure.unknown("Swift demangler batch omitted its semantic tree")
         }
 
-        let payload = preciseIdentifier.dropFirst(2)
-        let requiresSwiftModule = payload.first?.isNumber != true
-        return try demangledModuleName(
-            demangled,
-            requiresSwiftModule: requiresSwiftModule
+        if lines[lineIndex] == "<<NULL>>" {
+            modules.append(nil)
+            lineIndex += 1
+            continue
+        }
+
+        guard lines[lineIndex] == "kind=Global" else {
+            throw AcceptanceFailure.unknown("Swift demangler batch omitted its Global root")
+        }
+
+        lineIndex += 1
+
+        var semanticLines: [String] = []
+        while lineIndex < lines.count,
+              !lines[lineIndex].hasPrefix("Demangling for ")
+        {
+            if lines[lineIndex].isEmpty {
+                lineIndex += 1
+                break
+            }
+            semanticLines.append(lines[lineIndex])
+            lineIndex += 1
+        }
+        guard !semanticLines.isEmpty else {
+            throw AcceptanceFailure.unknown("Swift demangler batch returned an empty Global root")
+        }
+
+        var topLevelNodeCount = 0
+        var discoveredModules: Set<String> = []
+        let moduleExpression = try NSRegularExpression(
+            pattern: #"^\s+kind=Module, text="([A-Za-z_][A-Za-z0-9_]*)"$"#
         )
-    }
-}
+        for semanticLine in semanticLines {
+            let indentation = semanticLine.prefix(while: { $0 == " " }).count
+            guard indentation >= 2,
+                  indentation.isMultiple(of: 2),
+                  semanticLine.dropFirst(indentation).hasPrefix("kind=")
+            else {
+                throw AcceptanceFailure.unknown(
+                    "Swift demangler batch returned a malformed semantic tree for \(preciseIdentifier)"
+                )
+            }
 
-private func demangledModuleName(
-    _ demangled: String,
-    requiresSwiftModule: Bool
-) throws -> String? {
-    let expression = try NSRegularExpression(
-        pattern: #"^([A-Za-z_][A-Za-z0-9_]*)\.[A-Za-z_][A-Za-z0-9_.]*$"#
-    )
-    let range = NSRange(demangled.startIndex ..< demangled.endIndex, in: demangled)
-    guard let match = expression.firstMatch(in: demangled, range: range),
-          match.range == range,
-          let moduleRange = Range(match.range(at: 1), in: demangled)
-    else {
-        return nil
+            if indentation == 2 {
+                topLevelNodeCount += 1
+            }
+
+            let range = NSRange(semanticLine.startIndex ..< semanticLine.endIndex, in: semanticLine)
+            if let match = moduleExpression.firstMatch(in: semanticLine, range: range),
+               let moduleRange = Range(match.range(at: 1), in: semanticLine)
+            {
+                discoveredModules.insert(String(semanticLine[moduleRange]))
+            }
+        }
+        guard topLevelNodeCount == 1, discoveredModules.count == 1 else {
+            modules.append(nil)
+            continue
+        }
+
+        modules.append(discoveredModules.first)
+    }
+    guard lineIndex == lines.count else {
+        throw AcceptanceFailure.unknown("Swift demangler batch returned trailing output")
     }
 
-    let module = String(demangled[moduleRange])
-    return requiresSwiftModule && module != "Swift" ? nil : module
+    return modules
 }
 
 // MARK: - External consumer and target dependency boundary

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/CoreContractGuards.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/CoreContractGuards.swift
@@ -97,7 +97,10 @@ func analyzePublicAPISymbolGraphs(
     allowedModules: Set<String>,
     developerDirectory: URL = URL(fileURLWithPath: "/Applications/Xcode.app/Contents/Developer")
 ) throws -> JSONObject {
-    let moduleResolver = try PreciseIdentifierModuleResolver(developerDirectory: developerDirectory)
+    let moduleResolver = try PreciseIdentifierModuleResolver(
+        developerDirectory: developerDirectory,
+        preciseIdentifiers: preciseIdentifiersNeedingResolution(in: graphs, target: target)
+    )
     let knownAccessLevels: Set<String> = ["fileprivate", "internal", "open", "package", "private", "public"]
     let knownRelationshipKinds: Set<String> = [
         "conformsTo",
@@ -369,6 +372,42 @@ private func optionalStrictStringArray(_ object: JSONObject, key: String, contex
     return try strictStringArray(object, key: key, context: context)
 }
 
+// MARK: - Precise identifier discovery
+
+private func preciseIdentifiersNeedingResolution(
+    in graphs: [JSONObject],
+    target: String
+) throws -> Set<String> {
+    var identifiers: Set<String> = []
+    for graph in graphs where try graph.object("module").string("name") == target {
+        let symbols = try strictObjectArray(graph, key: "symbols", context: "symbol graph")
+        var publicSymbolIdentifiers: Set<String> = []
+        for symbol in symbols {
+            let access = try symbol.string("accessLevel")
+            guard access == "public" || access == "open" else {
+                continue
+            }
+
+            try publicSymbolIdentifiers.insert(symbol.object("identifier").string("precise"))
+            for fragment in try strictObjectArray(
+                symbol,
+                key: "declarationFragments",
+                context: "public symbol"
+            ) where fragment["preciseIdentifier"] != nil {
+                try identifiers.insert(fragment.string("preciseIdentifier"))
+            }
+        }
+        for relationship in try strictObjectArray(graph, key: "relationships", context: "symbol graph") {
+            guard try publicSymbolIdentifiers.contains(relationship.string("source")) else {
+                continue
+            }
+
+            try identifiers.insert(relationship.string("target"))
+        }
+    }
+    return identifiers
+}
+
 // MARK: - PreciseIdentifierModuleResolver
 
 private final class PreciseIdentifierModuleResolver {
@@ -380,12 +419,43 @@ private final class PreciseIdentifierModuleResolver {
     private let demangler: URL
     private var cache: [String: Resolution] = [:]
 
-    init(developerDirectory: URL) throws {
+    init(developerDirectory: URL, preciseIdentifiers: Set<String>) throws {
         demangler = developerDirectory.appendingPathComponent(
             "Toolchains/XcodeDefault.xctoolchain/usr/bin/swift-demangle"
         )
         guard FileManager.default.isExecutableFile(atPath: demangler.path) else {
             throw AcceptanceFailure.unknown("missing Swift demangler: \(demangler.path)")
+        }
+
+        let swiftIdentifiers = preciseIdentifiers
+            .filter { $0.hasPrefix("s:") }
+            .sorted()
+        guard !swiftIdentifiers.isEmpty else {
+            return
+        }
+
+        let mangledNames = swiftIdentifiers.map { "$s\($0.dropFirst(2))" }
+        let result = try runCommand(
+            [demangler.path] + mangledNames,
+            currentDirectory: FileManager.default.temporaryDirectory,
+            timeout: 30,
+            sampleMemory: false,
+            timeoutFailureKind: .unknown,
+            timeoutContext: "Swift USR demangler"
+        )
+        guard result.returnCode == 0, result.stderr.isEmpty else {
+            throw AcceptanceFailure.unknown(
+                "cannot demangle Swift preciseIdentifiers:\n" + commandFailureSummary(result)
+            )
+        }
+
+        let modules = try parseBatchDemanglerOutput(
+            result.stdout,
+            preciseIdentifiers: swiftIdentifiers,
+            mangledNames: mangledNames
+        )
+        for (identifier, module) in zip(swiftIdentifiers, modules) {
+            cache[identifier] = module.map(Resolution.module) ?? .invalid
         }
     }
 
@@ -413,64 +483,74 @@ private final class PreciseIdentifierModuleResolver {
             return preciseIdentifier.contains(":") ? "__foreign__" : nil
         }
 
-        let payload = preciseIdentifier.dropFirst(2)
-        guard !payload.isEmpty else {
-            return nil
-        }
-
-        let digits = payload.prefix(while: \.isNumber)
-        if !digits.isEmpty {
-            guard let length = Int(digits), length > 0 else {
-                return nil
-            }
-
-            let moduleStart = payload.index(payload.startIndex, offsetBy: digits.count)
-            guard let moduleEnd = payload.index(
-                moduleStart,
-                offsetBy: length,
-                limitedBy: payload.endIndex
-            ),
-                moduleEnd < payload.endIndex
-            else {
-                return nil
-            }
-
-            return String(payload[moduleStart ..< moduleEnd])
-        }
-
-        let mangled = "$s\(payload)"
-        let result = try runCommand(
-            [demangler.path, "--compact", mangled],
-            currentDirectory: FileManager.default.temporaryDirectory,
-            timeout: 10,
-            sampleMemory: false,
-            timeoutFailureKind: .unknown,
-            timeoutContext: "Swift USR demangler"
+        throw AcceptanceFailure.unknown(
+            "Swift preciseIdentifier was not included in the sealed demangler batch: \(preciseIdentifier)"
         )
-        guard result.returnCode == 0 else {
-            throw AcceptanceFailure.unknown(
-                "cannot demangle Swift preciseIdentifier \(preciseIdentifier):\n"
-                    + commandFailureSummary(result)
-            )
-        }
-
-        return try parseDemangledSwiftModule(result.stdout, mangled: mangled)
     }
 }
 
-func parseDemangledSwiftModule(_ output: String, mangled: String) throws -> String? {
-    let lines = output.split(whereSeparator: \.isNewline).map(String.init)
-    guard lines.count == 1, let demangled = lines.first, demangled != mangled else {
-        return nil
+func parseBatchDemanglerOutput(
+    _ output: String,
+    preciseIdentifiers: [String],
+    mangledNames: [String]
+) throws -> [String?] {
+    guard preciseIdentifiers.count == mangledNames.count else {
+        throw AcceptanceFailure.unknown("Swift demangler batch identity count is inconsistent")
+    }
+    guard output.last == "\n", !output.contains("\r") else {
+        throw AcceptanceFailure.unknown("Swift demangler batch has an incomplete record terminator")
     }
 
-    let expression = try NSRegularExpression(pattern: #"^Swift\.[A-Za-z_][A-Za-z0-9_]*$"#)
+    let lines = output.dropLast().split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+    guard lines.count == mangledNames.count else {
+        throw AcceptanceFailure.unknown(
+            "Swift demangler batch returned \(lines.count) records for \(mangledNames.count) inputs"
+        )
+    }
+
+    return try zip(zip(preciseIdentifiers, mangledNames), lines).map { pair, line in
+        let (preciseIdentifier, mangled) = pair
+        let prefix = "\(mangled) ---> "
+        guard line.hasPrefix(prefix) else {
+            throw AcceptanceFailure.unknown(
+                "Swift demangler batch returned a reordered or unsupported record"
+            )
+        }
+
+        let demangled = String(line.dropFirst(prefix.count))
+        guard !demangled.isEmpty else {
+            throw AcceptanceFailure.unknown("Swift demangler batch returned an empty record")
+        }
+        guard demangled != mangled else {
+            return nil
+        }
+
+        let payload = preciseIdentifier.dropFirst(2)
+        let requiresSwiftModule = payload.first?.isNumber != true
+        return try demangledModuleName(
+            demangled,
+            requiresSwiftModule: requiresSwiftModule
+        )
+    }
+}
+
+private func demangledModuleName(
+    _ demangled: String,
+    requiresSwiftModule: Bool
+) throws -> String? {
+    let expression = try NSRegularExpression(
+        pattern: #"^([A-Za-z_][A-Za-z0-9_]*)\.[A-Za-z_][A-Za-z0-9_.]*$"#
+    )
     let range = NSRange(demangled.startIndex ..< demangled.endIndex, in: demangled)
-    guard expression.firstMatch(in: demangled, range: range)?.range == range else {
+    guard let match = expression.firstMatch(in: demangled, range: range),
+          match.range == range,
+          let moduleRange = Range(match.range(at: 1), in: demangled)
+    else {
         return nil
     }
 
-    return "Swift"
+    let module = String(demangled[moduleRange])
+    return requiresSwiftModule && module != "Swift" ? nil : module
 }
 
 // MARK: - External consumer and target dependency boundary

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/CoreContractGuards.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/CoreContractGuards.swift
@@ -1,0 +1,587 @@
+import Foundation
+
+// MARK: - Compiler-derived public API boundary
+
+func compilerPublicAPIReport(
+    target: String,
+    paths: WorkspacePaths,
+    developerDirectory: URL,
+    contract: CoreGuardContract
+) throws -> JSONObject {
+    let scratch = paths.repository.appendingPathComponent(".build/swama-core-symbol-graph")
+    if FileManager.default.fileExists(atPath: scratch.path) {
+        for file in try regularFiles(in: scratch, extensions: ["json"])
+            where file.lastPathComponent.hasSuffix(".symbols.json")
+        {
+            try FileManager.default.removeItem(at: file)
+        }
+    }
+
+    var environment = try developerEnvironment(developerDirectory)
+    environment["SWIFTPM_MODULECACHE_OVERRIDE"] = scratch.appendingPathComponent("module-cache").path
+    let result = try runCommand(
+        [
+            "xcrun",
+            "swift",
+            "package",
+            "--package-path",
+            paths.package.path,
+            "--scratch-path",
+            scratch.path,
+            "--force-resolved-versions",
+            "dump-symbol-graph",
+            "--minimum-access-level",
+            "public",
+            "--skip-synthesized-members"
+        ],
+        currentDirectory: paths.repository,
+        environment: environment,
+        timeout: contract.compilerTimeoutSeconds,
+        sampleMemory: false,
+        timeoutFailureKind: .unknown,
+        timeoutContext: "SwamaCore symbol graph"
+    )
+    guard result.returnCode == 0 else {
+        throw AcceptanceFailure.failed(
+            "SwamaCore symbol graph build failed:\n\(commandFailureSummary(result))"
+        )
+    }
+
+    var graphs: [JSONObject] = []
+    var graphFiles: [JSONObject] = []
+    for file in try regularFiles(in: scratch, extensions: ["json"])
+        .filter({ $0.lastPathComponent.hasSuffix(".symbols.json") })
+        .sorted(by: { $0.path < $1.path })
+    {
+        let graph = try loadJSONObject(file)
+        guard (try? graph.object("module").string("name")) == target else {
+            continue
+        }
+
+        graphs.append(graph)
+        try graphFiles.append([
+            "file": relativePathForGuard(file, to: scratch),
+            "sha256": sha256File(file)
+        ])
+    }
+    guard !graphs.isEmpty else {
+        throw AcceptanceFailure.unknown("compiler produced no symbol graph for target: \(target)")
+    }
+
+    var report = try analyzePublicAPISymbolGraphs(
+        graphs,
+        target: target,
+        allowedModules: Set(contract.allowedPublicModules)
+    )
+    let reachabilityHits = try publicReachabilityAttributeHits(
+        in: paths.package.appendingPathComponent("Sources/\(target)"),
+        repository: paths.repository
+    )
+    report["status"] = "ready"
+    report["symbol_graph_files"] = graphFiles
+    report["reachability_attribute_hits"] = reachabilityHits
+    report["passed"] = report["passed"] as? Bool == true && reachabilityHits.isEmpty
+    report["duration_ms"] = result.durationMilliseconds
+    return report
+}
+
+func analyzePublicAPISymbolGraphs(
+    _ graphs: [JSONObject],
+    target: String,
+    allowedModules: Set<String>
+) throws -> JSONObject {
+    var canonicalSymbols: [JSONObject] = []
+    var violations: [JSONObject] = []
+
+    for graph in graphs {
+        guard try graph.object("module").string("name") == target else {
+            continue
+        }
+
+        let symbols = try graph.object("symbols")
+        let relationships = (try? graph.array("relationships").compactMap { $0 as? JSONObject }) ?? []
+        let relationshipsBySource = Dictionary(grouping: relationships) { $0["source"] as? String ?? "" }
+
+        for symbol in symbols.values.compactMap({ $0 as? JSONObject }) {
+            let access = (symbol["accessLevel"] as? String) ?? "public"
+            guard access == "public" || access == "open" else {
+                continue
+            }
+
+            let identifier = try symbol.object("identifier").string("precise")
+            let kind = try symbol.object("kind").string("identifier")
+            let path = try symbol.array("pathComponents").compactMap { $0 as? String }
+            let fragments = try symbol.array("declarationFragments").compactMap { $0 as? JSONObject }
+            let declaration = fragments.compactMap { $0["spelling"] as? String }.joined()
+            let canonicalFragments = fragments.map { fragment -> JSONObject in
+                var value: JSONObject = [
+                    "kind": fragment["kind"] as? String ?? "unknown",
+                    "spelling": fragment["spelling"] as? String ?? ""
+                ]
+                if let precise = fragment["preciseIdentifier"] as? String {
+                    value["precise_identifier"] = precise
+                    value["module"] = moduleName(in: precise) ?? "unknown"
+                }
+                return value
+            }
+            var references: Set<String> = []
+
+            for fragment in fragments where fragment["kind"] as? String == "typeIdentifier" {
+                guard let precise = fragment["preciseIdentifier"] as? String,
+                      let module = moduleName(in: precise)
+                else {
+                    continue
+                }
+
+                references.insert(module)
+                if !allowedModules.contains(module) {
+                    violations.append(publicAPIViolation(
+                        identifier: identifier,
+                        path: path,
+                        module: module,
+                        source: "declaration"
+                    ))
+                }
+            }
+
+            var conformances: [String] = []
+            for relationship in relationshipsBySource[identifier] ?? [] {
+                guard let relationshipKind = relationship["kind"] as? String,
+                      ["conformsTo", "inheritsFrom", "requirementOf"].contains(relationshipKind),
+                      let targetIdentifier = relationship["target"] as? String
+                else {
+                    continue
+                }
+
+                let fallback = relationship["targetFallback"] as? String
+                let module = moduleName(in: targetIdentifier) ?? fallback?.split(separator: ".").first.map(String.init)
+                if let module {
+                    references.insert(module)
+                    conformances.append(fallback ?? targetIdentifier)
+                    if !allowedModules.contains(module) {
+                        violations.append(publicAPIViolation(
+                            identifier: identifier,
+                            path: path,
+                            module: module,
+                            source: relationshipKind
+                        ))
+                    }
+                }
+            }
+
+            canonicalSymbols.append([
+                "identifier": identifier,
+                "kind": kind,
+                "path": path,
+                "declaration": declaration,
+                "declaration_fragments": canonicalFragments,
+                "referenced_modules": references.sorted(),
+                "conformances": conformances.sorted()
+            ])
+        }
+    }
+
+    canonicalSymbols.sort { lhs, rhs in
+        (lhs["identifier"] as? String ?? "") < (rhs["identifier"] as? String ?? "")
+    }
+    let uniqueViolations = Dictionary(grouping: violations) { violation in
+        [
+            violation["identifier"] as? String ?? "",
+            violation["module"] as? String ?? "",
+            violation["source"] as? String ?? ""
+        ].joined(separator: "\u{0}")
+    }
+    .values
+    .compactMap(\.first)
+    .sorted { lhs, rhs in
+        let left = "\(lhs["identifier"] ?? ""):\(lhs["module"] ?? ""):\(lhs["source"] ?? "")"
+        let right = "\(rhs["identifier"] ?? ""):\(rhs["module"] ?? ""):\(rhs["source"] ?? "")"
+        return left < right
+    }
+
+    return try [
+        "target": target,
+        "graph_count": graphs.count,
+        "symbol_count": canonicalSymbols.count,
+        "allowed_modules": allowedModules.sorted(),
+        "symbols": canonicalSymbols,
+        "manifest_sha256": sha256(compactJSONData(canonicalSymbols)),
+        "violations": uniqueViolations,
+        "passed": uniqueViolations.isEmpty
+    ]
+}
+
+func publicReachabilityAttributeHits(in root: URL, repository: URL) throws -> [JSONObject] {
+    guard FileManager.default.fileExists(atPath: root.path) else {
+        return []
+    }
+
+    let expression = try NSRegularExpression(
+        pattern: #"^\s*(?:@[A-Za-z_][A-Za-z0-9_]*(?:\([^)]*\))?\s+)*@(inlinable|usableFromInline)\b"#
+    )
+    var hits: [JSONObject] = []
+    for file in try regularFiles(in: root, extensions: ["swift"]).sorted(by: { $0.path < $1.path }) {
+        let lines = try String(contentsOf: file, encoding: .utf8)
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map(String.init)
+        for (index, line) in lines.enumerated() {
+            let range = NSRange(line.startIndex ..< line.endIndex, in: line)
+            for match in expression.matches(in: line, range: range) {
+                guard let attributeRange = Range(match.range(at: 1), in: line) else {
+                    continue
+                }
+
+                hits.append([
+                    "file": relativePathForGuard(file, to: repository),
+                    "line": index + 1,
+                    "attribute": "@\(line[attributeRange])"
+                ])
+            }
+        }
+    }
+    return hits
+}
+
+private func publicAPIViolation(
+    identifier: String,
+    path: [String],
+    module: String,
+    source: String
+) -> JSONObject {
+    [
+        "identifier": identifier,
+        "path": path,
+        "module": module,
+        "source": source
+    ]
+}
+
+private func moduleName(in preciseIdentifier: String) -> String? {
+    guard preciseIdentifier.hasPrefix("s:") else {
+        return preciseIdentifier.contains(":") ? "__foreign__" : nil
+    }
+
+    let payload = preciseIdentifier.dropFirst(2)
+    var digits = ""
+    for character in payload {
+        guard character.isNumber else {
+            break
+        }
+
+        digits.append(character)
+    }
+    guard let length = Int(digits), length > 0 else {
+        return "Swift"
+    }
+
+    let moduleStart = payload.index(payload.startIndex, offsetBy: digits.count)
+    guard let moduleEnd = payload.index(moduleStart, offsetBy: length, limitedBy: payload.endIndex) else {
+        return nil
+    }
+
+    return String(payload[moduleStart ..< moduleEnd])
+}
+
+// MARK: - External consumer and target dependency boundary
+
+func externalConsumerBoundaryReport(
+    fixture: URL,
+    contract: CoreGuardContract
+) throws -> JSONObject {
+    let manifestURL = fixture.appendingPathComponent("Package.swift")
+    let manifest = try String(contentsOf: manifestURL, encoding: .utf8)
+    let products = try captures(
+        #"\.product\s*\(\s*name:\s*\"([^\"]+)\""#,
+        in: manifest
+    )
+    let remotePackages = try captures(#"\.package\s*\(\s*url:\s*\"([^\"]+)\""#, in: manifest)
+    let expectedProducts = [contract.fixtureProduct]
+    let unexpectedProducts = Array(Set(products).subtracting(expectedProducts)).sorted()
+    let missingProducts = Array(Set(expectedProducts).subtracting(products)).sorted()
+
+    let allowedImports = Set(contract.fixtureAllowedImports)
+    let expression = try NSRegularExpression(pattern: swiftImportDeclarationPattern)
+    var imports: Set<String> = []
+    let sourceRoot = fixture.appendingPathComponent("Sources")
+    if FileManager.default.fileExists(atPath: sourceRoot.path) {
+        for file in try regularFiles(in: sourceRoot, extensions: ["swift"]) {
+            let lines = try String(contentsOf: file, encoding: .utf8)
+                .split(separator: "\n", omittingEmptySubsequences: false)
+            for line in lines {
+                if let module = swiftImportedModule(in: String(line), matching: expression) {
+                    imports.insert(module)
+                }
+            }
+        }
+    }
+    let unexpectedImports = Array(imports.subtracting(allowedImports)).sorted()
+    let missingImports = allowedImports.contains(contract.fixtureProduct) && !imports.contains(contract.fixtureProduct)
+        ? [contract.fixtureProduct]
+        : []
+    let passed = remotePackages.isEmpty
+        && unexpectedProducts.isEmpty
+        && missingProducts.isEmpty
+        && unexpectedImports.isEmpty
+        && missingImports.isEmpty
+
+    return [
+        "status": passed ? "ready" : "unmet",
+        "expected_products": expectedProducts,
+        "actual_products": products.sorted(),
+        "unexpected_products": unexpectedProducts,
+        "missing_products": missingProducts,
+        "remote_packages": remotePackages.sorted(),
+        "actual_imports": imports.sorted(),
+        "unexpected_imports": unexpectedImports,
+        "missing_imports": missingImports,
+        "passed": passed
+    ]
+}
+
+func coreTargetDependencyReport(
+    target: String,
+    paths: WorkspacePaths,
+    developerDirectory: URL,
+    contract: CoreGuardContract
+) throws -> JSONObject {
+    let result = try runCommand(
+        [
+            "xcrun",
+            "swift",
+            "package",
+            "--package-path",
+            paths.package.path,
+            "describe",
+            "--type",
+            "json"
+        ],
+        currentDirectory: paths.repository,
+        environment: developerEnvironment(developerDirectory),
+        timeout: 60,
+        sampleMemory: false,
+        timeoutFailureKind: .unknown,
+        timeoutContext: "SwamaCore dependency graph"
+    )
+    guard result.returnCode == 0,
+          let data = result.stdout.data(using: .utf8),
+          let description = try JSONSerialization.jsonObject(with: data) as? JSONObject
+    else {
+        throw AcceptanceFailure.unknown(
+            "cannot inspect SwamaCore dependency graph:\n\(commandFailureSummary(result))"
+        )
+    }
+
+    return try analyzeTargetDependencyGraph(
+        description,
+        target: target,
+        forbiddenProducts: Set(contract.forbiddenTransitiveProducts)
+    )
+}
+
+func analyzeTargetDependencyGraph(
+    _ description: JSONObject,
+    target: String,
+    forbiddenProducts: Set<String>
+) throws -> JSONObject {
+    let targetObjects = try description.array("targets").compactMap { $0 as? JSONObject }
+    let targetsByName = Dictionary(uniqueKeysWithValues: targetObjects.compactMap { item -> (String, JSONObject)? in
+        guard let name = item["name"] as? String else {
+            return nil
+        }
+
+        return (name, item)
+    })
+    guard targetsByName[target] != nil else {
+        return [
+            "status": "unmet",
+            "target": target,
+            "target_dependencies": [],
+            "product_dependencies": [],
+            "forbidden_products": [],
+            "passed": false
+        ]
+    }
+
+    var queue = [target]
+    var visited: Set<String> = []
+    var products: Set<String> = []
+    while let name = queue.popLast() {
+        guard visited.insert(name).inserted, let item = targetsByName[name] else {
+            continue
+        }
+
+        let targetDependencies = (item["target_dependencies"] as? [String]) ?? []
+        let productDependencies = (item["product_dependencies"] as? [String]) ?? []
+        queue.append(contentsOf: targetDependencies)
+        products.formUnion(productDependencies)
+    }
+    let forbidden = products.intersection(forbiddenProducts).sorted()
+    return [
+        "status": forbidden.isEmpty ? "ready" : "violated",
+        "target": target,
+        "target_dependencies": visited.sorted(),
+        "product_dependencies": products.sorted(),
+        "forbidden_products": forbidden,
+        "passed": forbidden.isEmpty
+    ]
+}
+
+private func captures(_ pattern: String, in text: String) throws -> [String] {
+    let expression = try NSRegularExpression(pattern: pattern)
+    let range = NSRange(text.startIndex ..< text.endIndex, in: text)
+    return expression.matches(in: text, range: range).compactMap { match in
+        guard let capture = Range(match.range(at: 1), in: text) else {
+            return nil
+        }
+
+        return String(text[capture])
+    }
+}
+
+// MARK: - Canonical three-route parity records
+
+func paritySchemaReport(_ contract: ParityContract) -> JSONObject {
+    [
+        "status": "ready",
+        "schema_version": contract.schemaVersion,
+        "required_routes": contract.requiredRoutes,
+        "event_types": contract.eventTypes,
+        "terminal_kinds": contract.terminalKinds,
+        "finish_reasons": contract.finishReasons,
+        "execution_status": "unmet"
+    ]
+}
+
+func validateParityRecord(_ record: JSONObject, contract: ParityContract) throws -> JSONObject {
+    try requireExactKeys(
+        record,
+        expected: ["schema_version", "case_id", "route", "events", "terminal"],
+        context: "parity record"
+    )
+    guard try record.integer("schema_version") == contract.schemaVersion else {
+        throw AcceptanceFailure.unknown("parity record schema_version is unsupported")
+    }
+    guard try !record.string("case_id").isEmpty else {
+        throw AcceptanceFailure.unknown("parity record case_id is empty")
+    }
+
+    let route = try record.string("route")
+    guard contract.requiredRoutes.contains(route) else {
+        throw AcceptanceFailure.unknown("parity record route is unknown: \(route)")
+    }
+
+    let events = try record.array("events")
+    for (index, value) in events.enumerated() {
+        guard let event = value as? JSONObject else {
+            throw AcceptanceFailure.unknown("parity event at index \(index) is not an object")
+        }
+        guard try event.integer("sequence") == index else {
+            throw AcceptanceFailure.unknown("parity event sequence is not contiguous at index \(index)")
+        }
+
+        let type = try event.string("type")
+        guard contract.eventTypes.contains(type) else {
+            throw AcceptanceFailure.unknown("parity event type is unknown: \(type)")
+        }
+
+        switch type {
+        case "text_delta":
+            try requireExactKeys(event, expected: ["sequence", "type", "text"], context: "text_delta event")
+            _ = try event.string("text")
+
+        case "tool_call":
+            try requireExactKeys(
+                event,
+                expected: ["sequence", "type", "name", "arguments"],
+                context: "tool_call event"
+            )
+            guard try !event.string("name").isEmpty else {
+                throw AcceptanceFailure.unknown("tool_call event name is empty")
+            }
+            guard event["arguments"] != nil else {
+                throw AcceptanceFailure.unknown("tool_call event arguments are missing")
+            }
+
+        default:
+            throw AcceptanceFailure.unknown("parity event type is not implemented: \(type)")
+        }
+    }
+
+    let terminal = try record.object("terminal")
+    let kind = try terminal.string("kind")
+    guard contract.terminalKinds.contains(kind) else {
+        throw AcceptanceFailure.unknown("parity terminal kind is unknown: \(kind)")
+    }
+
+    switch kind {
+    case "response":
+        try validateResponseTerminal(terminal, contract: contract)
+
+    case "cancelled":
+        try requireExactKeys(terminal, expected: ["kind"], context: "cancelled terminal")
+
+    case "error":
+        try requireExactKeys(terminal, expected: ["kind", "code"], context: "error terminal")
+        guard try !terminal.string("code").isEmpty else {
+            throw AcceptanceFailure.unknown("parity error code is empty")
+        }
+
+    default:
+        throw AcceptanceFailure.unknown("parity terminal kind is not implemented: \(kind)")
+    }
+    return record
+}
+
+private func validateResponseTerminal(_ terminal: JSONObject, contract: ParityContract) throws {
+    try requireExactKeys(
+        terminal,
+        expected: ["kind", "output", "tool_calls", "finish_reason", "usage"],
+        context: "response terminal"
+    )
+    _ = try terminal.string("output")
+    let finishReason = try terminal.string("finish_reason")
+    guard contract.finishReasons.contains(finishReason) else {
+        throw AcceptanceFailure.unknown("parity finish_reason is unknown: \(finishReason)")
+    }
+
+    for (index, value) in try terminal.array("tool_calls").enumerated() {
+        guard let call = value as? JSONObject else {
+            throw AcceptanceFailure.unknown("parity tool call at index \(index) is not an object")
+        }
+
+        try requireExactKeys(call, expected: ["name", "arguments"], context: "terminal tool call")
+        guard try !call.string("name").isEmpty, call["arguments"] != nil else {
+            throw AcceptanceFailure.unknown("parity terminal tool call is incomplete")
+        }
+    }
+    let usage = try terminal.object("usage")
+    try requireExactKeys(
+        usage,
+        expected: ["prompt_tokens", "completion_tokens", "total_tokens"],
+        context: "parity usage"
+    )
+    let prompt = try usage.integer("prompt_tokens")
+    let completion = try usage.integer("completion_tokens")
+    let total = try usage.integer("total_tokens")
+    guard prompt >= 0, completion >= 0, total == prompt + completion else {
+        throw AcceptanceFailure.unknown("parity usage token counts are invalid")
+    }
+}
+
+private func requireExactKeys(_ object: JSONObject, expected: Set<String>, context: String) throws {
+    let actual = Set(object.keys)
+    guard actual == expected else {
+        let missing = expected.subtracting(actual).sorted()
+        let unknown = actual.subtracting(expected).sorted()
+        throw AcceptanceFailure.unknown(
+            "\(context) keys are invalid; missing=\(missing), unknown=\(unknown)"
+        )
+    }
+}
+
+private func relativePathForGuard(_ file: URL, to root: URL) -> String {
+    file.resolvingSymlinksInPath().path.replacingOccurrences(
+        of: root.resolvingSymlinksInPath().path + "/",
+        with: ""
+    )
+}

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/CoreContractGuards.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/CoreContractGuards.swift
@@ -132,12 +132,19 @@ func analyzePublicAPISymbolGraphs(
             )
             let declaration = fragments.compactMap { $0["spelling"] as? String }.joined()
             let canonicalFragments = try fragments.map { fragment -> JSONObject in
+                let fragmentKind = try fragment.string("kind")
                 var value: JSONObject = try [
-                    "kind": fragment.string("kind"),
+                    "kind": fragmentKind,
                     "spelling": fragment.string("spelling")
                 ]
                 if fragment["preciseIdentifier"] != nil {
                     let precise = try fragment.string("preciseIdentifier")
+                    guard moduleName(in: precise) != nil else {
+                        throw AcceptanceFailure.unknown(
+                            "public declaration has an unparseable preciseIdentifier: \(precise)"
+                        )
+                    }
+
                     value["precise_identifier"] = precise
                     value["module"] = moduleName(in: precise) ?? "unknown"
                 }
@@ -146,10 +153,15 @@ func analyzePublicAPISymbolGraphs(
             var references: Set<String> = []
 
             for fragment in fragments where fragment["kind"] as? String == "typeIdentifier" {
-                guard let precise = fragment["preciseIdentifier"] as? String,
-                      let module = moduleName(in: precise)
-                else {
+                guard fragment["preciseIdentifier"] != nil else {
                     continue
+                }
+
+                let precise = try fragment.string("preciseIdentifier")
+                guard let module = moduleName(in: precise) else {
+                    throw AcceptanceFailure.unknown(
+                        "public typeIdentifier has an unparseable module: \(precise)"
+                    )
                 }
 
                 references.insert(module)
@@ -176,18 +188,23 @@ func analyzePublicAPISymbolGraphs(
                 let fallback = try relationship["targetFallback"] == nil
                     ? nil
                     : relationship.string("targetFallback")
-                let module = moduleName(in: targetIdentifier) ?? fallback?.split(separator: ".").first.map(String.init)
-                if let module {
-                    references.insert(module)
-                    conformances.append(fallback ?? targetIdentifier)
-                    if !allowedModules.contains(module) {
-                        violations.append(publicAPIViolation(
-                            identifier: identifier,
-                            path: path,
-                            module: module,
-                            source: relationshipKind
-                        ))
-                    }
+                guard let module = moduleName(in: targetIdentifier)
+                    ?? fallback?.split(separator: ".").first.map(String.init)
+                else {
+                    throw AcceptanceFailure.unknown(
+                        "public relationship has an unparseable target: \(targetIdentifier)"
+                    )
+                }
+
+                references.insert(module)
+                conformances.append(fallback ?? targetIdentifier)
+                if !allowedModules.contains(module) {
+                    violations.append(publicAPIViolation(
+                        identifier: identifier,
+                        path: path,
+                        module: module,
+                        source: relationshipKind
+                    ))
                 }
             }
 
@@ -302,6 +319,14 @@ private func strictStringArray(_ object: JSONObject, key: String, context: Strin
     }
 }
 
+private func optionalStrictStringArray(_ object: JSONObject, key: String, context: String) throws -> [String] {
+    guard object[key] != nil else {
+        return []
+    }
+
+    return try strictStringArray(object, key: key, context: context)
+}
+
 private func moduleName(in preciseIdentifier: String) -> String? {
     guard preciseIdentifier.hasPrefix("s:") else {
         return preciseIdentifier.contains(":") ? "__foreign__" : nil
@@ -366,12 +391,9 @@ func externalConsumerBoundaryReport(
     let sourceRoot = fixture.appendingPathComponent("Sources")
     if FileManager.default.fileExists(atPath: sourceRoot.path) {
         for file in try regularFiles(in: sourceRoot, extensions: ["swift"]) {
-            let lines = try String(contentsOf: file, encoding: .utf8)
-                .split(separator: "\n", omittingEmptySubsequences: false)
-            for line in lines {
-                if let module = swiftImportedModule(in: String(line), matching: expression) {
-                    imports.insert(module)
-                }
+            let source = try String(contentsOf: file, encoding: .utf8)
+            for declaration in swiftImportedModules(in: source, matching: expression) {
+                imports.insert(declaration.module)
             }
         }
     }
@@ -671,7 +693,7 @@ func analyzeResolvedTargetDependencyGraph(
         let traits = activeTraits?[node.package] ?? ["default"]
 
         for dependency in try targetDependencyDescriptors(targetDescription) {
-            guard dependency.isActive(platform: "macos", traits: traits) else {
+            guard try dependency.isActive(platform: "macos", traits: traits) else {
                 continue
             }
 
@@ -783,13 +805,24 @@ private struct TargetDependencyDescriptor {
     let package: String?
     let condition: JSONObject?
 
-    func isActive(platform: String, traits: Set<String>) -> Bool {
+    func isActive(platform: String, traits: Set<String>) throws -> Bool {
         guard let condition else {
             return true
         }
+        guard Set(condition.keys).isSubset(of: ["platformNames", "traits"]) else {
+            throw AcceptanceFailure.unknown("resolved target dependency condition has unknown keys")
+        }
 
-        let platforms = Set((condition["platformNames"] as? [String]) ?? [])
-        let requiredTraits = Set((condition["traits"] as? [String]) ?? [])
+        let platforms = try Set(optionalStrictStringArray(
+            condition,
+            key: "platformNames",
+            context: "resolved target dependency condition"
+        ))
+        let requiredTraits = try Set(optionalStrictStringArray(
+            condition,
+            key: "traits",
+            context: "resolved target dependency condition"
+        ))
         return (platforms.isEmpty || platforms.contains(platform))
             && requiredTraits.isSubset(of: traits)
     }
@@ -801,7 +834,7 @@ private func resolvedPackageDescriptors(_ root: JSONObject) throws -> [String: R
     while let node = queue.popLast() {
         let identity = try node.string("identity")
         let path = try node.string("path")
-        let dependencies = try node.array("dependencies").compactMap { $0 as? JSONObject }
+        let dependencies = try strictObjectArray(node, key: "dependencies", context: "resolved package graph")
         var aliases: [String: String] = [:]
         for dependency in dependencies {
             let dependencyIdentity = try dependency.string("identity")
@@ -815,10 +848,14 @@ private func resolvedPackageDescriptors(_ root: JSONObject) throws -> [String: R
                 aliases[alias] = dependencyIdentity
             }
         }
-        let descriptor = ResolvedPackageDescriptor(
+        let descriptor = try ResolvedPackageDescriptor(
             path: path,
             directPackageAliases: aliases,
-            activeTraits: Set((node["traits"] as? [String]) ?? [])
+            activeTraits: Set(optionalStrictStringArray(
+                node,
+                key: "traits",
+                context: "resolved package graph"
+            ))
         )
         if let existing = result[identity],
            existing.path != descriptor.path
@@ -837,19 +874,24 @@ private func resolvedPackageDescriptors(_ root: JSONObject) throws -> [String: R
 
 private func packageProducts(_ manifest: JSONObject) throws -> [String: PackageProduct] {
     var result: [String: PackageProduct] = [:]
-    for value in try manifest.array("products") {
-        guard let product = value as? JSONObject else {
-            throw AcceptanceFailure.unknown("resolved package product is not an object")
-        }
-
+    for product in try strictObjectArray(manifest, key: "products", context: "resolved package manifest") {
         let name = try product.string("name")
         guard result[name] == nil else {
             throw AcceptanceFailure.unknown("resolved package has duplicate product: \(name)")
         }
 
+        let type = try product.object("type")
+        guard type.count == 1 else {
+            throw AcceptanceFailure.unknown("resolved package product type has an unsupported shape")
+        }
+
+        let isLibrary = type["library"] != nil
+        if isLibrary {
+            _ = try strictStringArray(type, key: "library", context: "resolved library product")
+        }
         result[name] = try PackageProduct(
-            targets: product.array("targets").compactMap { $0 as? String },
-            isLibrary: (try? product.object("type").array("library")) != nil
+            targets: strictStringArray(product, key: "targets", context: "resolved package product"),
+            isLibrary: isLibrary
         )
     }
     return result
@@ -857,11 +899,7 @@ private func packageProducts(_ manifest: JSONObject) throws -> [String: PackageP
 
 private func packageTargets(_ manifest: JSONObject) throws -> [String: JSONObject] {
     var result: [String: JSONObject] = [:]
-    for value in try manifest.array("targets") {
-        guard let target = value as? JSONObject else {
-            throw AcceptanceFailure.unknown("resolved package target is not an object")
-        }
-
+    for target in try strictObjectArray(manifest, key: "targets", context: "resolved package manifest") {
         let name = try target.string("name")
         guard result[name] == nil else {
             throw AcceptanceFailure.unknown("resolved package has duplicate target: \(name)")
@@ -874,9 +912,13 @@ private func packageTargets(_ manifest: JSONObject) throws -> [String: JSONObjec
 
 private func packageDependencyAliases(_ manifest: JSONObject) throws -> [String: String] {
     var result: [String: String] = [:]
-    for value in try manifest.array("dependencies") {
-        guard let dependency = value as? JSONObject else {
-            throw AcceptanceFailure.unknown("resolved package dependency is not an object")
+    for dependency in try strictObjectArray(
+        manifest,
+        key: "dependencies",
+        context: "resolved package manifest"
+    ) {
+        guard dependency.count == 1 else {
+            throw AcceptanceFailure.unknown("resolved package dependency has an unsupported shape")
         }
 
         for descriptors in dependency.values {
@@ -884,14 +926,18 @@ private func packageDependencyAliases(_ manifest: JSONObject) throws -> [String:
                 throw AcceptanceFailure.unknown("resolved package dependency payload is not an array")
             }
 
-            for value in descriptors {
+            for (index, value) in descriptors.enumerated() {
                 guard let descriptor = value as? JSONObject else {
-                    throw AcceptanceFailure.unknown("resolved package dependency descriptor is not an object")
+                    throw AcceptanceFailure.unknown(
+                        "resolved package dependency descriptor[\(index)] is not an object"
+                    )
                 }
 
                 let identity = try descriptor.string("identity")
-                let aliases = [identity, descriptor["nameForTargetDependencyResolutionOnly"] as? String]
-                    .compactMap(\.self)
+                var aliases = [identity]
+                if descriptor["nameForTargetDependencyResolutionOnly"] != nil {
+                    try aliases.append(descriptor.string("nameForTargetDependencyResolutionOnly"))
+                }
                 for alias in aliases {
                     if let existing = result[alias], existing != identity {
                         throw AcceptanceFailure.unknown(
@@ -908,32 +954,56 @@ private func packageDependencyAliases(_ manifest: JSONObject) throws -> [String:
 
 private func targetDependencyDescriptors(_ target: JSONObject) throws -> [TargetDependencyDescriptor] {
     var result: [TargetDependencyDescriptor] = []
-    for value in try target.array("dependencies") {
-        guard let dependency = value as? JSONObject, dependency.count == 1,
+    for dependency in try strictObjectArray(target, key: "dependencies", context: "resolved package target") {
+        guard dependency.count == 1,
               let kind = dependency.keys.first,
               let parts = dependency[kind] as? [Any],
+              ["byName", "product", "target"].contains(kind),
+              parts.count == (kind == "product" ? 4 : 2),
               let name = parts.first as? String
         else {
             throw AcceptanceFailure.unknown("resolved target dependency has an unsupported shape")
         }
 
-        result.append(TargetDependencyDescriptor(
+        let package: String?
+        if kind == "product", !(parts[1] is NSNull) {
+            guard let value = parts[1] as? String else {
+                throw AcceptanceFailure.unknown("resolved product dependency package is not a string")
+            }
+
+            package = value
+        }
+        else {
+            package = nil
+        }
+        if kind == "product", !(parts[2] is NSNull) {
+            guard let aliases = parts[2] as? JSONObject,
+                  aliases.values.allSatisfy({ $0 is String })
+            else {
+                throw AcceptanceFailure.unknown("resolved product dependency module aliases are invalid")
+            }
+        }
+
+        try result.append(TargetDependencyDescriptor(
             kind: kind,
             name: name,
-            package: kind == "product" && parts.count > 1 ? parts[1] as? String : nil,
+            package: package,
             condition: dependencyCondition(kind: kind, parts: parts)
         ))
     }
     return result
 }
 
-private func dependencyCondition(kind: String, parts: [Any]) -> JSONObject? {
+private func dependencyCondition(kind: String, parts: [Any]) throws -> JSONObject? {
     let index = kind == "product" ? 3 : 1
-    guard parts.indices.contains(index) else {
+    guard !(parts[index] is NSNull) else {
         return nil
     }
+    guard let condition = parts[index] as? JSONObject else {
+        throw AcceptanceFailure.unknown("resolved target dependency condition is not an object")
+    }
 
-    return parts[index] as? JSONObject
+    return condition
 }
 
 private func resolveProductDependency(

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/CoreContractGuards.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/CoreContractGuards.swift
@@ -177,9 +177,9 @@ func analyzePublicAPISymbolGraphs(
                     "spelling": fragment.string("spelling")
                 ]
                 if fragment["preciseIdentifier"] != nil {
-                    guard fragmentKind == "typeIdentifier" else {
+                    guard ["attribute", "typeIdentifier"].contains(fragmentKind) else {
                         throw AcceptanceFailure.unknown(
-                            "non-type declaration fragment carries preciseIdentifier: \(fragmentKind)"
+                            "unsupported declaration fragment carries preciseIdentifier: \(fragmentKind)"
                         )
                     }
 
@@ -197,7 +197,9 @@ func analyzePublicAPISymbolGraphs(
             }
             var references: Set<String> = []
 
-            for fragment in fragments where fragment["kind"] as? String == "typeIdentifier" {
+            for fragment in fragments
+                where ["attribute", "typeIdentifier"].contains(fragment["kind"] as? String ?? "")
+            {
                 guard fragment["preciseIdentifier"] != nil else {
                     continue
                 }
@@ -227,9 +229,7 @@ func analyzePublicAPISymbolGraphs(
                 let fallback = try relationship["targetFallback"] == nil
                     ? nil
                     : relationship.string("targetFallback")
-                guard let module = moduleName(in: targetIdentifier)
-                    ?? fallback?.split(separator: ".").first.map(String.init)
-                else {
+                guard let module = moduleName(in: targetIdentifier) else {
                     throw AcceptanceFailure.unknown(
                         "public relationship has an unparseable target: \(targetIdentifier)"
                     )
@@ -367,6 +367,10 @@ private func optionalStrictStringArray(_ object: JSONObject, key: String, contex
 }
 
 private func moduleName(in preciseIdentifier: String) -> String? {
+    let knownClangModules = ["c:@T@NSTimeInterval": "Foundation"]
+    if let module = knownClangModules[preciseIdentifier] {
+        return module
+    }
     guard preciseIdentifier.hasPrefix("s:") else {
         return preciseIdentifier.contains(":") ? "__foreign__" : nil
     }
@@ -401,7 +405,8 @@ private func moduleName(in preciseIdentifier: String) -> String? {
 
 private func isValidStandardLibraryUSRPayload(_ payload: String) -> Bool {
     let substitutions: Set<String> = [
-        "SD", "SP", "SR", "SS", "SV", "Sa", "Sb", "Sc", "Sd", "Sf", "Si", "Sp", "Sq", "Sr", "Su", "Sv"
+        "SD", "SE", "SH", "SP", "SQ", "SR", "SS", "SV", "SY", "Sa", "Sb", "Sc", "ScA", "ScM", "Sd", "Se",
+        "Sf", "Sh", "Si", "Sn", "Sp", "Sq", "Sr", "Su", "Sv"
     ]
     if substitutions.contains(payload) {
         return true
@@ -436,7 +441,7 @@ private func isValidStandardLibraryUSRPayload(_ payload: String) -> Bool {
         return false
     }
 
-    return ["A", "C", "E", "O", "P", "V"].contains(nominalKind)
+    return ["A", "C", "E", "O", "P", "V", "a"].contains(nominalKind)
 }
 
 // MARK: - External consumer and target dependency boundary

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/CoreContractGuards.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/CoreContractGuards.swift
@@ -20,20 +20,7 @@ func compilerPublicAPIReport(
     var environment = try developerEnvironment(developerDirectory)
     environment["SWIFTPM_MODULECACHE_OVERRIDE"] = scratch.appendingPathComponent("module-cache").path
     let result = try runCommand(
-        [
-            "xcrun",
-            "swift",
-            "package",
-            "--package-path",
-            paths.package.path,
-            "--scratch-path",
-            scratch.path,
-            "--force-resolved-versions",
-            "dump-symbol-graph",
-            "--minimum-access-level",
-            "public",
-            "--skip-synthesized-members"
-        ],
+        symbolGraphCommand(package: paths.package, scratch: scratch),
         currentDirectory: paths.repository,
         environment: environment,
         timeout: contract.compilerTimeoutSeconds,
@@ -85,6 +72,24 @@ func compilerPublicAPIReport(
     return report
 }
 
+func symbolGraphCommand(package: URL, scratch: URL) -> [String] {
+    [
+        "xcrun",
+        "swift",
+        "package",
+        "--package-path",
+        package.path,
+        "--scratch-path",
+        scratch.path,
+        "--force-resolved-versions",
+        "dump-symbol-graph",
+        "--minimum-access-level",
+        "public",
+        "--skip-synthesized-members",
+        "--emit-extension-block-symbols"
+    ]
+}
+
 func analyzePublicAPISymbolGraphs(
     _ graphs: [JSONObject],
     target: String,
@@ -98,11 +103,11 @@ func analyzePublicAPISymbolGraphs(
             continue
         }
 
-        let symbols = try graph.object("symbols")
+        let symbols = try graph.array("symbols").compactMap { $0 as? JSONObject }
         let relationships = (try? graph.array("relationships").compactMap { $0 as? JSONObject }) ?? []
         let relationshipsBySource = Dictionary(grouping: relationships) { $0["source"] as? String ?? "" }
 
-        for symbol in symbols.values.compactMap({ $0 as? JSONObject }) {
+        for symbol in symbols {
             let access = (symbol["accessLevel"] as? String) ?? "public"
             guard access == "public" || access == "open" else {
                 continue
@@ -147,7 +152,8 @@ func analyzePublicAPISymbolGraphs(
             var conformances: [String] = []
             for relationship in relationshipsBySource[identifier] ?? [] {
                 guard let relationshipKind = relationship["kind"] as? String,
-                      ["conformsTo", "inheritsFrom", "requirementOf"].contains(relationshipKind),
+                      ["conformsTo", "extensionTo", "inheritsFrom", "memberOf", "requirementOf"]
+                      .contains(relationshipKind),
                       let targetIdentifier = relationship["target"] as? String
                 else {
                     continue
@@ -286,20 +292,34 @@ private func moduleName(in preciseIdentifier: String) -> String? {
 
 func externalConsumerBoundaryReport(
     fixture: URL,
-    contract: CoreGuardContract
+    contract: CoreGuardContract,
+    developerDirectory: URL = URL(fileURLWithPath: "/Applications/Xcode.app/Contents/Developer")
 ) throws -> JSONObject {
-    let manifestURL = fixture.appendingPathComponent("Package.swift")
-    let manifest = try String(contentsOf: manifestURL, encoding: .utf8)
-    let products = try captures(
-        #"\.product\s*\(\s*name:\s*\"([^\"]+)\""#,
-        in: manifest
+    let result = try runCommand(
+        [
+            "xcrun",
+            "swift",
+            "package",
+            "--package-path",
+            fixture.path,
+            "dump-package"
+        ],
+        currentDirectory: fixture,
+        environment: developerEnvironment(developerDirectory),
+        timeout: 60,
+        sampleMemory: false,
+        timeoutFailureKind: .unknown,
+        timeoutContext: "external consumer manifest"
     )
-    let remotePackages = try captures(#"\.package\s*\(\s*url:\s*\"([^\"]+)\""#, in: manifest)
-    let expectedProducts = [contract.fixtureProduct]
-    let unexpectedProducts = Array(Set(products).subtracting(expectedProducts)).sorted()
-    let missingProducts = Array(Set(expectedProducts).subtracting(products)).sorted()
+    guard result.returnCode == 0,
+          let data = result.stdout.data(using: .utf8),
+          let description = try JSONSerialization.jsonObject(with: data) as? JSONObject
+    else {
+        throw AcceptanceFailure.unknown(
+            "cannot inspect external consumer manifest:\n\(commandFailureSummary(result))"
+        )
+    }
 
-    let allowedImports = Set(contract.fixtureAllowedImports)
     let expression = try NSRegularExpression(pattern: swiftImportDeclarationPattern)
     var imports: Set<String> = []
     let sourceRoot = fixture.appendingPathComponent("Sources")
@@ -314,23 +334,104 @@ func externalConsumerBoundaryReport(
             }
         }
     }
+    return try analyzeExternalConsumerPackage(description, imports: imports, contract: contract)
+}
+
+func analyzeExternalConsumerPackage(
+    _ description: JSONObject,
+    imports: Set<String>,
+    contract: CoreGuardContract
+) throws -> JSONObject {
+    let packageDependencies = try description.array("dependencies").compactMap { $0 as? JSONObject }
+    var packageDescriptors: [JSONObject] = []
+    for dependency in packageDependencies {
+        for kind in dependency.keys.sorted() {
+            guard let items = dependency[kind] as? [Any] else {
+                continue
+            }
+
+            for value in items {
+                guard let item = value as? JSONObject else {
+                    continue
+                }
+
+                packageDescriptors.append([
+                    "kind": kind,
+                    "identity": item["identity"] as? String ?? "unknown"
+                ])
+            }
+        }
+    }
+    let allowedPackageDependencies = packageDescriptors.filter {
+        $0["kind"] as? String == "fileSystem" && $0["identity"] as? String == "swama"
+    }
+    let unexpectedPackageDependencies = packageDescriptors.filter {
+        !($0["kind"] as? String == "fileSystem" && $0["identity"] as? String == "swama")
+    }
+
+    let targets = try description.array("targets").compactMap { $0 as? JSONObject }
+    var targetDependencies: [JSONObject] = []
+    for target in targets {
+        let targetName = target["name"] as? String ?? "unknown"
+        for value in (target["dependencies"] as? [Any]) ?? [] {
+            guard let dependency = value as? JSONObject else {
+                continue
+            }
+
+            for kind in dependency.keys.sorted() {
+                guard let parts = dependency[kind] as? [Any] else {
+                    continue
+                }
+
+                targetDependencies.append([
+                    "target": targetName,
+                    "kind": kind,
+                    "name": parts.first as? String ?? "unknown",
+                    "package": parts.count > 1 ? parts[1] as? String ?? "" : ""
+                ])
+            }
+        }
+    }
+    let allowedTargetDependencies = targetDependencies.filter {
+        $0["kind"] as? String == "product"
+            && $0["name"] as? String == contract.fixtureProduct
+            && $0["package"] as? String == "swama"
+    }
+    let unexpectedTargetDependencies = targetDependencies.filter {
+        !($0["kind"] as? String == "product"
+            && $0["name"] as? String == contract.fixtureProduct
+            && $0["package"] as? String == "swama"
+        )
+    }
+    let products = targetDependencies.compactMap { item -> String? in
+        item["kind"] as? String == "product" ? item["name"] as? String : nil
+    }
+    let unexpectedProducts = Array(Set(products).subtracting([contract.fixtureProduct])).sorted()
+    let missingProducts = allowedTargetDependencies.isEmpty ? [contract.fixtureProduct] : []
+    let allowedImports = Set(contract.fixtureAllowedImports)
     let unexpectedImports = Array(imports.subtracting(allowedImports)).sorted()
-    let missingImports = allowedImports.contains(contract.fixtureProduct) && !imports.contains(contract.fixtureProduct)
-        ? [contract.fixtureProduct]
-        : []
-    let passed = remotePackages.isEmpty
-        && unexpectedProducts.isEmpty
-        && missingProducts.isEmpty
+    let missingImports = !imports.contains(contract.fixtureProduct) ? [contract.fixtureProduct] : []
+    let passed = targets.count == 1
+        && packageDescriptors.count == 1
+        && allowedPackageDependencies.count == 1
+        && unexpectedPackageDependencies.isEmpty
+        && targetDependencies.count == 1
+        && allowedTargetDependencies.count == 1
+        && unexpectedTargetDependencies.isEmpty
         && unexpectedImports.isEmpty
         && missingImports.isEmpty
 
     return [
         "status": passed ? "ready" : "unmet",
-        "expected_products": expectedProducts,
+        "target_count": targets.count,
+        "package_dependencies": packageDescriptors,
+        "unexpected_package_dependencies": unexpectedPackageDependencies,
+        "target_dependencies": targetDependencies,
+        "unexpected_target_dependencies": unexpectedTargetDependencies,
+        "expected_products": [contract.fixtureProduct],
         "actual_products": products.sorted(),
         "unexpected_products": unexpectedProducts,
         "missing_products": missingProducts,
-        "remote_packages": remotePackages.sorted(),
         "actual_imports": imports.sorted(),
         "unexpected_imports": unexpectedImports,
         "missing_imports": missingImports,
@@ -344,98 +445,420 @@ func coreTargetDependencyReport(
     developerDirectory: URL,
     contract: CoreGuardContract
 ) throws -> JSONObject {
-    let result = try runCommand(
+    let environment = try developerEnvironment(developerDirectory)
+    let graphResult = try runCommand(
         [
             "xcrun",
             "swift",
             "package",
             "--package-path",
             paths.package.path,
-            "describe",
-            "--type",
+            "--force-resolved-versions",
+            "show-dependencies",
+            "--format",
             "json"
         ],
         currentDirectory: paths.repository,
-        environment: developerEnvironment(developerDirectory),
+        environment: environment,
         timeout: 60,
         sampleMemory: false,
         timeoutFailureKind: .unknown,
-        timeoutContext: "SwamaCore dependency graph"
+        timeoutContext: "SwamaCore resolved package graph"
     )
-    guard result.returnCode == 0,
-          let data = result.stdout.data(using: .utf8),
-          let description = try JSONSerialization.jsonObject(with: data) as? JSONObject
+    guard graphResult.returnCode == 0,
+          let data = graphResult.stdout.data(using: .utf8),
+          let resolvedGraph = try JSONSerialization.jsonObject(with: data) as? JSONObject
     else {
         throw AcceptanceFailure.unknown(
-            "cannot inspect SwamaCore dependency graph:\n\(commandFailureSummary(result))"
+            "cannot inspect SwamaCore resolved package graph:\n\(commandFailureSummary(graphResult))"
         )
     }
 
-    return try analyzeTargetDependencyGraph(
-        description,
+    let descriptors = try resolvedPackageDescriptors(resolvedGraph)
+    var manifests: [String: JSONObject] = [:]
+    for descriptor in descriptors.sorted(by: { $0.key < $1.key }) {
+        let manifestResult = try runCommand(
+            [
+                "xcrun",
+                "swift",
+                "package",
+                "--package-path",
+                descriptor.value.path,
+                "dump-package"
+            ],
+            currentDirectory: URL(fileURLWithPath: descriptor.value.path),
+            environment: environment,
+            timeout: 60,
+            sampleMemory: false,
+            timeoutFailureKind: .unknown,
+            timeoutContext: "resolved package manifest \(descriptor.key)"
+        )
+        guard manifestResult.returnCode == 0,
+              let manifestData = manifestResult.stdout.data(using: .utf8),
+              let manifest = try JSONSerialization.jsonObject(with: manifestData) as? JSONObject
+        else {
+            throw AcceptanceFailure.unknown(
+                "cannot inspect resolved package manifest \(descriptor.key):\n"
+                    + commandFailureSummary(manifestResult)
+            )
+        }
+
+        manifests[descriptor.key] = manifest
+    }
+
+    return try analyzeResolvedTargetDependencyGraph(
+        rootIdentity: resolvedGraph.string("identity"),
+        manifests: manifests,
+        packageAliases: descriptors.mapValues(\.directPackageAliases),
+        activeTraits: descriptors.mapValues(\.activeTraits),
         target: target,
         forbiddenProducts: Set(contract.forbiddenTransitiveProducts)
     )
 }
 
-func analyzeTargetDependencyGraph(
-    _ description: JSONObject,
+func analyzeResolvedTargetDependencyGraph(
+    rootIdentity: String,
+    manifests: [String: JSONObject],
+    packageAliases: [String: [String: String]]? = nil,
+    activeTraits: [String: Set<String>]? = nil,
     target: String,
     forbiddenProducts: Set<String>
 ) throws -> JSONObject {
-    let targetObjects = try description.array("targets").compactMap { $0 as? JSONObject }
-    let targetsByName = Dictionary(uniqueKeysWithValues: targetObjects.compactMap { item -> (String, JSONObject)? in
-        guard let name = item["name"] as? String else {
-            return nil
-        }
-
-        return (name, item)
-    })
-    guard targetsByName[target] != nil else {
-        return [
-            "status": "unmet",
-            "target": target,
-            "target_dependencies": [],
-            "product_dependencies": [],
-            "forbidden_products": [],
-            "passed": false
-        ]
+    guard manifests[rootIdentity] != nil else {
+        throw AcceptanceFailure.unknown("resolved package graph is missing root manifest: \(rootIdentity)")
     }
 
-    var queue = [target]
-    var visited: Set<String> = []
-    var products: Set<String> = []
-    while let name = queue.popLast() {
-        guard visited.insert(name).inserted, let item = targetsByName[name] else {
+    var productsByPackage: [String: [String: PackageProduct]] = [:]
+    var targetsByPackage: [String: [String: JSONObject]] = [:]
+    var aliasesByPackage = packageAliases ?? [:]
+    for (identity, manifest) in manifests {
+        productsByPackage[identity] = try packageProducts(manifest)
+        targetsByPackage[identity] = try packageTargets(manifest)
+        if aliasesByPackage[identity] == nil {
+            let identities = try packageDependencyIdentities(manifest)
+            aliasesByPackage[identity] = Dictionary(uniqueKeysWithValues: identities.map { ($0, $0) })
+        }
+    }
+
+    let rootProducts = productsByPackage[rootIdentity] ?? [:]
+    let rootTargets = targetsByPackage[rootIdentity] ?? [:]
+    let libraryProductTargets = rootProducts[target]?.targets ?? []
+    let libraryProductPresent = rootProducts[target]?.isLibrary == true
+        && libraryProductTargets == [target]
+        && rootTargets[target] != nil
+
+    var queue = [ResolvedTarget(package: rootIdentity, name: target)]
+    var visitedTargets: Set<ResolvedTarget> = []
+    var visitedProducts: Set<ResolvedProduct> = []
+    var unresolved: Set<String> = []
+    while let node = queue.popLast() {
+        guard visitedTargets.insert(node).inserted else {
+            continue
+        }
+        guard manifests[node.package] != nil else {
+            unresolved.insert("missing package manifest \(node.package)")
             continue
         }
 
-        let targetDependencies = (item["target_dependencies"] as? [String]) ?? []
-        let productDependencies = (item["product_dependencies"] as? [String]) ?? []
-        queue.append(contentsOf: targetDependencies)
-        products.formUnion(productDependencies)
+        let targets = targetsByPackage[node.package] ?? [:]
+        guard let targetDescription = targets[node.name] else {
+            unresolved.insert("missing target \(node.package):\(node.name)")
+            continue
+        }
+
+        let aliases = aliasesByPackage[node.package] ?? [:]
+        let traits = activeTraits?[node.package] ?? ["default"]
+
+        for dependency in try targetDependencyDescriptors(targetDescription) {
+            guard dependency.isActive(platform: "macos", traits: traits) else {
+                continue
+            }
+
+            switch dependency.kind {
+            case "target":
+                queue.append(ResolvedTarget(package: node.package, name: dependency.name))
+
+            case "product":
+                resolveProductDependency(
+                    name: dependency.name,
+                    requestedPackage: dependency.package,
+                    sourcePackage: node.package,
+                    packageAliases: aliases,
+                    productsByPackage: productsByPackage,
+                    queue: &queue,
+                    visitedProducts: &visitedProducts,
+                    unresolved: &unresolved
+                )
+
+            case "byName":
+                if targets[dependency.name] != nil {
+                    queue.append(ResolvedTarget(package: node.package, name: dependency.name))
+                }
+                else {
+                    resolveProductDependency(
+                        name: dependency.name,
+                        requestedPackage: nil,
+                        sourcePackage: node.package,
+                        packageAliases: aliases,
+                        productsByPackage: productsByPackage,
+                        queue: &queue,
+                        visitedProducts: &visitedProducts,
+                        unresolved: &unresolved
+                    )
+                }
+
+            default:
+                unresolved.insert(
+                    "unsupported dependency \(node.package):\(node.name) \(dependency.kind):\(dependency.name)"
+                )
+            }
+        }
     }
-    let forbidden = products.intersection(forbiddenProducts).sorted()
+
+    let forbidden = Set(visitedProducts.map(\.name)).intersection(forbiddenProducts).sorted()
+    let passed = libraryProductPresent && unresolved.isEmpty && forbidden.isEmpty
+    var manifestHashes: JSONObject = [:]
+    var resolvedTraits: JSONObject = [:]
+    for identity in Set(visitedTargets.map(\.package)).sorted() {
+        if let manifest = manifests[identity] {
+            manifestHashes[identity] = try sha256(compactJSONData(manifest))
+        }
+        resolvedTraits[identity] = (activeTraits?[identity] ?? ["default"]).sorted()
+    }
     return [
-        "status": forbidden.isEmpty ? "ready" : "violated",
+        "status": passed ? "ready" : (libraryProductPresent && unresolved.isEmpty ? "violated" : "unmet"),
         "target": target,
-        "target_dependencies": visited.sorted(),
-        "product_dependencies": products.sorted(),
+        "root_package": rootIdentity,
+        "library_product_present": libraryProductPresent,
+        "library_product_targets": libraryProductTargets,
+        "target_dependencies": visitedTargets.map(\.description).sorted(),
+        "product_dependencies": visitedProducts.map(\.description).sorted(),
         "forbidden_products": forbidden,
-        "passed": forbidden.isEmpty
+        "unresolved_dependencies": unresolved.sorted(),
+        "manifest_sha256": manifestHashes,
+        "resolved_package_traits": resolvedTraits,
+        "passed": passed
     ]
 }
 
-private func captures(_ pattern: String, in text: String) throws -> [String] {
-    let expression = try NSRegularExpression(pattern: pattern)
-    let range = NSRange(text.startIndex ..< text.endIndex, in: text)
-    return expression.matches(in: text, range: range).compactMap { match in
-        guard let capture = Range(match.range(at: 1), in: text) else {
-            return nil
+// MARK: - ResolvedPackageDescriptor
+
+private struct ResolvedPackageDescriptor {
+    let path: String
+    let directPackageAliases: [String: String]
+    let activeTraits: Set<String>
+}
+
+// MARK: - ResolvedTarget
+
+private struct ResolvedTarget: Hashable {
+    let package: String
+    let name: String
+
+    var description: String { "\(package):\(name)" }
+}
+
+// MARK: - ResolvedProduct
+
+private struct ResolvedProduct: Hashable {
+    let package: String
+    let name: String
+
+    var description: String { "\(package):\(name)" }
+}
+
+// MARK: - PackageProduct
+
+private struct PackageProduct {
+    let targets: [String]
+    let isLibrary: Bool
+}
+
+// MARK: - TargetDependencyDescriptor
+
+private struct TargetDependencyDescriptor {
+    let kind: String
+    let name: String
+    let package: String?
+    let condition: JSONObject?
+
+    func isActive(platform: String, traits: Set<String>) -> Bool {
+        guard let condition else {
+            return true
         }
 
-        return String(text[capture])
+        let platforms = Set((condition["platformNames"] as? [String]) ?? [])
+        let requiredTraits = Set((condition["traits"] as? [String]) ?? [])
+        return (platforms.isEmpty || platforms.contains(platform))
+            && requiredTraits.isSubset(of: traits)
     }
+}
+
+private func resolvedPackageDescriptors(_ root: JSONObject) throws -> [String: ResolvedPackageDescriptor] {
+    var result: [String: ResolvedPackageDescriptor] = [:]
+    var queue = [root]
+    while let node = queue.popLast() {
+        let identity = try node.string("identity")
+        let path = try node.string("path")
+        let dependencies = try node.array("dependencies").compactMap { $0 as? JSONObject }
+        var aliases: [String: String] = [:]
+        for dependency in dependencies {
+            let dependencyIdentity = try dependency.string("identity")
+            let dependencyName = try dependency.string("name")
+            for alias in [dependencyIdentity, dependencyName] {
+                if let existing = aliases[alias], existing != dependencyIdentity {
+                    throw AcceptanceFailure.unknown(
+                        "resolved package alias is ambiguous: \(identity):\(alias)"
+                    )
+                }
+                aliases[alias] = dependencyIdentity
+            }
+        }
+        let descriptor = ResolvedPackageDescriptor(
+            path: path,
+            directPackageAliases: aliases,
+            activeTraits: Set((node["traits"] as? [String]) ?? [])
+        )
+        if let existing = result[identity],
+           existing.path != descriptor.path
+           || existing.directPackageAliases != descriptor.directPackageAliases
+           || existing.activeTraits != descriptor.activeTraits
+        {
+            throw AcceptanceFailure.unknown(
+                "resolved package identity has inconsistent descriptors: \(identity)"
+            )
+        }
+        result[identity] = descriptor
+        queue.append(contentsOf: dependencies)
+    }
+    return result
+}
+
+private func packageProducts(_ manifest: JSONObject) throws -> [String: PackageProduct] {
+    var result: [String: PackageProduct] = [:]
+    for value in try manifest.array("products") {
+        guard let product = value as? JSONObject else {
+            throw AcceptanceFailure.unknown("resolved package product is not an object")
+        }
+
+        let name = try product.string("name")
+        guard result[name] == nil else {
+            throw AcceptanceFailure.unknown("resolved package has duplicate product: \(name)")
+        }
+
+        result[name] = try PackageProduct(
+            targets: product.array("targets").compactMap { $0 as? String },
+            isLibrary: (try? product.object("type").array("library")) != nil
+        )
+    }
+    return result
+}
+
+private func packageTargets(_ manifest: JSONObject) throws -> [String: JSONObject] {
+    var result: [String: JSONObject] = [:]
+    for value in try manifest.array("targets") {
+        guard let target = value as? JSONObject else {
+            throw AcceptanceFailure.unknown("resolved package target is not an object")
+        }
+
+        let name = try target.string("name")
+        guard result[name] == nil else {
+            throw AcceptanceFailure.unknown("resolved package has duplicate target: \(name)")
+        }
+
+        result[name] = target
+    }
+    return result
+}
+
+private func packageDependencyIdentities(_ manifest: JSONObject) throws -> Set<String> {
+    var result: Set<String> = []
+    for value in try manifest.array("dependencies") {
+        guard let dependency = value as? JSONObject else {
+            throw AcceptanceFailure.unknown("resolved package dependency is not an object")
+        }
+
+        for descriptors in dependency.values {
+            guard let descriptors = descriptors as? [Any] else {
+                throw AcceptanceFailure.unknown("resolved package dependency payload is not an array")
+            }
+
+            for value in descriptors {
+                guard let descriptor = value as? JSONObject else {
+                    throw AcceptanceFailure.unknown("resolved package dependency descriptor is not an object")
+                }
+
+                try result.insert(descriptor.string("identity"))
+            }
+        }
+    }
+    return result
+}
+
+private func targetDependencyDescriptors(_ target: JSONObject) throws -> [TargetDependencyDescriptor] {
+    var result: [TargetDependencyDescriptor] = []
+    for value in try target.array("dependencies") {
+        guard let dependency = value as? JSONObject, dependency.count == 1,
+              let kind = dependency.keys.first,
+              let parts = dependency[kind] as? [Any],
+              let name = parts.first as? String
+        else {
+            throw AcceptanceFailure.unknown("resolved target dependency has an unsupported shape")
+        }
+
+        result.append(TargetDependencyDescriptor(
+            kind: kind,
+            name: name,
+            package: kind == "product" && parts.count > 1 ? parts[1] as? String : nil,
+            condition: dependencyCondition(kind: kind, parts: parts)
+        ))
+    }
+    return result
+}
+
+private func dependencyCondition(kind: String, parts: [Any]) -> JSONObject? {
+    let index = kind == "product" ? 3 : 1
+    guard parts.indices.contains(index) else {
+        return nil
+    }
+
+    return parts[index] as? JSONObject
+}
+
+private func resolveProductDependency(
+    name: String,
+    requestedPackage: String?,
+    sourcePackage: String,
+    packageAliases: [String: String],
+    productsByPackage: [String: [String: PackageProduct]],
+    queue: inout [ResolvedTarget],
+    visitedProducts: inout Set<ResolvedProduct>,
+    unresolved: inout Set<String>
+) {
+    let candidates: [String] =
+        if let requestedPackage, !requestedPackage.isEmpty {
+            packageAliases[requestedPackage].map { [$0] } ?? []
+        }
+        else {
+            Set(packageAliases.values)
+                .filter { identity in
+                    productsByPackage[identity]?[name] != nil
+                }
+                .sorted()
+        }
+    guard candidates.count == 1,
+          let package = candidates.first,
+          let product = productsByPackage[package]?[name],
+          !product.targets.isEmpty
+    else {
+        if requestedPackage == nil || packageAliases[requestedPackage ?? ""] != nil {
+            unresolved.insert("unresolved product \(sourcePackage):\(name)")
+        }
+        return
+    }
+
+    visitedProducts.insert(ResolvedProduct(package: package, name: name))
+    queue.append(contentsOf: product.targets.map { ResolvedTarget(package: package, name: $0) })
 }
 
 // MARK: - Canonical three-route parity records
@@ -498,9 +921,8 @@ func validateParityRecord(_ record: JSONObject, contract: ParityContract) throws
             guard try !event.string("name").isEmpty else {
                 throw AcceptanceFailure.unknown("tool_call event name is empty")
             }
-            guard event["arguments"] != nil else {
-                throw AcceptanceFailure.unknown("tool_call event arguments are missing")
-            }
+
+            _ = try event.object("arguments")
 
         default:
             throw AcceptanceFailure.unknown("parity event type is not implemented: \(type)")
@@ -550,9 +972,11 @@ private func validateResponseTerminal(_ terminal: JSONObject, contract: ParityCo
         }
 
         try requireExactKeys(call, expected: ["name", "arguments"], context: "terminal tool call")
-        guard try !call.string("name").isEmpty, call["arguments"] != nil else {
+        guard try !call.string("name").isEmpty else {
             throw AcceptanceFailure.unknown("parity terminal tool call is incomplete")
         }
+
+        _ = try call.object("arguments")
     }
     let usage = try terminal.object("usage")
     try requireExactKeys(

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/CoreContractGuards.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/CoreContractGuards.swift
@@ -58,7 +58,8 @@ func compilerPublicAPIReport(
     var report = try analyzePublicAPISymbolGraphs(
         graphs,
         target: target,
-        allowedModules: Set(contract.allowedPublicModules)
+        allowedModules: Set(contract.allowedPublicModules),
+        developerDirectory: developerDirectory
     )
     let reachabilityHits = try publicReachabilityAttributeHits(
         in: paths.package.appendingPathComponent("Sources/\(target)"),
@@ -93,8 +94,10 @@ func symbolGraphCommand(package: URL, scratch: URL) -> [String] {
 func analyzePublicAPISymbolGraphs(
     _ graphs: [JSONObject],
     target: String,
-    allowedModules: Set<String>
+    allowedModules: Set<String>,
+    developerDirectory: URL = URL(fileURLWithPath: "/Applications/Xcode.app/Contents/Developer")
 ) throws -> JSONObject {
+    let moduleResolver = try PreciseIdentifierModuleResolver(developerDirectory: developerDirectory)
     let knownAccessLevels: Set<String> = ["fileprivate", "internal", "open", "package", "private", "public"]
     let knownRelationshipKinds: Set<String> = [
         "conformsTo",
@@ -184,14 +187,14 @@ func analyzePublicAPISymbolGraphs(
                     }
 
                     let precise = try fragment.string("preciseIdentifier")
-                    guard moduleName(in: precise) != nil else {
+                    guard let module = try moduleResolver.moduleName(in: precise) else {
                         throw AcceptanceFailure.unknown(
                             "public declaration has an unparseable preciseIdentifier: \(precise)"
                         )
                     }
 
                     value["precise_identifier"] = precise
-                    value["module"] = moduleName(in: precise) ?? "unknown"
+                    value["module"] = module
                 }
                 return value
             }
@@ -205,7 +208,7 @@ func analyzePublicAPISymbolGraphs(
                 }
 
                 let precise = try fragment.string("preciseIdentifier")
-                guard let module = moduleName(in: precise) else {
+                guard let module = try moduleResolver.moduleName(in: precise) else {
                     throw AcceptanceFailure.unknown(
                         "public typeIdentifier has an unparseable module: \(precise)"
                     )
@@ -229,7 +232,7 @@ func analyzePublicAPISymbolGraphs(
                 let fallback = try relationship["targetFallback"] == nil
                     ? nil
                     : relationship.string("targetFallback")
-                guard let module = moduleName(in: targetIdentifier) else {
+                guard let module = try moduleResolver.moduleName(in: targetIdentifier) else {
                     throw AcceptanceFailure.unknown(
                         "public relationship has an unparseable target: \(targetIdentifier)"
                     )
@@ -366,82 +369,108 @@ private func optionalStrictStringArray(_ object: JSONObject, key: String, contex
     return try strictStringArray(object, key: key, context: context)
 }
 
-private func moduleName(in preciseIdentifier: String) -> String? {
-    let knownClangModules = ["c:@T@NSTimeInterval": "Foundation"]
-    if let module = knownClangModules[preciseIdentifier] {
-        return module
-    }
-    guard preciseIdentifier.hasPrefix("s:") else {
-        return preciseIdentifier.contains(":") ? "__foreign__" : nil
+// MARK: - PreciseIdentifierModuleResolver
+
+private final class PreciseIdentifierModuleResolver {
+    private enum Resolution {
+        case module(String)
+        case invalid
     }
 
-    let payload = preciseIdentifier.dropFirst(2)
-    guard !payload.isEmpty else {
-        return nil
+    private let demangler: URL
+    private var cache: [String: Resolution] = [:]
+
+    init(developerDirectory: URL) throws {
+        demangler = developerDirectory.appendingPathComponent(
+            "Toolchains/XcodeDefault.xctoolchain/usr/bin/swift-demangle"
+        )
+        guard FileManager.default.isExecutableFile(atPath: demangler.path) else {
+            throw AcceptanceFailure.unknown("missing Swift demangler: \(demangler.path)")
+        }
     }
 
-    var digits = ""
-    for character in payload {
-        guard character.isNumber else {
-            break
+    func moduleName(in preciseIdentifier: String) throws -> String? {
+        if let cached = cache[preciseIdentifier] {
+            switch cached {
+            case let .module(module):
+                return module
+            case .invalid:
+                return nil
+            }
         }
 
-        digits.append(character)
-    }
-    guard !digits.isEmpty else {
-        return isValidStandardLibraryUSRPayload(String(payload)) ? "Swift" : nil
-    }
-    guard let length = Int(digits), length > 0 else {
-        return nil
+        let module = try resolve(preciseIdentifier)
+        cache[preciseIdentifier] = module.map(Resolution.module) ?? .invalid
+        return module
     }
 
-    let moduleStart = payload.index(payload.startIndex, offsetBy: digits.count)
-    guard let moduleEnd = payload.index(moduleStart, offsetBy: length, limitedBy: payload.endIndex) else {
-        return nil
-    }
+    private func resolve(_ preciseIdentifier: String) throws -> String? {
+        let knownClangModules = ["c:@T@NSTimeInterval": "Foundation"]
+        if let module = knownClangModules[preciseIdentifier] {
+            return module
+        }
+        guard preciseIdentifier.hasPrefix("s:") else {
+            return preciseIdentifier.contains(":") ? "__foreign__" : nil
+        }
 
-    return String(payload[moduleStart ..< moduleEnd])
+        let payload = preciseIdentifier.dropFirst(2)
+        guard !payload.isEmpty else {
+            return nil
+        }
+
+        let digits = payload.prefix(while: \.isNumber)
+        if !digits.isEmpty {
+            guard let length = Int(digits), length > 0 else {
+                return nil
+            }
+
+            let moduleStart = payload.index(payload.startIndex, offsetBy: digits.count)
+            guard let moduleEnd = payload.index(
+                moduleStart,
+                offsetBy: length,
+                limitedBy: payload.endIndex
+            ),
+                moduleEnd < payload.endIndex
+            else {
+                return nil
+            }
+
+            return String(payload[moduleStart ..< moduleEnd])
+        }
+
+        let mangled = "$s\(payload)"
+        let result = try runCommand(
+            [demangler.path, "--compact", mangled],
+            currentDirectory: FileManager.default.temporaryDirectory,
+            timeout: 10,
+            sampleMemory: false,
+            timeoutFailureKind: .unknown,
+            timeoutContext: "Swift USR demangler"
+        )
+        guard result.returnCode == 0 else {
+            throw AcceptanceFailure.unknown(
+                "cannot demangle Swift preciseIdentifier \(preciseIdentifier):\n"
+                    + commandFailureSummary(result)
+            )
+        }
+
+        return try parseDemangledSwiftModule(result.stdout, mangled: mangled)
+    }
 }
 
-private func isValidStandardLibraryUSRPayload(_ payload: String) -> Bool {
-    let substitutions: Set<String> = [
-        "SD", "SE", "SH", "SP", "SQ", "SR", "SS", "SV", "SY", "Sa", "Sb", "Sc", "ScA", "ScM", "Sd", "Se",
-        "Sf", "Sh", "Si", "Sn", "Sp", "Sq", "Sr", "Su", "Sv"
-    ]
-    if substitutions.contains(payload) {
-        return true
+func parseDemangledSwiftModule(_ output: String, mangled: String) throws -> String? {
+    let lines = output.split(whereSeparator: \.isNewline).map(String.init)
+    guard lines.count == 1, let demangled = lines.first, demangled != mangled else {
+        return nil
     }
 
-    let characters = Array(payload)
-    guard characters.first == "s" else {
-        return false
+    let expression = try NSRegularExpression(pattern: #"^Swift\.[A-Za-z_][A-Za-z0-9_]*$"#)
+    let range = NSRange(demangled.startIndex ..< demangled.endIndex, in: demangled)
+    guard expression.firstMatch(in: demangled, range: range)?.range == range else {
+        return nil
     }
 
-    var index = 1
-    var digits = ""
-    while characters.indices.contains(index), characters[index].isNumber {
-        digits.append(characters[index])
-        index += 1
-    }
-    guard let nameLength = Int(digits), nameLength > 0,
-          characters.indices.contains(index + nameLength - 1)
-    else {
-        return false
-    }
-
-    let name = characters[index ..< index + nameLength]
-    guard name.allSatisfy({ $0.isLetter || $0.isNumber || $0 == "_" }) else {
-        return false
-    }
-
-    index += nameLength
-    guard index == characters.count - 1,
-          let nominalKind = characters.last
-    else {
-        return false
-    }
-
-    return ["A", "C", "E", "O", "P", "V", "a"].contains(nominalKind)
+    return "Swift"
 }
 
 // MARK: - External consumer and target dependency boundary
@@ -477,13 +506,14 @@ func externalConsumerBoundaryReport(
         )
     }
 
-    let expression = try NSRegularExpression(pattern: swiftImportDeclarationPattern)
     var imports: Set<String> = []
     let sourceRoot = fixture.appendingPathComponent("Sources")
     if FileManager.default.fileExists(atPath: sourceRoot.path) {
         for file in try regularFiles(in: sourceRoot, extensions: ["swift"]) {
-            let source = try String(contentsOf: file, encoding: .utf8)
-            for declaration in swiftImportedModules(in: source, matching: expression) {
+            for declaration in try compilerImportedModules(
+                in: file,
+                developerDirectory: developerDirectory
+            ) {
                 imports.insert(declaration.module)
             }
         }

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/CoreContractGuards.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/CoreContractGuards.swift
@@ -95,6 +95,18 @@ func analyzePublicAPISymbolGraphs(
     target: String,
     allowedModules: Set<String>
 ) throws -> JSONObject {
+    let knownAccessLevels: Set<String> = ["fileprivate", "internal", "open", "package", "private", "public"]
+    let knownRelationshipKinds: Set<String> = [
+        "conformsTo",
+        "defaultImplementationOf",
+        "extensionTo",
+        "inheritsFrom",
+        "memberOf",
+        "optionalRequirementOf",
+        "overloadOf",
+        "overrides",
+        "requirementOf"
+    ]
     var canonicalSymbols: [JSONObject] = []
     var violations: [JSONObject] = []
 
@@ -108,7 +120,13 @@ func analyzePublicAPISymbolGraphs(
         var relationshipsBySource: [String: [JSONObject]] = [:]
         for relationship in relationships {
             let source = try relationship.string("source")
-            _ = try relationship.string("kind")
+            let relationshipKind = try relationship.string("kind")
+            guard knownRelationshipKinds.contains(relationshipKind) else {
+                throw AcceptanceFailure.unknown(
+                    "public symbol relationship kind is unknown: \(relationshipKind)"
+                )
+            }
+
             _ = try relationship.string("target")
             if relationship["targetFallback"] != nil {
                 _ = try relationship.string("targetFallback")
@@ -118,6 +136,9 @@ func analyzePublicAPISymbolGraphs(
 
         for symbol in symbols {
             let access = try symbol.string("accessLevel")
+            guard knownAccessLevels.contains(access) else {
+                throw AcceptanceFailure.unknown("public symbol accessLevel is unknown: \(access)")
+            }
             guard access == "public" || access == "open" else {
                 continue
             }
@@ -133,11 +154,35 @@ func analyzePublicAPISymbolGraphs(
             let declaration = fragments.compactMap { $0["spelling"] as? String }.joined()
             let canonicalFragments = try fragments.map { fragment -> JSONObject in
                 let fragmentKind = try fragment.string("kind")
+                let allowedFragmentKinds: Set<String> = [
+                    "attribute",
+                    "externalParam",
+                    "genericParameter",
+                    "identifier",
+                    "internalParam",
+                    "keyword",
+                    "number",
+                    "string",
+                    "text",
+                    "typeIdentifier"
+                ]
+                guard allowedFragmentKinds.contains(fragmentKind) else {
+                    throw AcceptanceFailure.unknown(
+                        "public declaration fragment kind is unknown: \(fragmentKind)"
+                    )
+                }
+
                 var value: JSONObject = try [
                     "kind": fragmentKind,
                     "spelling": fragment.string("spelling")
                 ]
                 if fragment["preciseIdentifier"] != nil {
+                    guard fragmentKind == "typeIdentifier" else {
+                        throw AcceptanceFailure.unknown(
+                            "non-type declaration fragment carries preciseIdentifier: \(fragmentKind)"
+                        )
+                    }
+
                     let precise = try fragment.string("preciseIdentifier")
                     guard moduleName(in: precise) != nil else {
                         throw AcceptanceFailure.unknown(
@@ -178,12 +223,6 @@ func analyzePublicAPISymbolGraphs(
             var conformances: [String] = []
             for relationship in relationshipsBySource[identifier] ?? [] {
                 let relationshipKind = try relationship.string("kind")
-                guard ["conformsTo", "extensionTo", "inheritsFrom", "memberOf", "requirementOf"]
-                    .contains(relationshipKind)
-                else {
-                    continue
-                }
-
                 let targetIdentifier = try relationship.string("target")
                 let fallback = try relationship["targetFallback"] == nil
                     ? nil
@@ -333,6 +372,10 @@ private func moduleName(in preciseIdentifier: String) -> String? {
     }
 
     let payload = preciseIdentifier.dropFirst(2)
+    guard !payload.isEmpty else {
+        return nil
+    }
+
     var digits = ""
     for character in payload {
         guard character.isNumber else {
@@ -341,8 +384,11 @@ private func moduleName(in preciseIdentifier: String) -> String? {
 
         digits.append(character)
     }
+    guard !digits.isEmpty else {
+        return isValidStandardLibraryUSRPayload(String(payload)) ? "Swift" : nil
+    }
     guard let length = Int(digits), length > 0 else {
-        return "Swift"
+        return nil
     }
 
     let moduleStart = payload.index(payload.startIndex, offsetBy: digits.count)
@@ -351,6 +397,46 @@ private func moduleName(in preciseIdentifier: String) -> String? {
     }
 
     return String(payload[moduleStart ..< moduleEnd])
+}
+
+private func isValidStandardLibraryUSRPayload(_ payload: String) -> Bool {
+    let substitutions: Set<String> = [
+        "SD", "SP", "SR", "SS", "SV", "Sa", "Sb", "Sc", "Sd", "Sf", "Si", "Sp", "Sq", "Sr", "Su", "Sv"
+    ]
+    if substitutions.contains(payload) {
+        return true
+    }
+
+    let characters = Array(payload)
+    guard characters.first == "s" else {
+        return false
+    }
+
+    var index = 1
+    var digits = ""
+    while characters.indices.contains(index), characters[index].isNumber {
+        digits.append(characters[index])
+        index += 1
+    }
+    guard let nameLength = Int(digits), nameLength > 0,
+          characters.indices.contains(index + nameLength - 1)
+    else {
+        return false
+    }
+
+    let name = characters[index ..< index + nameLength]
+    guard name.allSatisfy({ $0.isLetter || $0.isNumber || $0 == "_" }) else {
+        return false
+    }
+
+    index += nameLength
+    guard index == characters.count - 1,
+          let nominalKind = characters.last
+    else {
+        return false
+    }
+
+    return ["A", "C", "E", "O", "P", "V"].contains(nominalKind)
 }
 
 // MARK: - External consumer and target dependency boundary
@@ -881,13 +967,35 @@ private func packageProducts(_ manifest: JSONObject) throws -> [String: PackageP
         }
 
         let type = try product.object("type")
-        guard type.count == 1 else {
+        guard type.count == 1, let productKind = type.keys.first else {
             throw AcceptanceFailure.unknown("resolved package product type has an unsupported shape")
         }
 
-        let isLibrary = type["library"] != nil
-        if isLibrary {
-            _ = try strictStringArray(type, key: "library", context: "resolved library product")
+        let isLibrary: Bool
+        switch productKind {
+        case "library":
+            let payload = try strictStringArray(type, key: "library", context: "resolved library product")
+            guard payload.count == 1,
+                  let linkage = payload.first,
+                  ["automatic", "dynamic", "static"].contains(linkage)
+            else {
+                throw AcceptanceFailure.unknown("resolved library product linkage is invalid")
+            }
+
+            isLibrary = true
+
+        case "executable",
+             "plugin",
+             "snippet",
+             "test":
+            guard type[productKind] is NSNull else {
+                throw AcceptanceFailure.unknown("resolved non-library product payload is not null")
+            }
+
+            isLibrary = false
+
+        default:
+            throw AcceptanceFailure.unknown("resolved package product kind is unknown: \(productKind)")
         }
         result[name] = try PackageProduct(
             targets: strictStringArray(product, key: "targets", context: "resolved package product"),
@@ -967,8 +1075,8 @@ private func targetDependencyDescriptors(_ target: JSONObject) throws -> [Target
 
         let package: String?
         if kind == "product", !(parts[1] is NSNull) {
-            guard let value = parts[1] as? String else {
-                throw AcceptanceFailure.unknown("resolved product dependency package is not a string")
+            guard let value = parts[1] as? String, !value.isEmpty else {
+                throw AcceptanceFailure.unknown("resolved product dependency package is missing or empty")
             }
 
             package = value

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/CoreContractGuards.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/CoreContractGuards.swift
@@ -103,27 +103,41 @@ func analyzePublicAPISymbolGraphs(
             continue
         }
 
-        let symbols = try graph.array("symbols").compactMap { $0 as? JSONObject }
-        let relationships = (try? graph.array("relationships").compactMap { $0 as? JSONObject }) ?? []
-        let relationshipsBySource = Dictionary(grouping: relationships) { $0["source"] as? String ?? "" }
+        let symbols = try strictObjectArray(graph, key: "symbols", context: "symbol graph")
+        let relationships = try strictObjectArray(graph, key: "relationships", context: "symbol graph")
+        var relationshipsBySource: [String: [JSONObject]] = [:]
+        for relationship in relationships {
+            let source = try relationship.string("source")
+            _ = try relationship.string("kind")
+            _ = try relationship.string("target")
+            if relationship["targetFallback"] != nil {
+                _ = try relationship.string("targetFallback")
+            }
+            relationshipsBySource[source, default: []].append(relationship)
+        }
 
         for symbol in symbols {
-            let access = (symbol["accessLevel"] as? String) ?? "public"
+            let access = try symbol.string("accessLevel")
             guard access == "public" || access == "open" else {
                 continue
             }
 
             let identifier = try symbol.object("identifier").string("precise")
             let kind = try symbol.object("kind").string("identifier")
-            let path = try symbol.array("pathComponents").compactMap { $0 as? String }
-            let fragments = try symbol.array("declarationFragments").compactMap { $0 as? JSONObject }
+            let path = try strictStringArray(symbol, key: "pathComponents", context: "public symbol")
+            let fragments = try strictObjectArray(
+                symbol,
+                key: "declarationFragments",
+                context: "public symbol"
+            )
             let declaration = fragments.compactMap { $0["spelling"] as? String }.joined()
-            let canonicalFragments = fragments.map { fragment -> JSONObject in
-                var value: JSONObject = [
-                    "kind": fragment["kind"] as? String ?? "unknown",
-                    "spelling": fragment["spelling"] as? String ?? ""
+            let canonicalFragments = try fragments.map { fragment -> JSONObject in
+                var value: JSONObject = try [
+                    "kind": fragment.string("kind"),
+                    "spelling": fragment.string("spelling")
                 ]
-                if let precise = fragment["preciseIdentifier"] as? String {
+                if fragment["preciseIdentifier"] != nil {
+                    let precise = try fragment.string("preciseIdentifier")
                     value["precise_identifier"] = precise
                     value["module"] = moduleName(in: precise) ?? "unknown"
                 }
@@ -151,15 +165,17 @@ func analyzePublicAPISymbolGraphs(
 
             var conformances: [String] = []
             for relationship in relationshipsBySource[identifier] ?? [] {
-                guard let relationshipKind = relationship["kind"] as? String,
-                      ["conformsTo", "extensionTo", "inheritsFrom", "memberOf", "requirementOf"]
-                      .contains(relationshipKind),
-                      let targetIdentifier = relationship["target"] as? String
+                let relationshipKind = try relationship.string("kind")
+                guard ["conformsTo", "extensionTo", "inheritsFrom", "memberOf", "requirementOf"]
+                    .contains(relationshipKind)
                 else {
                     continue
                 }
 
-                let fallback = relationship["targetFallback"] as? String
+                let targetIdentifier = try relationship.string("target")
+                let fallback = try relationship["targetFallback"] == nil
+                    ? nil
+                    : relationship.string("targetFallback")
                 let module = moduleName(in: targetIdentifier) ?? fallback?.split(separator: ".").first.map(String.init)
                 if let module {
                     references.insert(module)
@@ -262,6 +278,30 @@ private func publicAPIViolation(
     ]
 }
 
+private func strictObjectArray(_ object: JSONObject, key: String, context: String) throws -> [JSONObject] {
+    try object.array(key).enumerated().map { index, value in
+        guard let value = value as? JSONObject else {
+            throw AcceptanceFailure.unknown(
+                "\(context) \(key)[\(index)] is not an object"
+            )
+        }
+
+        return value
+    }
+}
+
+private func strictStringArray(_ object: JSONObject, key: String, context: String) throws -> [String] {
+    try object.array(key).enumerated().map { index, value in
+        guard let value = value as? String else {
+            throw AcceptanceFailure.unknown(
+                "\(context) \(key)[\(index)] is not a string"
+            )
+        }
+
+        return value
+    }
+}
+
 private func moduleName(in preciseIdentifier: String) -> String? {
     guard preciseIdentifier.hasPrefix("s:") else {
         return preciseIdentifier.contains(":") ? "__foreign__" : nil
@@ -292,6 +332,7 @@ private func moduleName(in preciseIdentifier: String) -> String? {
 
 func externalConsumerBoundaryReport(
     fixture: URL,
+    expectedPackage: URL,
     contract: CoreGuardContract,
     developerDirectory: URL = URL(fileURLWithPath: "/Applications/Xcode.app/Contents/Developer")
 ) throws -> JSONObject {
@@ -334,62 +375,106 @@ func externalConsumerBoundaryReport(
             }
         }
     }
-    return try analyzeExternalConsumerPackage(description, imports: imports, contract: contract)
+    return try analyzeExternalConsumerPackage(
+        description,
+        imports: imports,
+        expectedPackagePath: canonicalFilesystemPath(expectedPackage.path),
+        contract: contract
+    )
 }
 
 func analyzeExternalConsumerPackage(
     _ description: JSONObject,
     imports: Set<String>,
+    expectedPackagePath: String,
     contract: CoreGuardContract
 ) throws -> JSONObject {
-    let packageDependencies = try description.array("dependencies").compactMap { $0 as? JSONObject }
+    let packageDependencies = try strictObjectArray(
+        description,
+        key: "dependencies",
+        context: "external consumer package"
+    )
     var packageDescriptors: [JSONObject] = []
     for dependency in packageDependencies {
-        for kind in dependency.keys.sorted() {
-            guard let items = dependency[kind] as? [Any] else {
-                continue
-            }
+        guard dependency.count == 1, let kind = dependency.keys.first else {
+            throw AcceptanceFailure.unknown("external consumer package dependency has an unsupported shape")
+        }
 
-            for value in items {
-                guard let item = value as? JSONObject else {
-                    continue
+        let items = try strictObjectArray(
+            dependency,
+            key: kind,
+            context: "external consumer package dependency"
+        )
+        for item in items {
+            let identity = try item.string("identity")
+            let path: String =
+                if kind == "fileSystem" {
+                    try canonicalFilesystemPath(item.string("path"))
                 }
-
-                packageDescriptors.append([
-                    "kind": kind,
-                    "identity": item["identity"] as? String ?? "unknown"
-                ])
-            }
+                else {
+                    ""
+                }
+            packageDescriptors.append([
+                "kind": kind,
+                "identity": identity,
+                "path": path,
+                "path_sha256": sha256(Data(path.utf8))
+            ])
         }
     }
     let allowedPackageDependencies = packageDescriptors.filter {
-        $0["kind"] as? String == "fileSystem" && $0["identity"] as? String == "swama"
+        $0["kind"] as? String == "fileSystem"
+            && $0["identity"] as? String == "swama"
+            && $0["path"] as? String == expectedPackagePath
     }
     let unexpectedPackageDependencies = packageDescriptors.filter {
-        !($0["kind"] as? String == "fileSystem" && $0["identity"] as? String == "swama")
+        !($0["kind"] as? String == "fileSystem"
+            && $0["identity"] as? String == "swama"
+            && $0["path"] as? String == expectedPackagePath
+        )
     }
 
-    let targets = try description.array("targets").compactMap { $0 as? JSONObject }
+    let targets = try strictObjectArray(description, key: "targets", context: "external consumer package")
     var targetDependencies: [JSONObject] = []
     for target in targets {
-        let targetName = target["name"] as? String ?? "unknown"
-        for value in (target["dependencies"] as? [Any]) ?? [] {
-            guard let dependency = value as? JSONObject else {
-                continue
+        let targetName = try target.string("name")
+        for dependency in try strictObjectArray(
+            target,
+            key: "dependencies",
+            context: "external consumer target \(targetName)"
+        ) {
+            guard dependency.count == 1, let kind = dependency.keys.first else {
+                throw AcceptanceFailure.unknown(
+                    "external consumer target dependency has an unsupported shape"
+                )
             }
 
-            for kind in dependency.keys.sorted() {
-                guard let parts = dependency[kind] as? [Any] else {
-                    continue
+            let parts = try dependency.array(kind)
+            guard let name = parts.first as? String else {
+                throw AcceptanceFailure.unknown(
+                    "external consumer target dependency name is not a string"
+                )
+            }
+
+            let package: String
+            if parts.count > 1, !(parts[1] is NSNull) {
+                guard let value = parts[1] as? String else {
+                    throw AcceptanceFailure.unknown(
+                        "external consumer target dependency package is not a string"
+                    )
                 }
 
-                targetDependencies.append([
-                    "target": targetName,
-                    "kind": kind,
-                    "name": parts.first as? String ?? "unknown",
-                    "package": parts.count > 1 ? parts[1] as? String ?? "" : ""
-                ])
+                package = value
             }
+            else {
+                package = ""
+            }
+            targetDependencies.append([
+                "target": targetName,
+                "kind": kind,
+                "name": name,
+                "package": package
+            ])
         }
     }
     let allowedTargetDependencies = targetDependencies.filter {
@@ -424,6 +509,8 @@ func analyzeExternalConsumerPackage(
     return [
         "status": passed ? "ready" : "unmet",
         "target_count": targets.count,
+        "expected_package_path": expectedPackagePath,
+        "expected_package_path_sha256": sha256(Data(expectedPackagePath.utf8)),
         "package_dependencies": packageDescriptors,
         "unexpected_package_dependencies": unexpectedPackageDependencies,
         "target_dependencies": targetDependencies,
@@ -437,6 +524,13 @@ func analyzeExternalConsumerPackage(
         "missing_imports": missingImports,
         "passed": passed
     ]
+}
+
+private func canonicalFilesystemPath(_ path: String) -> String {
+    URL(fileURLWithPath: path)
+        .standardizedFileURL
+        .resolvingSymlinksInPath()
+        .path
 }
 
 func coreTargetDependencyReport(
@@ -534,10 +628,17 @@ func analyzeResolvedTargetDependencyGraph(
     for (identity, manifest) in manifests {
         productsByPackage[identity] = try packageProducts(manifest)
         targetsByPackage[identity] = try packageTargets(manifest)
-        if aliasesByPackage[identity] == nil {
-            let identities = try packageDependencyIdentities(manifest)
-            aliasesByPackage[identity] = Dictionary(uniqueKeysWithValues: identities.map { ($0, $0) })
+        let declaredAliases = try packageDependencyAliases(manifest)
+        var aliases = aliasesByPackage[identity] ?? [:]
+        for (alias, packageIdentity) in declaredAliases {
+            if let existing = aliases[alias], existing != packageIdentity {
+                throw AcceptanceFailure.unknown(
+                    "package dependency alias is ambiguous: \(identity):\(alias)"
+                )
+            }
+            aliases[alias] = packageIdentity
         }
+        aliasesByPackage[identity] = aliases
     }
 
     let rootProducts = productsByPackage[rootIdentity] ?? [:]
@@ -771,8 +872,8 @@ private func packageTargets(_ manifest: JSONObject) throws -> [String: JSONObjec
     return result
 }
 
-private func packageDependencyIdentities(_ manifest: JSONObject) throws -> Set<String> {
-    var result: Set<String> = []
+private func packageDependencyAliases(_ manifest: JSONObject) throws -> [String: String] {
+    var result: [String: String] = [:]
     for value in try manifest.array("dependencies") {
         guard let dependency = value as? JSONObject else {
             throw AcceptanceFailure.unknown("resolved package dependency is not an object")
@@ -788,7 +889,17 @@ private func packageDependencyIdentities(_ manifest: JSONObject) throws -> Set<S
                     throw AcceptanceFailure.unknown("resolved package dependency descriptor is not an object")
                 }
 
-                try result.insert(descriptor.string("identity"))
+                let identity = try descriptor.string("identity")
+                let aliases = [identity, descriptor["nameForTargetDependencyResolutionOnly"] as? String]
+                    .compactMap(\.self)
+                for alias in aliases {
+                    if let existing = result[alias], existing != identity {
+                        throw AcceptanceFailure.unknown(
+                            "package dependency alias maps to multiple identities: \(alias)"
+                        )
+                    }
+                    result[alias] = identity
+                }
             }
         }
     }
@@ -851,9 +962,7 @@ private func resolveProductDependency(
           let product = productsByPackage[package]?[name],
           !product.targets.isEmpty
     else {
-        if requestedPackage == nil || packageAliases[requestedPackage ?? ""] != nil {
-            unresolved.insert("unresolved product \(sourcePackage):\(name)")
-        }
+        unresolved.insert("unresolved product \(sourcePackage):\(name)")
         return
     }
 

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Provenance.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Provenance.swift
@@ -79,7 +79,10 @@ func currentInstrumentIdentity(paths: WorkspacePaths) throws -> JSONObject {
     let harnessSources = try regularFiles(
         in: paths.harness.appendingPathComponent("Sources"),
         extensions: ["swift"]
-    ) + [paths.harness.appendingPathComponent("Package.swift")]
+    ) + [
+        paths.harness.appendingPathComponent("Package.swift"),
+        paths.harness.appendingPathComponent("Package.resolved")
+    ]
     let harnessTests = try regularFiles(
         in: paths.harness.appendingPathComponent("Tests"),
         extensions: ["swift"]

--- a/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
+++ b/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
@@ -349,7 +349,7 @@ struct AcceptanceTests {
         let graph: JSONObject = [
             "module": ["name": "SwamaCore"],
             "symbols": [
-                "model": symbolGraphSymbol(
+                symbolGraphSymbol(
                     precise: "s:9SwamaCore6EngineC5model11MLXLMCommon14ModelContainerCvp",
                     path: ["Engine", "model"],
                     declaration: [
@@ -357,34 +357,47 @@ struct AcceptanceTests {
                         typeFragment("ModelContainer", precise: "s:11MLXLMCommon14ModelContainerC")
                     ]
                 ),
-                "cache": symbolGraphSymbol(
+                symbolGraphSymbol(
                     precise: "s:9SwamaCore6EngineC5cacheSay11MLXLMCommon7KVCache_pGvp",
                     path: ["Engine", "cache"],
                     declaration: [
                         typeFragment("KVCache", precise: "s:11MLXLMCommon7KVCacheP")
                     ]
                 ),
-                "safe": symbolGraphSymbol(
+                symbolGraphSymbol(
                     precise: "s:9SwamaCore7PayloadV4data10Foundation4DataVvp",
                     path: ["Payload", "data"],
                     declaration: [
                         typeFragment("Data", precise: "s:10Foundation4DataV")
                     ]
                 ),
-                "payload": symbolGraphSymbol(
+                symbolGraphSymbol(
                     precise: "s:9SwamaCore7PayloadV",
                     path: ["Payload"],
                     declaration: [
                         typeFragment("Payload", precise: "s:9SwamaCore7PayloadV")
                     ]
+                ),
+                symbolGraphSymbol(
+                    precise: "s:9SwamaCore18externalMemberTestyyF",
+                    path: ["External", "member"],
+                    declaration: [["kind": "identifier", "spelling": "member"]]
                 )
             ],
-            "relationships": [[
-                "kind": "conformsTo",
-                "source": "s:9SwamaCore7PayloadV",
-                "target": "s:12ForeignTypes14ForeignProtocolP",
-                "targetFallback": "ForeignTypes.ForeignProtocol"
-            ]]
+            "relationships": [
+                [
+                    "kind": "conformsTo",
+                    "source": "s:9SwamaCore7PayloadV",
+                    "target": "s:12ForeignTypes14ForeignProtocolP",
+                    "targetFallback": "ForeignTypes.ForeignProtocol"
+                ],
+                [
+                    "kind": "memberOf",
+                    "source": "s:9SwamaCore18externalMemberTestyyF",
+                    "target": "s:8Upstream8ExternalV",
+                    "targetFallback": "Upstream.External"
+                ]
+            ]
         ]
 
         let report = try analyzePublicAPISymbolGraphs(
@@ -395,13 +408,24 @@ struct AcceptanceTests {
         #expect(report["passed"] as? Bool == false)
         let violations = (report["violations"] as? [JSONObject]) ?? []
         let modules = Set(violations.compactMap { $0["module"] as? String })
-        #expect(modules == ["ForeignTypes", "MLXLMCommon"])
+        #expect(modules == ["ForeignTypes", "MLXLMCommon", "Upstream"])
         #expect(Set(violations.compactMap { ($0["path"] as? [String])?.joined(separator: ".") }) == [
             "Engine.cache",
             "Engine.model",
+            "External.member",
             "Payload"
         ])
         #expect((report["manifest_sha256"] as? String)?.count == 64)
+    }
+
+    @Test func compilerSymbolGraphIncludesExtensionBlocks() {
+        let command = symbolGraphCommand(
+            package: URL(fileURLWithPath: "/package"),
+            scratch: URL(fileURLWithPath: "/scratch")
+        )
+        #expect(command.contains("--emit-extension-block-symbols"))
+        #expect(command.contains("--skip-synthesized-members"))
+        #expect(command.contains("public"))
     }
 
     @Test func coreBoundaryReportsCompilerOracleAsUnmetWhenTargetIsAbsent() throws {
@@ -433,23 +457,82 @@ struct AcceptanceTests {
         #expect(try report.array("unexpected_imports").contains { ($0 as? String) == "MLXLMCommon" })
     }
 
-    @Test func targetDependencyGraphRejectsTransitiveAudioProducts() throws {
+    @Test func consumerBoundaryRejectsExtraPathPackagesAndByNameTargets() throws {
+        let paths = try WorkspacePaths.discover(explicit: repositoryRoot.path)
+        let contract = try AcceptanceContract.load(from: paths.contract).coreGuards
         let description: JSONObject = [
-            "targets": [
-                [
-                    "name": "SwamaCore",
-                    "target_dependencies": ["Implementation"],
-                    "product_dependencies": ["FoundationShim"]
-                ],
-                [
-                    "name": "Implementation",
-                    "target_dependencies": [],
-                    "product_dependencies": ["MLXAudioCore"]
+            "dependencies": [
+                ["fileSystem": [["identity": "swama"]]],
+                ["fileSystem": [["identity": "helper"]]]
+            ],
+            "targets": [[
+                "name": "SwamaAcceptanceProbe",
+                "dependencies": [
+                    ["product": ["SwamaCore", "swama", NSNull(), NSNull()]],
+                    ["byName": ["Helper", NSNull()]]
                 ]
+            ]]
+        ]
+
+        let report = try analyzeExternalConsumerPackage(
+            description,
+            imports: ["Foundation", "SwamaCore"],
+            contract: contract
+        )
+        #expect(try report.boolean("passed") == false)
+        #expect(try report.array("unexpected_package_dependencies").contains { value in
+            (value as? JSONObject)?["identity"] as? String == "helper"
+        })
+        #expect(try report.array("unexpected_target_dependencies").contains { value in
+            (value as? JSONObject)?["kind"] as? String == "byName"
+        })
+    }
+
+    @Test func targetDependencyGraphRejectsTransitiveAudioProducts() throws {
+        let manifests: [String: JSONObject] = [
+            "swama": [
+                "dependencies": [["fileSystem": [["identity": "wrapper"]]]],
+                "products": [[
+                    "name": "SwamaCore",
+                    "targets": ["SwamaCore"],
+                    "type": ["library": ["automatic"]]
+                ]],
+                "targets": [
+                    [
+                        "name": "SwamaCore",
+                        "dependencies": [["target": ["Implementation", NSNull()]]]
+                    ],
+                    [
+                        "name": "Implementation",
+                        "dependencies": [["product": ["Wrapper", "wrapper", NSNull(), NSNull()]]]
+                    ]
+                ]
+            ],
+            "wrapper": [
+                "dependencies": [["fileSystem": [["identity": "audio"]]]],
+                "products": [[
+                    "name": "Wrapper",
+                    "targets": ["Wrapper"],
+                    "type": ["library": ["automatic"]]
+                ]],
+                "targets": [[
+                    "name": "Wrapper",
+                    "dependencies": [["product": ["MLXAudioCore", "audio", NSNull(), NSNull()]]]
+                ]]
+            ],
+            "audio": [
+                "dependencies": [],
+                "products": [[
+                    "name": "MLXAudioCore",
+                    "targets": ["MLXAudioCore"],
+                    "type": ["library": ["automatic"]]
+                ]],
+                "targets": [["name": "MLXAudioCore", "dependencies": []]]
             ]
         ]
-        let report = try analyzeTargetDependencyGraph(
-            description,
+        let report = try analyzeResolvedTargetDependencyGraph(
+            rootIdentity: "swama",
+            manifests: manifests,
             target: "SwamaCore",
             forbiddenProducts: ["MLXAudioCore", "MLXAudioSTT", "MLXAudioTTS"]
         )
@@ -457,9 +540,81 @@ struct AcceptanceTests {
         #expect(try report.boolean("passed") == false)
         #expect(try report.array("forbidden_products") as? [String] == ["MLXAudioCore"])
         #expect(try Set(report.array("target_dependencies").compactMap { $0 as? String }) == [
-            "Implementation",
-            "SwamaCore"
+            "audio:MLXAudioCore",
+            "swama:Implementation",
+            "swama:SwamaCore",
+            "wrapper:Wrapper"
         ])
+        #expect(try Set(report.array("product_dependencies").compactMap { $0 as? String }) == [
+            "audio:MLXAudioCore",
+            "wrapper:Wrapper"
+        ])
+        #expect(try report.boolean("library_product_present"))
+        #expect(try report.array("unresolved_dependencies").isEmpty)
+    }
+
+    @Test func resolvedTargetDependencyOracleReadsTheRealSwiftPMPackageGraph() throws {
+        let paths = try WorkspacePaths.discover(explicit: repositoryRoot.path)
+        let contract = try AcceptanceContract.load(from: paths.contract).coreGuards
+        let report = try coreTargetDependencyReport(
+            target: "SwamaKit",
+            paths: paths,
+            developerDirectory: URL(fileURLWithPath: "/Applications/Xcode.app/Contents/Developer"),
+            contract: contract
+        )
+
+        #expect(try report.boolean("passed") == false)
+        #expect(try Set(report.array("forbidden_products").compactMap { $0 as? String }) == [
+            "MLXAudioCore",
+            "MLXAudioSTT",
+            "MLXAudioTTS"
+        ])
+        #expect(try report.array("unresolved_dependencies").isEmpty)
+        #expect(try report.object("manifest_sha256").keys.contains("mlx-audio-swift"))
+        #expect(try report.object("resolved_package_traits").array("swama") as? [String] == ["default"])
+    }
+
+    @Test func targetDependencyGraphRejectsAMissingLibraryProduct() throws {
+        let missingProduct: [String: JSONObject] = [
+            "swama": [
+                "dependencies": [],
+                "products": [],
+                "targets": [["name": "SwamaCore", "dependencies": []]]
+            ]
+        ]
+        let missingReport = try analyzeResolvedTargetDependencyGraph(
+            rootIdentity: "swama",
+            manifests: missingProduct,
+            target: "SwamaCore",
+            forbiddenProducts: ["MLXAudioCore", "MLXAudioSTT", "MLXAudioTTS"]
+        )
+
+        #expect(try missingReport.boolean("passed") == false)
+        #expect(try missingReport.boolean("library_product_present") == false)
+        #expect(try missingReport.string("status") == "unmet")
+        #expect(try missingReport.array("forbidden_products").isEmpty)
+
+        let miswiredProduct: [String: JSONObject] = [
+            "swama": [
+                "dependencies": [],
+                "products": [[
+                    "name": "SwamaCore",
+                    "targets": ["Implementation"],
+                    "type": ["library": ["automatic"]]
+                ]],
+                "targets": [["name": "SwamaCore", "dependencies": []]]
+            ]
+        ]
+        let miswiredReport = try analyzeResolvedTargetDependencyGraph(
+            rootIdentity: "swama",
+            manifests: miswiredProduct,
+            target: "SwamaCore",
+            forbiddenProducts: ["MLXAudioCore", "MLXAudioSTT", "MLXAudioTTS"]
+        )
+
+        #expect(try miswiredReport.boolean("passed") == false)
+        #expect(try miswiredReport.boolean("library_product_present") == false)
+        #expect(try miswiredReport.array("library_product_targets") as? [String] == ["Implementation"])
     }
 
     @Test func inlinableAndUsableFromInlineCannotOpenUncheckedReachability() throws {
@@ -511,6 +666,47 @@ struct AcceptanceTests {
         unknownEvent["events"] = [["sequence": 0, "type": "mystery"]]
         #expect(throws: AcceptanceFailure.self) {
             _ = try validateParityRecord(unknownEvent, contract: contract)
+        }
+
+        var validToolCalls = valid
+        validToolCalls["events"] = [[
+            "sequence": 0,
+            "type": "tool_call",
+            "name": "lookup",
+            "arguments": ["query": "hello"]
+        ]]
+        validToolCalls["terminal"] = [
+            "kind": "response",
+            "output": "",
+            "tool_calls": [["name": "lookup", "arguments": ["query": "hello"]]],
+            "finish_reason": "tool_call",
+            "usage": ["prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2]
+        ]
+        #expect(throws: Never.self) {
+            _ = try validateParityRecord(validToolCalls, contract: contract)
+        }
+
+        var nullEventArguments = validToolCalls
+        nullEventArguments["events"] = [[
+            "sequence": 0,
+            "type": "tool_call",
+            "name": "lookup",
+            "arguments": NSNull()
+        ]]
+        #expect(throws: AcceptanceFailure.self) {
+            _ = try validateParityRecord(nullEventArguments, contract: contract)
+        }
+
+        var scalarTerminalArguments = validToolCalls
+        scalarTerminalArguments["terminal"] = [
+            "kind": "response",
+            "output": "",
+            "tool_calls": [["name": "lookup", "arguments": 42]],
+            "finish_reason": "tool_call",
+            "usage": ["prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2]
+        ]
+        #expect(throws: AcceptanceFailure.self) {
+            _ = try validateParityRecord(scalarTerminalArguments, contract: contract)
         }
     }
 

--- a/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
+++ b/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
@@ -345,6 +345,175 @@ struct AcceptanceTests {
         #expect(swiftImportedModule(in: "let example = \"import NIO\"", matching: expression) == nil)
     }
 
+    @Test func compilerPublicAPIGateRejectsUpstreamTypesAndConformances() throws {
+        let graph: JSONObject = [
+            "module": ["name": "SwamaCore"],
+            "symbols": [
+                "model": symbolGraphSymbol(
+                    precise: "s:9SwamaCore6EngineC5model11MLXLMCommon14ModelContainerCvp",
+                    path: ["Engine", "model"],
+                    declaration: [
+                        typeFragment("Engine", precise: "s:9SwamaCore6EngineC"),
+                        typeFragment("ModelContainer", precise: "s:11MLXLMCommon14ModelContainerC")
+                    ]
+                ),
+                "cache": symbolGraphSymbol(
+                    precise: "s:9SwamaCore6EngineC5cacheSay11MLXLMCommon7KVCache_pGvp",
+                    path: ["Engine", "cache"],
+                    declaration: [
+                        typeFragment("KVCache", precise: "s:11MLXLMCommon7KVCacheP")
+                    ]
+                ),
+                "safe": symbolGraphSymbol(
+                    precise: "s:9SwamaCore7PayloadV4data10Foundation4DataVvp",
+                    path: ["Payload", "data"],
+                    declaration: [
+                        typeFragment("Data", precise: "s:10Foundation4DataV")
+                    ]
+                ),
+                "payload": symbolGraphSymbol(
+                    precise: "s:9SwamaCore7PayloadV",
+                    path: ["Payload"],
+                    declaration: [
+                        typeFragment("Payload", precise: "s:9SwamaCore7PayloadV")
+                    ]
+                )
+            ],
+            "relationships": [[
+                "kind": "conformsTo",
+                "source": "s:9SwamaCore7PayloadV",
+                "target": "s:12ForeignTypes14ForeignProtocolP",
+                "targetFallback": "ForeignTypes.ForeignProtocol"
+            ]]
+        ]
+
+        let report = try analyzePublicAPISymbolGraphs(
+            [graph],
+            target: "SwamaCore",
+            allowedModules: ["Swift", "Foundation", "SwamaCore"]
+        )
+        #expect(report["passed"] as? Bool == false)
+        let violations = (report["violations"] as? [JSONObject]) ?? []
+        let modules = Set(violations.compactMap { $0["module"] as? String })
+        #expect(modules == ["ForeignTypes", "MLXLMCommon"])
+        #expect(Set(violations.compactMap { ($0["path"] as? [String])?.joined(separator: ".") }) == [
+            "Engine.cache",
+            "Engine.model",
+            "Payload"
+        ])
+        #expect((report["manifest_sha256"] as? String)?.count == 64)
+    }
+
+    @Test func coreBoundaryReportsCompilerOracleAsUnmetWhenTargetIsAbsent() throws {
+        let paths = try WorkspacePaths.discover(explicit: repositoryRoot.path)
+        let contract = try AcceptanceContract.load(from: paths.contract)
+        let report = try architectureReport(
+            contract: contract.architecture,
+            coreGuards: contract.coreGuards,
+            stage: .coreBoundary,
+            paths: paths
+        )
+
+        #expect(report["passed"] as? Bool == false)
+        let compiler = try report.object("compiler_public_api")
+        #expect(try compiler.string("status") == "unmet")
+        #expect(try compiler.boolean("passed") == false)
+    }
+
+    @Test func consumerBoundaryNamesEveryCurrentMLXDependencyAndImport() throws {
+        let paths = try WorkspacePaths.discover(explicit: repositoryRoot.path)
+        let contract = try AcceptanceContract.load(from: paths.contract)
+        let report = try externalConsumerBoundaryReport(
+            fixture: paths.fixture,
+            contract: contract.coreGuards
+        )
+
+        #expect(try report.boolean("passed") == false)
+        #expect(try report.array("unexpected_products").contains { ($0 as? String) == "MLXLMCommon" })
+        #expect(try report.array("unexpected_imports").contains { ($0 as? String) == "MLXLMCommon" })
+    }
+
+    @Test func targetDependencyGraphRejectsTransitiveAudioProducts() throws {
+        let description: JSONObject = [
+            "targets": [
+                [
+                    "name": "SwamaCore",
+                    "target_dependencies": ["Implementation"],
+                    "product_dependencies": ["FoundationShim"]
+                ],
+                [
+                    "name": "Implementation",
+                    "target_dependencies": [],
+                    "product_dependencies": ["MLXAudioCore"]
+                ]
+            ]
+        ]
+        let report = try analyzeTargetDependencyGraph(
+            description,
+            target: "SwamaCore",
+            forbiddenProducts: ["MLXAudioCore", "MLXAudioSTT", "MLXAudioTTS"]
+        )
+
+        #expect(try report.boolean("passed") == false)
+        #expect(try report.array("forbidden_products") as? [String] == ["MLXAudioCore"])
+        #expect(try Set(report.array("target_dependencies").compactMap { $0 as? String }) == [
+            "Implementation",
+            "SwamaCore"
+        ])
+    }
+
+    @Test func inlinableAndUsableFromInlineCannotOpenUncheckedReachability() throws {
+        let temporary = FileManager.default
+            .temporaryDirectory
+            .appendingPathComponent("swama-inline-boundary-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: temporary) }
+        try FileManager.default.createDirectory(at: temporary, withIntermediateDirectories: true)
+        try Data(
+            """
+            @inlinable public func leak() {}
+            @available(macOS 15.4, *) @usableFromInline internal let hidden = 1
+            // @inlinable public func commentOnly() {}
+            let example = "@usableFromInline"
+
+            """.utf8
+        ).write(to: temporary.appendingPathComponent("Leak.swift"))
+
+        let hits = try publicReachabilityAttributeHits(in: temporary, repository: temporary)
+        #expect(hits.count == 2)
+        #expect(Set(hits.compactMap { $0["attribute"] as? String }) == ["@inlinable", "@usableFromInline"])
+    }
+
+    @Test func paritySchemaRejectsMissingRouteAndUnknownEvents() throws {
+        let paths = try WorkspacePaths.discover(explicit: repositoryRoot.path)
+        let contract = try AcceptanceContract.load(from: paths.contract).coreGuards.parity
+        let valid: JSONObject = [
+            "schema_version": contract.schemaVersion,
+            "case_id": "fixed-case",
+            "route": "core",
+            "events": [["sequence": 0, "type": "text_delta", "text": "ok"]],
+            "terminal": [
+                "kind": "response",
+                "output": "ok",
+                "tool_calls": [],
+                "finish_reason": "completed",
+                "usage": ["prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2]
+            ]
+        ]
+        #expect(throws: Never.self) { _ = try validateParityRecord(valid, contract: contract) }
+
+        var missingRoute = valid
+        missingRoute.removeValue(forKey: "route")
+        #expect(throws: AcceptanceFailure.self) {
+            _ = try validateParityRecord(missingRoute, contract: contract)
+        }
+
+        var unknownEvent = valid
+        unknownEvent["events"] = [["sequence": 0, "type": "mystery"]]
+        #expect(throws: AcceptanceFailure.self) {
+            _ = try validateParityRecord(unknownEvent, contract: contract)
+        }
+    }
+
     @Test func medianUsesAllMeasuredSamples() {
         #expect(median([511, 568, 580, 574, 572]) == 572)
     }
@@ -550,11 +719,13 @@ struct AcceptanceTests {
         }
         let childPIDValue = try #require(
             Int(String(contentsOf: childPIDFile, encoding: .utf8)
-                .trimmingCharacters(in: .whitespacesAndNewlines))
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            )
         )
         let grandchildPIDValue = try #require(
             Int(String(contentsOf: grandchildPIDFile, encoding: .utf8)
-                .trimmingCharacters(in: .whitespacesAndNewlines))
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            )
         )
         childPID = pid_t(childPIDValue)
         grandchildPID = pid_t(grandchildPIDValue)
@@ -565,10 +736,12 @@ struct AcceptanceTests {
     @Test func contractCarriesSeparateProductAndFixtureBuildBudgets() throws {
         let paths = try WorkspacePaths.discover(explicit: repositoryRoot.path)
         let contract = try AcceptanceContract.load(from: paths.contract)
-        #expect(contract.schemaVersion == 3)
+        #expect(contract.schemaVersion == 4)
         #expect(contract.build.productTimeoutSeconds == 1200)
         #expect(contract.build.externalFixtureTimeoutSeconds == 1200)
         #expect(contract.build.externalFixtureTimeoutRetryLimit == 1)
+        #expect(contract.coreGuards.schemaVersion == 1)
+        #expect(contract.coreGuards.parity.requiredRoutes == ["core", "cli", "http"])
     }
 
     @Test func cleanWorktreeCanBeBoundToHead() throws {
@@ -638,6 +811,24 @@ struct AcceptanceTests {
             Issue.record("unexpected error: \(error)")
             return nil
         }
+    }
+
+    private func symbolGraphSymbol(
+        precise: String,
+        path: [String],
+        declaration: [JSONObject]
+    ) -> JSONObject {
+        [
+            "identifier": ["precise": precise, "interfaceLanguage": "swift"],
+            "kind": ["identifier": "swift.property", "displayName": "Instance Property"],
+            "pathComponents": path,
+            "declarationFragments": declaration,
+            "accessLevel": "public"
+        ]
+    }
+
+    private func typeFragment(_ spelling: String, precise: String) -> JSONObject {
+        ["kind": "typeIdentifier", "spelling": spelling, "preciseIdentifier": precise]
     }
 
     private func syntheticReport(paths: WorkspacePaths) throws -> JSONObject {

--- a/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
+++ b/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
@@ -350,6 +350,7 @@ struct AcceptanceTests {
         #else
         import Foundation
         #endif
+        import `MLX`
         @_exported import NIO
         internal import AppKit
         package import struct NIOCore.ByteBuffer
@@ -365,6 +366,7 @@ struct AcceptanceTests {
             "MLXLMCommon",
             "UIKit",
             "Foundation",
+            "MLX",
             "NIO",
             "AppKit",
             "NIOCore",
@@ -372,8 +374,8 @@ struct AcceptanceTests {
             "ArgumentParser"
         ])
         #expect(declarations.allSatisfy { $0.line > 0 })
-        if declarations.count == 8 {
-            #expect(declarations[6].line == declarations[7].line)
+        if declarations.count == 9 {
+            #expect(declarations[7].line == declarations[8].line)
         }
         #expect(throws: AcceptanceFailure.self) {
             _ = try parsedSwiftImports(source: "import", file: temporary)

--- a/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
+++ b/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
@@ -384,6 +384,39 @@ struct AcceptanceTests {
         )
         #expect(extendedRegex.map(\.module) == ["SwamaCore"])
         #expect(extendedRegex.map(\.line) == [2])
+
+        let escapedRegexSource = "let pattern = #/foo\\/#; import AppKit/#\n"
+            + "let many = ##/foo\\/##; import NIO/##\n"
+            + "import SwamaCore\n"
+        let escapedRegex = swiftImportedModules(in: escapedRegexSource, matching: expression)
+        #expect(escapedRegex.map(\.module) == ["SwamaCore"])
+        #expect(escapedRegex.map(\.line) == [3])
+
+        let escapedRawSource = ###"""
+        let one = #"literal \#"#; import AppKit"#
+        let many = ##"literal \##"##; import NIO"##
+        let multiline = #"""
+        literal \#"""#; import ArgumentParser
+        """#
+        import SwamaCore
+        """###
+        let escapedRaw = swiftImportedModules(in: escapedRawSource, matching: expression)
+        #expect(escapedRaw.map(\.module) == ["SwamaCore"])
+        #expect(escapedRaw.map(\.line) == [6])
+
+        let bareRegexSource = "let pattern = /foo; import AppKit/\n"
+            + "let escaped = /foo\\/; import NIO/\n"
+            + "import SwamaCore\n"
+        let bareRegex = swiftImportedModules(in: bareRegexSource, matching: expression)
+        #expect(bareRegex.map(\.module) == ["SwamaCore"])
+        #expect(bareRegex.map(\.line) == [3])
+
+        let division = swiftImportedModules(
+            in: "let quotient = 8 / 2; import AppKit\n",
+            matching: expression
+        )
+        #expect(division.map(\.module) == ["AppKit"])
+        #expect(division.map(\.line) == [1])
     }
 
     @Test func compilerPublicAPIGateRejectsUpstreamTypesAndConformances() throws {
@@ -543,6 +576,16 @@ struct AcceptanceTests {
                 "module": ["name": "SwamaCore"],
                 "symbols": [validSymbol],
                 "relationships": [[
+                    "kind": "conformsTo",
+                    "source": "s:9SwamaCore7PayloadV",
+                    "target": "s:not-real",
+                    "targetFallback": "Swift.Encodable"
+                ]]
+            ],
+            [
+                "module": ["name": "SwamaCore"],
+                "symbols": [validSymbol],
+                "relationships": [[
                     "kind": "futureConformance",
                     "source": "s:9SwamaCore7PayloadV",
                     "target": "s:11MLXLMCommon14ModelContainerC"
@@ -560,30 +603,85 @@ struct AcceptanceTests {
             }
         }
 
-        var validSwiftSymbol = validSymbol
-        validSwiftSymbol["declarationFragments"] = [[
-            "kind": "typeIdentifier",
-            "spelling": "Int",
-            "preciseIdentifier": "s:Si"
-        ]]
+        for (spelling, precise) in [
+            ("Int", "s:Si"),
+            ("Error", "s:s5ErrorP"),
+            ("Hashable", "s:SH"),
+            ("Range", "s:Sn"),
+            ("Set", "s:Sh"),
+            ("Void", "s:s4Voida"),
+            ("TimeInterval", "c:@T@NSTimeInterval")
+        ] {
+            var validSwiftSymbol = validSymbol
+            validSwiftSymbol["declarationFragments"] = [[
+                "kind": "typeIdentifier",
+                "spelling": spelling,
+                "preciseIdentifier": precise
+            ]]
+            #expect(throws: Never.self) {
+                _ = try analyzePublicAPISymbolGraphs(
+                    [["module": ["name": "SwamaCore"], "symbols": [validSwiftSymbol], "relationships": []]],
+                    target: "SwamaCore",
+                    allowedModules: ["Swift", "Foundation", "SwamaCore"]
+                )
+            }
+        }
+
+        var validAttributeSymbol = validSymbol
+        validAttributeSymbol["declarationFragments"] = [
+            ["kind": "attribute", "spelling": "MainActor", "preciseIdentifier": "s:ScM"],
+            typeFragment("Payload", precise: "s:9SwamaCore7PayloadV")
+        ]
         #expect(throws: Never.self) {
             _ = try analyzePublicAPISymbolGraphs(
-                [["module": ["name": "SwamaCore"], "symbols": [validSwiftSymbol], "relationships": []]],
+                [["module": ["name": "SwamaCore"], "symbols": [validAttributeSymbol], "relationships": []]],
                 target: "SwamaCore",
                 allowedModules: ["Swift", "Foundation", "SwamaCore"]
             )
         }
-        validSwiftSymbol["declarationFragments"] = [[
-            "kind": "typeIdentifier",
-            "spelling": "Error",
-            "preciseIdentifier": "s:s5ErrorP"
-        ]]
-        #expect(throws: Never.self) {
-            _ = try analyzePublicAPISymbolGraphs(
-                [["module": ["name": "SwamaCore"], "symbols": [validSwiftSymbol], "relationships": []]],
-                target: "SwamaCore",
-                allowedModules: ["Swift", "Foundation", "SwamaCore"]
-            )
+
+        var externalAttributeSymbol = validSymbol
+        externalAttributeSymbol["declarationFragments"] = [
+            [
+                "kind": "attribute",
+                "spelling": "ExternalWrapper",
+                "preciseIdentifier": "s:8Upstream15ExternalWrapperV"
+            ],
+            typeFragment("Payload", precise: "s:9SwamaCore7PayloadV")
+        ]
+        let externalAttributeReport = try analyzePublicAPISymbolGraphs(
+            [["module": ["name": "SwamaCore"], "symbols": [externalAttributeSymbol], "relationships": []]],
+            target: "SwamaCore",
+            allowedModules: ["Swift", "Foundation", "SwamaCore"]
+        )
+        #expect(try externalAttributeReport.boolean("passed") == false)
+        #expect(try externalAttributeReport.array("violations").contains { value in
+            (value as? JSONObject)?["module"] as? String == "Upstream"
+        })
+
+        for (precise, fallback) in [
+            ("s:SE", "Swift.Encodable"),
+            ("s:SQ", "Swift.Equatable"),
+            ("s:SY", "Swift.RawRepresentable"),
+            ("s:ScA", "_Concurrency.Actor"),
+            ("s:Se", "Swift.Decodable")
+        ] {
+            #expect(throws: Never.self) {
+                _ = try analyzePublicAPISymbolGraphs(
+                    [[
+                        "module": ["name": "SwamaCore"],
+                        "symbols": [validSymbol],
+                        "relationships": [[
+                            "kind": "conformsTo",
+                            "source": "s:9SwamaCore7PayloadV",
+                            "target": precise,
+                            "targetFallback": fallback
+                        ]]
+                    ]],
+                    target: "SwamaCore",
+                    allowedModules: ["Swift", "Foundation", "SwamaCore"]
+                )
+            }
         }
     }
 

--- a/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
+++ b/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
@@ -354,6 +354,36 @@ struct AcceptanceTests {
         )
         #expect(sameLine.map(\.module) == ["SwamaCore", "AppKit"])
         #expect(sameLine.map(\.line) == [3, 3])
+
+        let rawString = swiftImportedModules(
+            in: """
+            let explanation = #"literal " ; import AppKit "#
+            import SwamaCore
+
+            """,
+            matching: expression
+        )
+        #expect(rawString.map(\.module) == ["SwamaCore"])
+        #expect(rawString.map(\.line) == [2])
+
+        let rawMultilineSource = "let explanation = #\"\"\"\n"
+            + "literal \" ; import AppKit\n"
+            + "\"\"\"#\n"
+            + "import SwamaCore\n"
+        let rawMultiline = swiftImportedModules(in: rawMultilineSource, matching: expression)
+        #expect(rawMultiline.map(\.module) == ["SwamaCore"])
+        #expect(rawMultiline.map(\.line) == [4])
+
+        let extendedRegex = swiftImportedModules(
+            in: """
+            let pattern = #/; import AppKit/#
+            import SwamaCore
+
+            """,
+            matching: expression
+        )
+        #expect(extendedRegex.map(\.module) == ["SwamaCore"])
+        #expect(extendedRegex.map(\.line) == [2])
     }
 
     @Test func compilerPublicAPIGateRejectsUpstreamTypesAndConformances() throws {
@@ -459,6 +489,32 @@ struct AcceptanceTests {
             "spelling": "Foo",
             "preciseIdentifier": "s:99Foo"
         ]]
+        var emptySwiftPreciseSymbol = validSymbol
+        emptySwiftPreciseSymbol["declarationFragments"] = [[
+            "kind": "typeIdentifier",
+            "spelling": "Empty",
+            "preciseIdentifier": "s:"
+        ]]
+        var zeroLengthSwiftPreciseSymbol = validSymbol
+        zeroLengthSwiftPreciseSymbol["declarationFragments"] = [[
+            "kind": "typeIdentifier",
+            "spelling": "Empty",
+            "preciseIdentifier": "s:0"
+        ]]
+        var invalidSwiftPreciseSymbol = validSymbol
+        invalidSwiftPreciseSymbol["declarationFragments"] = [[
+            "kind": "typeIdentifier",
+            "spelling": "NotReal",
+            "preciseIdentifier": "s:not-real"
+        ]]
+        var unknownFragmentKindSymbol = validSymbol
+        unknownFragmentKindSymbol["declarationFragments"] = [[
+            "kind": "futureTypeReference",
+            "spelling": "ModelContainer",
+            "preciseIdentifier": "s:11MLXLMCommon14ModelContainerC"
+        ]]
+        var unknownAccessSymbol = validSymbol
+        unknownAccessSymbol["accessLevel"] = "futurePublic"
         let malformedGraphs: [JSONObject] = [
             ["module": ["name": "SwamaCore"], "symbols": [42], "relationships": []],
             ["module": ["name": "SwamaCore"], "symbols": [validSymbol], "relationships": [42]],
@@ -469,6 +525,11 @@ struct AcceptanceTests {
             ],
             ["module": ["name": "SwamaCore"], "symbols": [unqualifiedPreciseSymbol], "relationships": []],
             ["module": ["name": "SwamaCore"], "symbols": [truncatedPreciseSymbol], "relationships": []],
+            ["module": ["name": "SwamaCore"], "symbols": [emptySwiftPreciseSymbol], "relationships": []],
+            ["module": ["name": "SwamaCore"], "symbols": [zeroLengthSwiftPreciseSymbol], "relationships": []],
+            ["module": ["name": "SwamaCore"], "symbols": [invalidSwiftPreciseSymbol], "relationships": []],
+            ["module": ["name": "SwamaCore"], "symbols": [unknownFragmentKindSymbol], "relationships": []],
+            ["module": ["name": "SwamaCore"], "symbols": [unknownAccessSymbol], "relationships": []],
             [
                 "module": ["name": "SwamaCore"],
                 "symbols": [validSymbol],
@@ -476,6 +537,15 @@ struct AcceptanceTests {
                     "kind": "conformsTo",
                     "source": "s:9SwamaCore7PayloadV",
                     "target": "ForeignProtocol"
+                ]]
+            ],
+            [
+                "module": ["name": "SwamaCore"],
+                "symbols": [validSymbol],
+                "relationships": [[
+                    "kind": "futureConformance",
+                    "source": "s:9SwamaCore7PayloadV",
+                    "target": "s:11MLXLMCommon14ModelContainerC"
                 ]]
             ]
         ]
@@ -488,6 +558,32 @@ struct AcceptanceTests {
                     allowedModules: ["Swift", "Foundation", "SwamaCore"]
                 )
             }
+        }
+
+        var validSwiftSymbol = validSymbol
+        validSwiftSymbol["declarationFragments"] = [[
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si"
+        ]]
+        #expect(throws: Never.self) {
+            _ = try analyzePublicAPISymbolGraphs(
+                [["module": ["name": "SwamaCore"], "symbols": [validSwiftSymbol], "relationships": []]],
+                target: "SwamaCore",
+                allowedModules: ["Swift", "Foundation", "SwamaCore"]
+            )
+        }
+        validSwiftSymbol["declarationFragments"] = [[
+            "kind": "typeIdentifier",
+            "spelling": "Error",
+            "preciseIdentifier": "s:s5ErrorP"
+        ]]
+        #expect(throws: Never.self) {
+            _ = try analyzePublicAPISymbolGraphs(
+                [["module": ["name": "SwamaCore"], "symbols": [validSwiftSymbol], "relationships": []]],
+                target: "SwamaCore",
+                allowedModules: ["Swift", "Foundation", "SwamaCore"]
+            )
         }
     }
 
@@ -816,6 +912,51 @@ struct AcceptanceTests {
                         "type": ["library": ["automatic"]]
                     ]],
                     "targets": [["name": "SwamaCore", "dependencies": []]]
+                ]
+            ],
+            [
+                "swama": [
+                    "dependencies": [],
+                    "products": [[
+                        "name": "SwamaCore",
+                        "targets": ["SwamaCore"],
+                        "type": ["library": []]
+                    ]],
+                    "targets": [["name": "SwamaCore", "dependencies": []]]
+                ]
+            ],
+            [
+                "swama": [
+                    "dependencies": [],
+                    "products": [[
+                        "name": "SwamaCore",
+                        "targets": ["SwamaCore"],
+                        "type": ["executable": ["unexpected"]]
+                    ]],
+                    "targets": [["name": "SwamaCore", "dependencies": []]]
+                ]
+            ],
+            [
+                "swama": [
+                    "dependencies": [["fileSystem": [["identity": "dependency"]]]],
+                    "products": [[
+                        "name": "SwamaCore",
+                        "targets": ["SwamaCore"],
+                        "type": ["library": ["automatic"]]
+                    ]],
+                    "targets": [[
+                        "name": "SwamaCore",
+                        "dependencies": [["product": ["Hidden", "", NSNull(), NSNull()]]]
+                    ]]
+                ],
+                "dependency": [
+                    "dependencies": [],
+                    "products": [[
+                        "name": "Hidden",
+                        "targets": ["Hidden"],
+                        "type": ["library": ["automatic"]]
+                    ]],
+                    "targets": [["name": "Hidden", "dependencies": []]]
                 ]
             ]
         ]

--- a/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
+++ b/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
@@ -343,6 +343,17 @@ struct AcceptanceTests {
         }
         #expect(swiftImportedModule(in: "// @_exported import NIO", matching: expression) == nil)
         #expect(swiftImportedModule(in: "let example = \"import NIO\"", matching: expression) == nil)
+        let sameLine = swiftImportedModules(
+            in: """
+            let explanation = "ignore; import NIO"
+            // ignore; import ArgumentParser
+            import SwamaCore; import AppKit // import NIOHTTP1
+
+            """,
+            matching: expression
+        )
+        #expect(sameLine.map(\.module) == ["SwamaCore", "AppKit"])
+        #expect(sameLine.map(\.line) == [3, 3])
     }
 
     @Test func compilerPublicAPIGateRejectsUpstreamTypesAndConformances() throws {
@@ -436,6 +447,18 @@ struct AcceptanceTests {
         )
         var malformedFragmentSymbol = validSymbol
         malformedFragmentSymbol["declarationFragments"] = [42]
+        var unqualifiedPreciseSymbol = validSymbol
+        unqualifiedPreciseSymbol["declarationFragments"] = [[
+            "kind": "typeIdentifier",
+            "spelling": "ForeignType",
+            "preciseIdentifier": "ForeignType"
+        ]]
+        var truncatedPreciseSymbol = validSymbol
+        truncatedPreciseSymbol["declarationFragments"] = [[
+            "kind": "typeIdentifier",
+            "spelling": "Foo",
+            "preciseIdentifier": "s:99Foo"
+        ]]
         let malformedGraphs: [JSONObject] = [
             ["module": ["name": "SwamaCore"], "symbols": [42], "relationships": []],
             ["module": ["name": "SwamaCore"], "symbols": [validSymbol], "relationships": [42]],
@@ -443,6 +466,17 @@ struct AcceptanceTests {
                 "module": ["name": "SwamaCore"],
                 "symbols": [malformedFragmentSymbol],
                 "relationships": []
+            ],
+            ["module": ["name": "SwamaCore"], "symbols": [unqualifiedPreciseSymbol], "relationships": []],
+            ["module": ["name": "SwamaCore"], "symbols": [truncatedPreciseSymbol], "relationships": []],
+            [
+                "module": ["name": "SwamaCore"],
+                "symbols": [validSymbol],
+                "relationships": [[
+                    "kind": "conformsTo",
+                    "source": "s:9SwamaCore7PayloadV",
+                    "target": "ForeignProtocol"
+                ]]
             ]
         ]
 
@@ -727,6 +761,75 @@ struct AcceptanceTests {
         #expect(try report.array("unresolved_dependencies") as? [String] == [
             "unresolved product swama:HiddenProduct"
         ])
+    }
+
+    @Test func targetDependencyGraphRejectsMalformedNestedEvidence() throws {
+        let malformed: [[String: JSONObject]] = [
+            [
+                "swama": [
+                    "dependencies": [],
+                    "products": [[
+                        "name": "SwamaCore",
+                        "targets": ["SwamaCore", NSNull()],
+                        "type": ["library": ["automatic"]]
+                    ]],
+                    "targets": [["name": "SwamaCore", "dependencies": []]]
+                ]
+            ],
+            [
+                "swama": [
+                    "dependencies": [],
+                    "products": [[
+                        "name": "SwamaCore",
+                        "targets": ["SwamaCore"],
+                        "type": ["library": ["automatic"]]
+                    ]],
+                    "targets": [[
+                        "name": "SwamaCore",
+                        "dependencies": [["product": ["Hidden", 42, NSNull(), NSNull()]]]
+                    ]]
+                ]
+            ],
+            [
+                "swama": [
+                    "dependencies": [],
+                    "products": [[
+                        "name": "SwamaCore",
+                        "targets": ["SwamaCore"],
+                        "type": ["library": ["automatic"]]
+                    ]],
+                    "targets": [[
+                        "name": "SwamaCore",
+                        "dependencies": [["product": ["Hidden", NSNull(), NSNull(), "active"]]]
+                    ]]
+                ]
+            ],
+            [
+                "swama": [
+                    "dependencies": [["fileSystem": [[
+                        "identity": "dependency",
+                        "nameForTargetDependencyResolutionOnly": 42
+                    ]]]],
+                    "products": [[
+                        "name": "SwamaCore",
+                        "targets": ["SwamaCore"],
+                        "type": ["library": ["automatic"]]
+                    ]],
+                    "targets": [["name": "SwamaCore", "dependencies": []]]
+                ]
+            ]
+        ]
+
+        for manifests in malformed {
+            #expect(throws: AcceptanceFailure.self) {
+                _ = try analyzeResolvedTargetDependencyGraph(
+                    rootIdentity: "swama",
+                    manifests: manifests,
+                    target: "SwamaCore",
+                    forbiddenProducts: ["MLXAudioCore", "MLXAudioSTT", "MLXAudioTTS"]
+                )
+            }
+        }
     }
 
     @Test func targetDependencyGraphResolvesCustomPackageAliases() throws {

--- a/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
+++ b/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
@@ -428,6 +428,35 @@ struct AcceptanceTests {
         #expect(command.contains("public"))
     }
 
+    @Test func compilerPublicAPIGateRejectsMalformedSymbolGraphEntries() throws {
+        let validSymbol = symbolGraphSymbol(
+            precise: "s:9SwamaCore7PayloadV",
+            path: ["Payload"],
+            declaration: [typeFragment("Payload", precise: "s:9SwamaCore7PayloadV")]
+        )
+        var malformedFragmentSymbol = validSymbol
+        malformedFragmentSymbol["declarationFragments"] = [42]
+        let malformedGraphs: [JSONObject] = [
+            ["module": ["name": "SwamaCore"], "symbols": [42], "relationships": []],
+            ["module": ["name": "SwamaCore"], "symbols": [validSymbol], "relationships": [42]],
+            [
+                "module": ["name": "SwamaCore"],
+                "symbols": [malformedFragmentSymbol],
+                "relationships": []
+            ]
+        ]
+
+        for graph in malformedGraphs {
+            #expect(throws: AcceptanceFailure.self) {
+                _ = try analyzePublicAPISymbolGraphs(
+                    [graph],
+                    target: "SwamaCore",
+                    allowedModules: ["Swift", "Foundation", "SwamaCore"]
+                )
+            }
+        }
+    }
+
     @Test func coreBoundaryReportsCompilerOracleAsUnmetWhenTargetIsAbsent() throws {
         let paths = try WorkspacePaths.discover(explicit: repositoryRoot.path)
         let contract = try AcceptanceContract.load(from: paths.contract)
@@ -449,6 +478,7 @@ struct AcceptanceTests {
         let contract = try AcceptanceContract.load(from: paths.contract)
         let report = try externalConsumerBoundaryReport(
             fixture: paths.fixture,
+            expectedPackage: paths.package,
             contract: contract.coreGuards
         )
 
@@ -462,8 +492,8 @@ struct AcceptanceTests {
         let contract = try AcceptanceContract.load(from: paths.contract).coreGuards
         let description: JSONObject = [
             "dependencies": [
-                ["fileSystem": [["identity": "swama"]]],
-                ["fileSystem": [["identity": "helper"]]]
+                ["fileSystem": [["identity": "swama", "path": "/repo/swama"]]],
+                ["fileSystem": [["identity": "helper", "path": "/repo/helper"]]]
             ],
             "targets": [[
                 "name": "SwamaAcceptanceProbe",
@@ -477,6 +507,7 @@ struct AcceptanceTests {
         let report = try analyzeExternalConsumerPackage(
             description,
             imports: ["Foundation", "SwamaCore"],
+            expectedPackagePath: "/repo/swama",
             contract: contract
         )
         #expect(try report.boolean("passed") == false)
@@ -486,6 +517,58 @@ struct AcceptanceTests {
         #expect(try report.array("unexpected_target_dependencies").contains { value in
             (value as? JSONObject)?["kind"] as? String == "byName"
         })
+
+        let wrongPath: JSONObject = [
+            "dependencies": [[
+                "fileSystem": [["identity": "swama", "path": "/tmp/unreviewed/swama"]]
+            ]],
+            "targets": [[
+                "name": "SwamaAcceptanceProbe",
+                "dependencies": [["product": ["SwamaCore", "swama", NSNull(), NSNull()]]]
+            ]]
+        ]
+        let wrongPathReport = try analyzeExternalConsumerPackage(
+            wrongPath,
+            imports: ["Foundation", "SwamaCore"],
+            expectedPackagePath: "/repo/swama",
+            contract: contract
+        )
+        #expect(try wrongPathReport.boolean("passed") == false)
+        #expect(try wrongPathReport.array("unexpected_package_dependencies").contains { value in
+            (value as? JSONObject)?["path"] as? String == "/tmp/unreviewed/swama"
+        })
+    }
+
+    @Test func consumerBoundaryRejectsMalformedManifestEntries() throws {
+        let paths = try WorkspacePaths.discover(explicit: repositoryRoot.path)
+        let contract = try AcceptanceContract.load(from: paths.contract).coreGuards
+        let validDependency: JSONObject = [
+            "fileSystem": [["identity": "swama", "path": "/repo/swama"]]
+        ]
+        let validTarget: JSONObject = [
+            "name": "SwamaAcceptanceProbe",
+            "dependencies": [["product": ["SwamaCore", "swama", NSNull(), NSNull()]]]
+        ]
+        let malformed: [JSONObject] = [
+            ["dependencies": [42], "targets": [validTarget]],
+            ["dependencies": [["fileSystem": [42]]], "targets": [validTarget]],
+            ["dependencies": [validDependency], "targets": [42]],
+            [
+                "dependencies": [validDependency],
+                "targets": [["name": "SwamaAcceptanceProbe", "dependencies": [42]]]
+            ]
+        ]
+
+        for description in malformed {
+            #expect(throws: AcceptanceFailure.self) {
+                _ = try analyzeExternalConsumerPackage(
+                    description,
+                    imports: ["Foundation", "SwamaCore"],
+                    expectedPackagePath: "/repo/swama",
+                    contract: contract
+                )
+            }
+        }
     }
 
     @Test func targetDependencyGraphRejectsTransitiveAudioProducts() throws {
@@ -569,7 +652,6 @@ struct AcceptanceTests {
             "MLXAudioSTT",
             "MLXAudioTTS"
         ])
-        #expect(try report.array("unresolved_dependencies").isEmpty)
         #expect(try report.object("manifest_sha256").keys.contains("mlx-audio-swift"))
         #expect(try report.object("resolved_package_traits").array("swama") as? [String] == ["default"])
     }
@@ -615,6 +697,94 @@ struct AcceptanceTests {
         #expect(try miswiredReport.boolean("passed") == false)
         #expect(try miswiredReport.boolean("library_product_present") == false)
         #expect(try miswiredReport.array("library_product_targets") as? [String] == ["Implementation"])
+    }
+
+    @Test func targetDependencyGraphRejectsAnUnknownExplicitPackageAlias() throws {
+        let manifests: [String: JSONObject] = [
+            "swama": [
+                "dependencies": [],
+                "products": [[
+                    "name": "SwamaCore",
+                    "targets": ["SwamaCore"],
+                    "type": ["library": ["automatic"]]
+                ]],
+                "targets": [[
+                    "name": "SwamaCore",
+                    "dependencies": [[
+                        "product": ["HiddenProduct", "undeclared-package", NSNull(), NSNull()]
+                    ]]
+                ]]
+            ]
+        ]
+        let report = try analyzeResolvedTargetDependencyGraph(
+            rootIdentity: "swama",
+            manifests: manifests,
+            target: "SwamaCore",
+            forbiddenProducts: ["MLXAudioCore", "MLXAudioSTT", "MLXAudioTTS"]
+        )
+
+        #expect(try report.boolean("passed") == false)
+        #expect(try report.array("unresolved_dependencies") as? [String] == [
+            "unresolved product swama:HiddenProduct"
+        ])
+    }
+
+    @Test func targetDependencyGraphResolvesCustomPackageAliases() throws {
+        let manifests: [String: JSONObject] = [
+            "swama": [
+                "dependencies": [["fileSystem": [[
+                    "identity": "dependency",
+                    "nameForTargetDependencyResolutionOnly": "ChosenAlias"
+                ]]]],
+                "products": [[
+                    "name": "SwamaCore",
+                    "targets": ["SwamaCore"],
+                    "type": ["library": ["automatic"]]
+                ]],
+                "targets": [[
+                    "name": "SwamaCore",
+                    "dependencies": [[
+                        "product": ["HiddenProduct", "ChosenAlias", NSNull(), NSNull()]
+                    ]]
+                ]]
+            ],
+            "dependency": [
+                "dependencies": [["fileSystem": [["identity": "audio"]]]],
+                "products": [[
+                    "name": "HiddenProduct",
+                    "targets": ["HiddenTarget"],
+                    "type": ["library": ["automatic"]]
+                ]],
+                "targets": [[
+                    "name": "HiddenTarget",
+                    "dependencies": [[
+                        "product": ["MLXAudioCore", "audio", NSNull(), NSNull()]
+                    ]]
+                ]]
+            ],
+            "audio": [
+                "dependencies": [],
+                "products": [[
+                    "name": "MLXAudioCore",
+                    "targets": ["MLXAudioCore"],
+                    "type": ["library": ["automatic"]]
+                ]],
+                "targets": [["name": "MLXAudioCore", "dependencies": []]]
+            ]
+        ]
+        let report = try analyzeResolvedTargetDependencyGraph(
+            rootIdentity: "swama",
+            manifests: manifests,
+            target: "SwamaCore",
+            forbiddenProducts: ["MLXAudioCore", "MLXAudioSTT", "MLXAudioTTS"]
+        )
+
+        #expect(try report.boolean("passed") == false)
+        #expect(try report.array("forbidden_products") as? [String] == ["MLXAudioCore"])
+        #expect(try report.array("unresolved_dependencies").isEmpty)
+        #expect(try report.array("product_dependencies").contains { value in
+            (value as? String) == "dependency:HiddenProduct"
+        })
     }
 
     @Test func inlinableAndUsableFromInlineCannotOpenUncheckedReachability() throws {

--- a/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
+++ b/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
@@ -343,6 +343,13 @@ struct AcceptanceTests {
         let customPrefix = /1
         let afterPlus = 1 + /foo; import FakeAfterPlus/
         let quotient = 8 / 2
+        #if os(macOS)
+        import MLXLMCommon
+        #elseif os(iOS)
+        import UIKit
+        #else
+        import Foundation
+        #endif
         @_exported import NIO
         internal import AppKit
         package import struct NIOCore.ByteBuffer
@@ -355,6 +362,9 @@ struct AcceptanceTests {
             developerDirectory: URL(fileURLWithPath: "/Applications/Xcode.app/Contents/Developer")
         )
         #expect(declarations.map(\.module) == [
+            "MLXLMCommon",
+            "UIKit",
+            "Foundation",
             "NIO",
             "AppKit",
             "NIOCore",
@@ -362,16 +372,60 @@ struct AcceptanceTests {
             "ArgumentParser"
         ])
         #expect(declarations.allSatisfy { $0.line > 0 })
-        #expect(declarations[3].line == declarations[4].line)
+        if declarations.count == 8 {
+            #expect(declarations[6].line == declarations[7].line)
+        }
+        let sentinel = "__SwamaAcceptanceImportSentinel"
+        let validAST = """
+        (source_file "/tmp/test.swift"
+          (import_decl decl_context=0x1 range=[/tmp/test.swift:1:1 - line:1:7] module="Foo")
+          (import_decl decl_context=0x1 range=[/tmp/test.swift:2:1 - line:2:8] module="\(sentinel)"))
+        """
+        #expect(try parseCompilerImportAST(validAST, sentinelModule: sentinel).map(\.module) == [
+            "Foo",
+            sentinel
+        ])
         for malformed in [
-            #"(source_file "<test>" (import_decl module="Foo")"#,
-            #"noise (source_file "<test>")"#,
-            #"(source_file "<test>" (import_decl module="Foo"))"#
+            validAST.dropLast().description,
+            "noise \(validAST)",
+            "(source_file \"/tmp/first.swift\")\n\(validAST)",
+            "(source_file \"/tmp/test.swift\"\n(unexpected_output)\n"
+                + "  (import_decl decl_context=0x1 range=[/tmp/test.swift:2:1 - line:2:8] "
+                + "module=\"\(sentinel)\"))",
+            validAST.replacingOccurrences(
+                of: "module=\"\(sentinel)\"))",
+                with: "module=\"\(sentinel)\")\n"
+                    + "  (import_decl decl_context=0x1 range=[/tmp/test.swift:3:1 - line:3:8] "
+                    + "module=\"\(sentinel)\"))"
+            ),
+            validAST + "\n  (unexpected_output)",
+            "\(validAST)\nnoise"
         ] {
             #expect(throws: AcceptanceFailure.self) {
-                _ = try parseCompilerImportAST(malformed)
+                _ = try parseCompilerImportAST(malformed, sentinelModule: sentinel)
             }
         }
+
+        let stripped = sourceRemovingConditionalCompilationDirectives(source)
+        #expect(stripped.utf8.count == source.utf8.count)
+        #expect(stripped.split(separator: "\n", omittingEmptySubsequences: false).count
+            == source.split(separator: "\n", omittingEmptySubsequences: false).count
+        )
+        #expect(!stripped.contains("#if os(macOS)"))
+        #expect(stripped.contains("import MLXLMCommon"))
+        #expect(stripped.contains("import Foundation"))
+    }
+
+    @Test func compilerImportParserAcceptsTheRealDiagnosticsFile() throws {
+        let paths = try WorkspacePaths.discover(explicit: repositoryRoot.path)
+        let file = paths.package
+            .appendingPathComponent("Sources/SwamaKit/Diagnostics/SwamaDiagnostics.swift")
+        let declarations = try compilerImportedModules(
+            in: file,
+            developerDirectory: URL(fileURLWithPath: "/Applications/Xcode.app/Contents/Developer")
+        )
+        #expect(declarations.map(\.module) == ["CryptoKit", "Darwin", "Foundation"])
+        #expect(declarations.map(\.line) == [1, 2, 3])
     }
 
     @Test func compilerPublicAPIGateRejectsUpstreamTypesAndConformances() throws {
@@ -417,7 +471,7 @@ struct AcceptanceTests {
                 [
                     "kind": "conformsTo",
                     "source": "s:9SwamaCore7PayloadV",
-                    "target": "s:12ForeignTypes14ForeignProtocolP",
+                    "target": "s:12ForeignTypes15ForeignProtocolP",
                     "targetFallback": "ForeignTypes.ForeignProtocol"
                 ],
                 [
@@ -495,6 +549,12 @@ struct AcceptanceTests {
             "spelling": "NotReal",
             "preciseIdentifier": "s:not-real"
         ]]
+        var invalidNumericPreciseSymbol = validSymbol
+        invalidNumericPreciseSymbol["declarationFragments"] = [[
+            "kind": "typeIdentifier",
+            "spelling": "Swift",
+            "preciseIdentifier": "s:5Swift?"
+        ]]
         var unknownFragmentKindSymbol = validSymbol
         unknownFragmentKindSymbol["declarationFragments"] = [[
             "kind": "futureTypeReference",
@@ -516,6 +576,7 @@ struct AcceptanceTests {
             ["module": ["name": "SwamaCore"], "symbols": [emptySwiftPreciseSymbol], "relationships": []],
             ["module": ["name": "SwamaCore"], "symbols": [zeroLengthSwiftPreciseSymbol], "relationships": []],
             ["module": ["name": "SwamaCore"], "symbols": [invalidSwiftPreciseSymbol], "relationships": []],
+            ["module": ["name": "SwamaCore"], "symbols": [invalidNumericPreciseSymbol], "relationships": []],
             ["module": ["name": "SwamaCore"], "symbols": [unknownFragmentKindSymbol], "relationships": []],
             ["module": ["name": "SwamaCore"], "symbols": [unknownAccessSymbol], "relationships": []],
             [
@@ -652,11 +713,36 @@ struct AcceptanceTests {
             #expect(try report.array("violations").isEmpty)
         }
 
-        #expect(try parseDemangledSwiftModule("Swift.ClosedRange\n", mangled: "$sSN") == "Swift")
-        #expect(try parseDemangledSwiftModule("$sSN\n", mangled: "$sSN") == nil)
-        #expect(try parseDemangledSwiftModule("Swift.Int\nnoise\n", mangled: "$sSi") == nil)
-        #expect(try parseDemangledSwiftModule("Other.Type\n", mangled: "$sXX") == nil)
-        #expect(try parseDemangledSwiftModule("Swift.Int noise\n", mangled: "$sSi") == nil)
+        let preciseIdentifiers = ["s:SN", "s:5Other4TypeV"]
+        let mangledNames = ["$sSN", "$s5Other4TypeV"]
+        let parsedModules = try parseBatchDemanglerOutput(
+            "$sSN ---> Swift.ClosedRange\n$s5Other4TypeV ---> Other.Type\n",
+            preciseIdentifiers: preciseIdentifiers,
+            mangledNames: mangledNames
+        )
+        #expect(parsedModules[0] == "Swift")
+        #expect(parsedModules[1] == "Other")
+        for malformed in [
+            "$s5Other4TypeV ---> Other.Type\n$sSN ---> Swift.ClosedRange\n",
+            "\n$sSN ---> Swift.ClosedRange\n$s5Other4TypeV ---> Other.Type\n",
+            "$sSN ---> Swift.ClosedRange\n$s5Other4TypeV ---> Other.Type",
+            "$sSN ---> Swift.ClosedRange\n$s5Other4TypeV ---> Other.Type\nnoise\n"
+        ] {
+            #expect(throws: AcceptanceFailure.self) {
+                _ = try parseBatchDemanglerOutput(
+                    malformed,
+                    preciseIdentifiers: preciseIdentifiers,
+                    mangledNames: mangledNames
+                )
+            }
+        }
+
+        let invalidModules = try parseBatchDemanglerOutput(
+            "$s5Swift? ---> $s5Swift?\n$sXX ---> Other.Type\n",
+            preciseIdentifiers: ["s:5Swift?", "s:XX"],
+            mangledNames: ["$s5Swift?", "$sXX"]
+        )
+        #expect(invalidModules == [nil, nil])
     }
 
     @Test func coreBoundaryReportsCompilerOracleAsUnmetWhenTargetIsAbsent() throws {

--- a/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
+++ b/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
@@ -325,98 +325,53 @@ struct AcceptanceTests {
     }
 
     @Test func architectureImportParserHandlesAttributesAccessAndScopedImports() throws {
-        let expression = try NSRegularExpression(pattern: swiftImportDeclarationPattern)
-        let imports = [
-            "import SwamaServer": "SwamaServer",
-            "@_exported import NIO": "NIO",
-            "@preconcurrency import AppKit": "AppKit",
-            "@testable import SwamaServer": "SwamaServer",
-            "@_implementationOnly import ArgumentParser": "ArgumentParser",
-            "@_spi(Testing) import NIOHTTP1": "NIOHTTP1",
-            "internal import SwamaAppSupport": "SwamaAppSupport",
-            "package import struct NIOCore.ByteBuffer": "NIOCore",
-            "@preconcurrency import MLXLMCommon": "MLXLMCommon"
-        ]
-
-        for (line, module) in imports {
-            #expect(swiftImportedModule(in: line, matching: expression) == module)
-        }
-        #expect(swiftImportedModule(in: "// @_exported import NIO", matching: expression) == nil)
-        #expect(swiftImportedModule(in: "let example = \"import NIO\"", matching: expression) == nil)
-        let sameLine = swiftImportedModules(
-            in: """
-            let explanation = "ignore; import NIO"
-            // ignore; import ArgumentParser
-            import SwamaCore; import AppKit // import NIOHTTP1
-
-            """,
-            matching: expression
-        )
-        #expect(sameLine.map(\.module) == ["SwamaCore", "AppKit"])
-        #expect(sameLine.map(\.line) == [3, 3])
-
-        let rawString = swiftImportedModules(
-            in: """
-            let explanation = #"literal " ; import AppKit "#
-            import SwamaCore
-
-            """,
-            matching: expression
-        )
-        #expect(rawString.map(\.module) == ["SwamaCore"])
-        #expect(rawString.map(\.line) == [2])
-
-        let rawMultilineSource = "let explanation = #\"\"\"\n"
-            + "literal \" ; import AppKit\n"
-            + "\"\"\"#\n"
-            + "import SwamaCore\n"
-        let rawMultiline = swiftImportedModules(in: rawMultilineSource, matching: expression)
-        #expect(rawMultiline.map(\.module) == ["SwamaCore"])
-        #expect(rawMultiline.map(\.line) == [4])
-
-        let extendedRegex = swiftImportedModules(
-            in: """
-            let pattern = #/; import AppKit/#
-            import SwamaCore
-
-            """,
-            matching: expression
-        )
-        #expect(extendedRegex.map(\.module) == ["SwamaCore"])
-        #expect(extendedRegex.map(\.line) == [2])
-
-        let escapedRegexSource = "let pattern = #/foo\\/#; import AppKit/#\n"
-            + "let many = ##/foo\\/##; import NIO/##\n"
-            + "import SwamaCore\n"
-        let escapedRegex = swiftImportedModules(in: escapedRegexSource, matching: expression)
-        #expect(escapedRegex.map(\.module) == ["SwamaCore"])
-        #expect(escapedRegex.map(\.line) == [3])
-
-        let escapedRawSource = ###"""
-        let one = #"literal \#"#; import AppKit"#
-        let many = ##"literal \##"##; import NIO"##
+        let temporary = FileManager.default
+            .temporaryDirectory
+            .appendingPathComponent("swama-import-parser-\(UUID().uuidString).swift")
+        defer { try? FileManager.default.removeItem(at: temporary) }
+        let source = ####"""
+        let explanation = "ignore; import FakeString"
+        // ignore; import FakeComment
+        let raw = #"literal \#"#; import FakeRaw"#
         let multiline = #"""
-        literal \#"""#; import ArgumentParser
+        literal \#"""#; import FakeMultiline
         """#
-        import SwamaCore
-        """###
-        let escapedRaw = swiftImportedModules(in: escapedRawSource, matching: expression)
-        #expect(escapedRaw.map(\.module) == ["SwamaCore"])
-        #expect(escapedRaw.map(\.line) == [6])
+        let extended = #/foo\/#; import FakeExtended/#
+        let bare = /foo; import FakeBare/
+        prefix operator /
+        prefix func / (value: Int) -> Int { value }
+        let customPrefix = /1
+        let afterPlus = 1 + /foo; import FakeAfterPlus/
+        let quotient = 8 / 2
+        @_exported import NIO
+        internal import AppKit
+        package import struct NIOCore.ByteBuffer
+        import SwamaCore; import ArgumentParser
+        """####
+        try Data(source.utf8).write(to: temporary)
 
-        let bareRegexSource = "let pattern = /foo; import AppKit/\n"
-            + "let escaped = /foo\\/; import NIO/\n"
-            + "import SwamaCore\n"
-        let bareRegex = swiftImportedModules(in: bareRegexSource, matching: expression)
-        #expect(bareRegex.map(\.module) == ["SwamaCore"])
-        #expect(bareRegex.map(\.line) == [3])
-
-        let division = swiftImportedModules(
-            in: "let quotient = 8 / 2; import AppKit\n",
-            matching: expression
+        let declarations = try compilerImportedModules(
+            in: temporary,
+            developerDirectory: URL(fileURLWithPath: "/Applications/Xcode.app/Contents/Developer")
         )
-        #expect(division.map(\.module) == ["AppKit"])
-        #expect(division.map(\.line) == [1])
+        #expect(declarations.map(\.module) == [
+            "NIO",
+            "AppKit",
+            "NIOCore",
+            "SwamaCore",
+            "ArgumentParser"
+        ])
+        #expect(declarations.allSatisfy { $0.line > 0 })
+        #expect(declarations[3].line == declarations[4].line)
+        for malformed in [
+            #"(source_file "<test>" (import_decl module="Foo")"#,
+            #"noise (source_file "<test>")"#,
+            #"(source_file "<test>" (import_decl module="Foo"))"#
+        ] {
+            #expect(throws: AcceptanceFailure.self) {
+                _ = try parseCompilerImportAST(malformed)
+            }
+        }
     }
 
     @Test func compilerPublicAPIGateRejectsUpstreamTypesAndConformances() throws {
@@ -607,6 +562,19 @@ struct AcceptanceTests {
             ("Int", "s:Si"),
             ("Error", "s:s5ErrorP"),
             ("Hashable", "s:SH"),
+            ("FloatingPoint", "s:SF"),
+            ("BidirectionalCollection", "s:SK"),
+            ("Comparable", "s:SL"),
+            ("MutableCollection", "s:SM"),
+            ("ClosedRange", "s:SN"),
+            ("Sequence", "s:ST"),
+            ("Numeric", "s:Sj"),
+            ("RandomAccessCollection", "s:Sk"),
+            ("Collection", "s:Sl"),
+            ("RangeReplaceableCollection", "s:Sm"),
+            ("IteratorProtocol", "s:St"),
+            ("Strideable", "s:Sx"),
+            ("BinaryInteger", "s:Sz"),
             ("Range", "s:Sn"),
             ("Set", "s:Sh"),
             ("Void", "s:s4Voida"),
@@ -618,13 +586,13 @@ struct AcceptanceTests {
                 "spelling": spelling,
                 "preciseIdentifier": precise
             ]]
-            #expect(throws: Never.self) {
-                _ = try analyzePublicAPISymbolGraphs(
-                    [["module": ["name": "SwamaCore"], "symbols": [validSwiftSymbol], "relationships": []]],
-                    target: "SwamaCore",
-                    allowedModules: ["Swift", "Foundation", "SwamaCore"]
-                )
-            }
+            let report = try analyzePublicAPISymbolGraphs(
+                [["module": ["name": "SwamaCore"], "symbols": [validSwiftSymbol], "relationships": []]],
+                target: "SwamaCore",
+                allowedModules: ["Swift", "Foundation", "SwamaCore"]
+            )
+            #expect(try report.boolean("passed"))
+            #expect(try report.array("violations").isEmpty)
         }
 
         var validAttributeSymbol = validSymbol
@@ -632,13 +600,13 @@ struct AcceptanceTests {
             ["kind": "attribute", "spelling": "MainActor", "preciseIdentifier": "s:ScM"],
             typeFragment("Payload", precise: "s:9SwamaCore7PayloadV")
         ]
-        #expect(throws: Never.self) {
-            _ = try analyzePublicAPISymbolGraphs(
-                [["module": ["name": "SwamaCore"], "symbols": [validAttributeSymbol], "relationships": []]],
-                target: "SwamaCore",
-                allowedModules: ["Swift", "Foundation", "SwamaCore"]
-            )
-        }
+        let validAttributeReport = try analyzePublicAPISymbolGraphs(
+            [["module": ["name": "SwamaCore"], "symbols": [validAttributeSymbol], "relationships": []]],
+            target: "SwamaCore",
+            allowedModules: ["Swift", "Foundation", "SwamaCore"]
+        )
+        #expect(try validAttributeReport.boolean("passed"))
+        #expect(try validAttributeReport.array("violations").isEmpty)
 
         var externalAttributeSymbol = validSymbol
         externalAttributeSymbol["declarationFragments"] = [
@@ -666,23 +634,29 @@ struct AcceptanceTests {
             ("s:ScA", "_Concurrency.Actor"),
             ("s:Se", "Swift.Decodable")
         ] {
-            #expect(throws: Never.self) {
-                _ = try analyzePublicAPISymbolGraphs(
-                    [[
-                        "module": ["name": "SwamaCore"],
-                        "symbols": [validSymbol],
-                        "relationships": [[
-                            "kind": "conformsTo",
-                            "source": "s:9SwamaCore7PayloadV",
-                            "target": precise,
-                            "targetFallback": fallback
-                        ]]
-                    ]],
-                    target: "SwamaCore",
-                    allowedModules: ["Swift", "Foundation", "SwamaCore"]
-                )
-            }
+            let report = try analyzePublicAPISymbolGraphs(
+                [[
+                    "module": ["name": "SwamaCore"],
+                    "symbols": [validSymbol],
+                    "relationships": [[
+                        "kind": "conformsTo",
+                        "source": "s:9SwamaCore7PayloadV",
+                        "target": precise,
+                        "targetFallback": fallback
+                    ]]
+                ]],
+                target: "SwamaCore",
+                allowedModules: ["Swift", "Foundation", "SwamaCore"]
+            )
+            #expect(try report.boolean("passed"))
+            #expect(try report.array("violations").isEmpty)
         }
+
+        #expect(try parseDemangledSwiftModule("Swift.ClosedRange\n", mangled: "$sSN") == "Swift")
+        #expect(try parseDemangledSwiftModule("$sSN\n", mangled: "$sSN") == nil)
+        #expect(try parseDemangledSwiftModule("Swift.Int\nnoise\n", mangled: "$sSi") == nil)
+        #expect(try parseDemangledSwiftModule("Other.Type\n", mangled: "$sXX") == nil)
+        #expect(try parseDemangledSwiftModule("Swift.Int noise\n", mangled: "$sSi") == nil)
     }
 
     @Test func coreBoundaryReportsCompilerOracleAsUnmetWhenTargetIsAbsent() throws {

--- a/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
+++ b/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
@@ -343,7 +343,7 @@ struct AcceptanceTests {
         let customPrefix = /1
         let afterPlus = 1 + /foo; import FakeAfterPlus/
         let quotient = 8 / 2
-        #if os(macOS)
+        #if(os(macOS))
         import MLXLMCommon
         #elseif os(iOS)
         import UIKit
@@ -375,45 +375,15 @@ struct AcceptanceTests {
         if declarations.count == 8 {
             #expect(declarations[6].line == declarations[7].line)
         }
-        let sentinel = "__SwamaAcceptanceImportSentinel"
-        let validAST = """
-        (source_file "/tmp/test.swift"
-          (import_decl decl_context=0x1 range=[/tmp/test.swift:1:1 - line:1:7] module="Foo")
-          (import_decl decl_context=0x1 range=[/tmp/test.swift:2:1 - line:2:8] module="\(sentinel)"))
-        """
-        #expect(try parseCompilerImportAST(validAST, sentinelModule: sentinel).map(\.module) == [
-            "Foo",
-            sentinel
-        ])
-        for malformed in [
-            validAST.dropLast().description,
-            "noise \(validAST)",
-            "(source_file \"/tmp/first.swift\")\n\(validAST)",
-            "(source_file \"/tmp/test.swift\"\n(unexpected_output)\n"
-                + "  (import_decl decl_context=0x1 range=[/tmp/test.swift:2:1 - line:2:8] "
-                + "module=\"\(sentinel)\"))",
-            validAST.replacingOccurrences(
-                of: "module=\"\(sentinel)\"))",
-                with: "module=\"\(sentinel)\")\n"
-                    + "  (import_decl decl_context=0x1 range=[/tmp/test.swift:3:1 - line:3:8] "
-                    + "module=\"\(sentinel)\"))"
-            ),
-            validAST + "\n  (unexpected_output)",
-            "\(validAST)\nnoise"
-        ] {
-            #expect(throws: AcceptanceFailure.self) {
-                _ = try parseCompilerImportAST(malformed, sentinelModule: sentinel)
-            }
+        #expect(throws: AcceptanceFailure.self) {
+            _ = try parsedSwiftImports(source: "import", file: temporary)
         }
-
-        let stripped = sourceRemovingConditionalCompilationDirectives(source)
-        #expect(stripped.utf8.count == source.utf8.count)
-        #expect(stripped.split(separator: "\n", omittingEmptySubsequences: false).count
-            == source.split(separator: "\n", omittingEmptySubsequences: false).count
-        )
-        #expect(!stripped.contains("#if os(macOS)"))
-        #expect(stripped.contains("import MLXLMCommon"))
-        #expect(stripped.contains("import Foundation"))
+        #expect(throws: AcceptanceFailure.self) {
+            _ = try compilerImportedModules(
+                in: temporary,
+                developerDirectory: URL(fileURLWithPath: "/nonexistent/swama-xcode")
+            )
+        }
     }
 
     @Test func compilerImportParserAcceptsTheRealDiagnosticsFile() throws {
@@ -555,6 +525,12 @@ struct AcceptanceTests {
             "spelling": "Swift",
             "preciseIdentifier": "s:5Swift?"
         ]]
+        var concatenatedPreciseSymbol = validSymbol
+        concatenatedPreciseSymbol["declarationFragments"] = [[
+            "kind": "typeIdentifier",
+            "spelling": "Int",
+            "preciseIdentifier": "s:Si5Other4TypeV"
+        ]]
         var unknownFragmentKindSymbol = validSymbol
         unknownFragmentKindSymbol["declarationFragments"] = [[
             "kind": "futureTypeReference",
@@ -577,6 +553,7 @@ struct AcceptanceTests {
             ["module": ["name": "SwamaCore"], "symbols": [zeroLengthSwiftPreciseSymbol], "relationships": []],
             ["module": ["name": "SwamaCore"], "symbols": [invalidSwiftPreciseSymbol], "relationships": []],
             ["module": ["name": "SwamaCore"], "symbols": [invalidNumericPreciseSymbol], "relationships": []],
+            ["module": ["name": "SwamaCore"], "symbols": [concatenatedPreciseSymbol], "relationships": []],
             ["module": ["name": "SwamaCore"], "symbols": [unknownFragmentKindSymbol], "relationships": []],
             ["module": ["name": "SwamaCore"], "symbols": [unknownAccessSymbol], "relationships": []],
             [
@@ -715,18 +692,36 @@ struct AcceptanceTests {
 
         let preciseIdentifiers = ["s:SN", "s:5Other4TypeV"]
         let mangledNames = ["$sSN", "$s5Other4TypeV"]
+        let validDemanglerOutput = """
+        Demangling for $sSN
+        kind=Global
+          kind=Structure
+            kind=Module, text="Swift"
+            kind=Identifier, text="ClosedRange"
+
+        Demangling for $s5Other4TypeV
+        kind=Global
+          kind=Structure
+            kind=Module, text="Other"
+            kind=Identifier, text="Type"
+
+
+        """
         let parsedModules = try parseBatchDemanglerOutput(
-            "$sSN ---> Swift.ClosedRange\n$s5Other4TypeV ---> Other.Type\n",
+            validDemanglerOutput,
             preciseIdentifiers: preciseIdentifiers,
             mangledNames: mangledNames
         )
         #expect(parsedModules[0] == "Swift")
         #expect(parsedModules[1] == "Other")
         for malformed in [
-            "$s5Other4TypeV ---> Other.Type\n$sSN ---> Swift.ClosedRange\n",
-            "\n$sSN ---> Swift.ClosedRange\n$s5Other4TypeV ---> Other.Type\n",
-            "$sSN ---> Swift.ClosedRange\n$s5Other4TypeV ---> Other.Type",
-            "$sSN ---> Swift.ClosedRange\n$s5Other4TypeV ---> Other.Type\nnoise\n"
+            validDemanglerOutput.replacingOccurrences(
+                of: "Demangling for $sSN",
+                with: "Demangling for $s5Other4TypeV"
+            ),
+            "\n" + validDemanglerOutput,
+            validDemanglerOutput.trimmingCharacters(in: .newlines),
+            validDemanglerOutput + "noise\n"
         ] {
             #expect(throws: AcceptanceFailure.self) {
                 _ = try parseBatchDemanglerOutput(
@@ -738,11 +733,29 @@ struct AcceptanceTests {
         }
 
         let invalidModules = try parseBatchDemanglerOutput(
-            "$s5Swift? ---> $s5Swift?\n$sXX ---> Other.Type\n",
+            "Demangling for $s5Swift?\n<<NULL>>\nDemangling for $sXX\n<<NULL>>\n",
             preciseIdentifiers: ["s:5Swift?", "s:XX"],
             mangledNames: ["$s5Swift?", "$sXX"]
         )
         #expect(invalidModules == [nil, nil])
+
+        let concatenatedModules = try parseBatchDemanglerOutput(
+            """
+            Demangling for $sSi5Other4TypeV
+            kind=Global
+              kind=Structure
+                kind=Module, text="Swift"
+                kind=Identifier, text="Int"
+              kind=Structure
+                kind=Module, text="Other"
+                kind=Identifier, text="Type"
+
+
+            """,
+            preciseIdentifiers: ["s:Si5Other4TypeV"],
+            mangledNames: ["$sSi5Other4TypeV"]
+        )
+        #expect(concatenatedModules == [nil])
     }
 
     @Test func coreBoundaryReportsCompilerOracleAsUnmetWhenTargetIsAbsent() throws {

--- a/Tools/SwamaAcceptance/contract.json
+++ b/Tools/SwamaAcceptance/contract.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 3,
+  "schema_version": 4,
   "build": {
     "product_timeout_seconds": 1200,
     "external_fixture_timeout_seconds": 1200,
@@ -99,5 +99,47 @@
       "SwamaServer",
       "SwamaAppSupport"
     ]
+  },
+  "core_guards": {
+    "schema_version": 1,
+    "compiler_timeout_seconds": 1200,
+    "allowed_public_modules": [
+      "Swift",
+      "Foundation",
+      "SwamaCore"
+    ],
+    "fixture_product": "SwamaCore",
+    "fixture_allowed_imports": [
+      "Foundation",
+      "SwamaCore"
+    ],
+    "forbidden_transitive_products": [
+      "MLXAudioCore",
+      "MLXAudioSTT",
+      "MLXAudioTTS"
+    ],
+    "parity": {
+      "schema_version": 1,
+      "required_routes": [
+        "core",
+        "cli",
+        "http"
+      ],
+      "event_types": [
+        "text_delta",
+        "tool_call"
+      ],
+      "terminal_kinds": [
+        "response",
+        "cancelled",
+        "error"
+      ],
+      "finish_reasons": [
+        "completed",
+        "length",
+        "tool_call",
+        "other"
+      ]
+    }
   }
 }


### PR DESCRIPTION
## Summary

- add staged `legacy-ratchet`, `core-boundary`, and `consumer-boundary` architecture gates
- inspect the future `SwamaCore` public surface through compiler symbol graphs, including declaration fragments, relationships, conformances, and reachability attributes
- require the external fixture to resolve only this workspace's `SwamaCore` product and reject transitive MLX Audio dependencies
- freeze a strict Core/CLI/HTTP semantic-parity record schema for later production adapters
- parse Swift imports with revision-pinned SwiftParser 603.0.2, including conditional-compilation branches and escaped identifiers
- resolve Swift precise identifiers through a strict single-root `swift-demangle --expand --tree-only` batch

This PR changes only `Tools/SwamaAcceptance`; it does not add `SwamaCore` or change production behavior, public API, targets, concurrency, or FoundationModels support. The current legacy stage remains green while the future Core stage is explicitly unmet.

## Verification

- `swift test --package-path Tools/SwamaAcceptance`: 41/41
- stable Swift 6.3 release build: pass
- clean cold referee build with SwiftParser dependency: 158.19s, below the 1200s budget
- Cindy second-machine custody: GO, baseline `5e2327f1`
- Miyabi final exact-bound review: GO, 0 findings
- reverse controls cover public upstream leaks, consumer side doors, schema drift, parser recovery, conditional imports, escaped imports, malformed/concatenated USRs, and tree-output framing

Reviewed exact: `3ffbfc0f376f282e4395c188538a2ed660864d49`.
