### PR TITLE
Scope Core symbol graph extraction to the target

### DIFF
--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/CoreContractGuards.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/CoreContractGuards.swift
@@ -289,13 +289,10 @@ func analyzePublicAPISymbolGraphs(
     allowedModules: Set<String>,
     developerDirectory: URL = URL(fileURLWithPath: "/Applications/Xcode.app/Contents/Developer")
 ) throws -> JSONObject {
-    let localIdentifiers = try localSymbolIdentifiers(in: graphs, target: target)
+    let localExtensionIdentifiers = try localExtensionIdentifiers(in: graphs, target: target)
     let moduleResolver = try PreciseIdentifierModuleResolver(
         developerDirectory: developerDirectory,
         preciseIdentifiers: preciseIdentifiersNeedingResolution(in: graphs, target: target)
-            .subtracting(localIdentifiers),
-        localIdentifiers: localIdentifiers,
-        localModule: target
     )
     let knownAccessLevels: Set<String> = ["fileprivate", "internal", "open", "package", "private", "public"]
     let knownRelationshipKinds: Set<String> = [
@@ -352,7 +349,12 @@ func analyzePublicAPISymbolGraphs(
                 let extensionTargets = try symbolRelationships.filter {
                     try $0.string("kind") == "extensionTo"
                 }
-                guard identifier.hasPrefix("s:e:"), extensionTargets.count == 1 else {
+                let extensionTarget = try extensionTargets.first?.string("target")
+                guard identifier.hasPrefix("s:e:"),
+                      extensionTargets.count == 1,
+                      extensionTarget?.hasPrefix("s:e:") == false,
+                      extensionTarget != identifier
+                else {
                     throw AcceptanceFailure.unknown(
                         "public extension symbol is missing its unique extensionTo relationship: \(identifier)"
                     )
@@ -442,10 +444,20 @@ func analyzePublicAPISymbolGraphs(
                 let fallback = try relationship["targetFallback"] == nil
                     ? nil
                     : relationship.string("targetFallback")
-                guard let module = try moduleResolver.moduleName(in: targetIdentifier) else {
-                    throw AcceptanceFailure.unknown(
-                        "public relationship has an unparseable target: \(targetIdentifier)"
-                    )
+                let module: String
+                if relationshipKind == "memberOf",
+                   localExtensionIdentifiers.contains(targetIdentifier)
+                {
+                    module = target
+                }
+                else {
+                    guard let resolved = try moduleResolver.moduleName(in: targetIdentifier) else {
+                        throw AcceptanceFailure.unknown(
+                            "public relationship has an unparseable target: \(targetIdentifier)"
+                        )
+                    }
+
+                    module = resolved
                 }
 
                 references.insert(module)
@@ -581,7 +593,7 @@ private func optionalStrictStringArray(_ object: JSONObject, key: String, contex
 
 // MARK: - Precise identifier discovery
 
-private func localSymbolIdentifiers(
+private func localExtensionIdentifiers(
     in graphs: [JSONObject],
     target: String
 ) throws -> Set<String> {
@@ -590,7 +602,11 @@ private func localSymbolIdentifiers(
         for symbol in try strictObjectArray(graph, key: "symbols", context: "symbol graph") {
             let precise = try symbol.object("identifier").string("precise")
             let kind = try symbol.object("kind").string("identifier")
-            if kind == "swift.extension", precise.hasPrefix("s:e:") {
+            let access = try symbol.string("accessLevel")
+            if ["public", "open"].contains(access),
+               kind == "swift.extension",
+               precise.hasPrefix("s:e:")
+            {
                 identifiers.insert(precise)
             }
         }
@@ -641,21 +657,12 @@ private final class PreciseIdentifierModuleResolver {
     }
 
     private let demangler: URL
-    private let localIdentifiers: Set<String>
-    private let localModule: String
     private var cache: [String: Resolution] = [:]
 
-    init(
-        developerDirectory: URL,
-        preciseIdentifiers: Set<String>,
-        localIdentifiers: Set<String>,
-        localModule: String
-    ) throws {
+    init(developerDirectory: URL, preciseIdentifiers: Set<String>) throws {
         demangler = developerDirectory.appendingPathComponent(
             "Toolchains/XcodeDefault.xctoolchain/usr/bin/swift-demangle"
         )
-        self.localIdentifiers = localIdentifiers
-        self.localModule = localModule
         guard FileManager.default.isExecutableFile(atPath: demangler.path) else {
             throw AcceptanceFailure.unknown("missing Swift demangler: \(demangler.path)")
         }
@@ -693,9 +700,6 @@ private final class PreciseIdentifierModuleResolver {
     }
 
     func moduleName(in preciseIdentifier: String) throws -> String? {
-        if localIdentifiers.contains(preciseIdentifier) {
-            return localModule
-        }
         if let cached = cache[preciseIdentifier] {
             switch cached {
             case let .module(module):

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/CoreContractGuards.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/CoreContractGuards.swift
@@ -347,6 +347,17 @@ func analyzePublicAPISymbolGraphs(
 
             let identifier = try symbol.object("identifier").string("precise")
             let kind = try symbol.object("kind").string("identifier")
+            let symbolRelationships = relationshipsBySource[identifier] ?? []
+            if kind == "swift.extension" {
+                let extensionTargets = try symbolRelationships.filter {
+                    try $0.string("kind") == "extensionTo"
+                }
+                guard identifier.hasPrefix("s:e:"), extensionTargets.count == 1 else {
+                    throw AcceptanceFailure.unknown(
+                        "public extension symbol is missing its unique extensionTo relationship: \(identifier)"
+                    )
+                }
+            }
             let path = try strictStringArray(symbol, key: "pathComponents", context: "public symbol")
             let fragments = try strictObjectArray(
                 symbol,
@@ -425,7 +436,7 @@ func analyzePublicAPISymbolGraphs(
             }
 
             var conformances: [String] = []
-            for relationship in relationshipsBySource[identifier] ?? [] {
+            for relationship in symbolRelationships {
                 let relationshipKind = try relationship.string("kind")
                 let targetIdentifier = try relationship.string("target")
                 let fallback = try relationship["targetFallback"] == nil
@@ -577,7 +588,11 @@ private func localSymbolIdentifiers(
     var identifiers: Set<String> = []
     for graph in graphs where try graph.object("module").string("name") == target {
         for symbol in try strictObjectArray(graph, key: "symbols", context: "symbol graph") {
-            try identifiers.insert(symbol.object("identifier").string("precise"))
+            let precise = try symbol.object("identifier").string("precise")
+            let kind = try symbol.object("kind").string("identifier")
+            if kind == "swift.extension", precise.hasPrefix("s:e:") {
+                identifiers.insert(precise)
+            }
         }
     }
     return identifiers

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/CoreContractGuards.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/CoreContractGuards.swift
@@ -239,9 +239,25 @@ func swiftTargetTriple(_ output: String) throws -> String {
         throw AcceptanceFailure.unknown("Swift target identity is invalid JSON: \(error)")
     }
 
-    let triple = try object.object("target").string("triple")
-    guard !triple.isEmpty else {
-        throw AcceptanceFailure.unknown("Swift target identity has an empty triple")
+    let target = try object.object("target")
+    let triple = try target.string("triple")
+    let unversionedTriple = try target.string("unversionedTriple")
+    let platform = try target.string("platform")
+    let arch = try target.string("arch")
+    guard platform == "macosx",
+          ["arm64", "x86_64"].contains(arch),
+          unversionedTriple == "\(arch)-apple-macosx"
+    else {
+        throw AcceptanceFailure.unknown("Swift target identity is not a supported macOS target")
+    }
+
+    let expression = try NSRegularExpression(
+        pattern: "^\(NSRegularExpression.escapedPattern(for: unversionedTriple))"
+            + #"[0-9]+(?:\.[0-9]+){0,2}$"#
+    )
+    let range = NSRange(triple.startIndex ..< triple.endIndex, in: triple)
+    guard expression.firstMatch(in: triple, range: range)?.range == range else {
+        throw AcceptanceFailure.unknown("Swift target identity has an invalid versioned triple")
     }
 
     return triple
@@ -273,9 +289,13 @@ func analyzePublicAPISymbolGraphs(
     allowedModules: Set<String>,
     developerDirectory: URL = URL(fileURLWithPath: "/Applications/Xcode.app/Contents/Developer")
 ) throws -> JSONObject {
+    let localIdentifiers = try localSymbolIdentifiers(in: graphs, target: target)
     let moduleResolver = try PreciseIdentifierModuleResolver(
         developerDirectory: developerDirectory,
         preciseIdentifiers: preciseIdentifiersNeedingResolution(in: graphs, target: target)
+            .subtracting(localIdentifiers),
+        localIdentifiers: localIdentifiers,
+        localModule: target
     )
     let knownAccessLevels: Set<String> = ["fileprivate", "internal", "open", "package", "private", "public"]
     let knownRelationshipKinds: Set<String> = [
@@ -550,6 +570,19 @@ private func optionalStrictStringArray(_ object: JSONObject, key: String, contex
 
 // MARK: - Precise identifier discovery
 
+private func localSymbolIdentifiers(
+    in graphs: [JSONObject],
+    target: String
+) throws -> Set<String> {
+    var identifiers: Set<String> = []
+    for graph in graphs where try graph.object("module").string("name") == target {
+        for symbol in try strictObjectArray(graph, key: "symbols", context: "symbol graph") {
+            try identifiers.insert(symbol.object("identifier").string("precise"))
+        }
+    }
+    return identifiers
+}
+
 private func preciseIdentifiersNeedingResolution(
     in graphs: [JSONObject],
     target: String
@@ -593,12 +626,21 @@ private final class PreciseIdentifierModuleResolver {
     }
 
     private let demangler: URL
+    private let localIdentifiers: Set<String>
+    private let localModule: String
     private var cache: [String: Resolution] = [:]
 
-    init(developerDirectory: URL, preciseIdentifiers: Set<String>) throws {
+    init(
+        developerDirectory: URL,
+        preciseIdentifiers: Set<String>,
+        localIdentifiers: Set<String>,
+        localModule: String
+    ) throws {
         demangler = developerDirectory.appendingPathComponent(
             "Toolchains/XcodeDefault.xctoolchain/usr/bin/swift-demangle"
         )
+        self.localIdentifiers = localIdentifiers
+        self.localModule = localModule
         guard FileManager.default.isExecutableFile(atPath: demangler.path) else {
             throw AcceptanceFailure.unknown("missing Swift demangler: \(demangler.path)")
         }
@@ -636,6 +678,9 @@ private final class PreciseIdentifierModuleResolver {
     }
 
     func moduleName(in preciseIdentifier: String) throws -> String? {
+        if localIdentifiers.contains(preciseIdentifier) {
+            return localModule
+        }
         if let cached = cache[preciseIdentifier] {
             switch cached {
             case let .module(module):

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/CoreContractGuards.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/CoreContractGuards.swift
@@ -9,34 +9,122 @@ func compilerPublicAPIReport(
     contract: CoreGuardContract
 ) throws -> JSONObject {
     let scratch = paths.repository.appendingPathComponent(".build/swama-core-symbol-graph")
-    if FileManager.default.fileExists(atPath: scratch.path) {
-        for file in try regularFiles(in: scratch, extensions: ["json"])
+    let symbolGraphOutput = scratch.appendingPathComponent("symbolgraph")
+    if FileManager.default.fileExists(atPath: symbolGraphOutput.path) {
+        for file in try regularFiles(in: symbolGraphOutput, extensions: ["json"])
             where file.lastPathComponent.hasSuffix(".symbols.json")
         {
             try FileManager.default.removeItem(at: file)
         }
     }
+    else {
+        try FileManager.default.createDirectory(
+            at: symbolGraphOutput,
+            withIntermediateDirectories: true
+        )
+    }
 
     var environment = try developerEnvironment(developerDirectory)
     environment["SWIFTPM_MODULECACHE_OVERRIDE"] = scratch.appendingPathComponent("module-cache").path
-    let result = try runCommand(
-        symbolGraphCommand(package: paths.package, scratch: scratch),
+    let swift = developerDirectory.appendingPathComponent(
+        "Toolchains/XcodeDefault.xctoolchain/usr/bin/swift"
+    )
+    let extractor = developerDirectory.appendingPathComponent(
+        "Toolchains/XcodeDefault.xctoolchain/usr/bin/swift-symbolgraph-extract"
+    )
+    guard FileManager.default.isExecutableFile(atPath: swift.path),
+          FileManager.default.isExecutableFile(atPath: extractor.path)
+    else {
+        throw AcceptanceFailure.unknown("selected Xcode is missing Swift symbol-graph tools")
+    }
+
+    let buildResult = try runCommand(
+        symbolGraphBuildCommand(
+            package: paths.package,
+            scratch: scratch,
+            target: target,
+            swift: swift
+        ),
         currentDirectory: paths.repository,
         environment: environment,
         timeout: contract.compilerTimeoutSeconds,
         sampleMemory: false,
         timeoutFailureKind: .unknown,
-        timeoutContext: "SwamaCore symbol graph"
+        timeoutContext: "SwamaCore target build"
     )
-    guard result.returnCode == 0 else {
+    guard buildResult.returnCode == 0 else {
         throw AcceptanceFailure.failed(
-            "SwamaCore symbol graph build failed:\n\(commandFailureSummary(result))"
+            "SwamaCore target build failed:\n\(commandFailureSummary(buildResult))"
+        )
+    }
+
+    let binPathResult = try runCommand(
+        symbolGraphBinPathCommand(package: paths.package, scratch: scratch, swift: swift),
+        currentDirectory: paths.repository,
+        environment: environment,
+        timeout: 60,
+        sampleMemory: false,
+        timeoutFailureKind: .unknown,
+        timeoutContext: "SwamaCore build path"
+    )
+    guard binPathResult.returnCode == 0 else {
+        throw AcceptanceFailure.unknown(
+            "cannot locate SwamaCore build products:\n\(commandFailureSummary(binPathResult))"
+        )
+    }
+
+    let binPath = try strictAbsolutePath(binPathResult.stdout, context: "SwamaCore build path")
+    let modules = binPath.appendingPathComponent("Modules")
+    guard FileManager.default.fileExists(
+        atPath: modules.appendingPathComponent("\(target).swiftmodule").path
+    )
+    else {
+        throw AcceptanceFailure.unknown("SwamaCore build produced no target module")
+    }
+
+    let targetInfoResult = try runCommand(
+        [swift.path, "-print-target-info"],
+        currentDirectory: paths.repository,
+        environment: environment,
+        timeout: 60,
+        sampleMemory: false,
+        timeoutFailureKind: .unknown,
+        timeoutContext: "Swift target identity"
+    )
+    guard targetInfoResult.returnCode == 0 else {
+        throw AcceptanceFailure.unknown(
+            "cannot identify selected Swift target:\n\(commandFailureSummary(targetInfoResult))"
+        )
+    }
+
+    let targetTriple = try swiftTargetTriple(targetInfoResult.stdout)
+    let sdk = try URL(fileURLWithPath: environmentValue(environment, key: "SDKROOT"))
+
+    let extractResult = try runCommand(
+        symbolGraphExtractCommand(
+            extractor: extractor,
+            target: target,
+            targetTriple: targetTriple,
+            sdk: sdk,
+            modules: modules,
+            output: symbolGraphOutput
+        ),
+        currentDirectory: paths.repository,
+        environment: environment,
+        timeout: contract.compilerTimeoutSeconds,
+        sampleMemory: false,
+        timeoutFailureKind: .unknown,
+        timeoutContext: "SwamaCore symbol graph extraction"
+    )
+    guard extractResult.returnCode == 0 else {
+        throw AcceptanceFailure.failed(
+            "SwamaCore symbol graph extraction failed:\n\(commandFailureSummary(extractResult))"
         )
     }
 
     var graphs: [JSONObject] = []
     var graphFiles: [JSONObject] = []
-    for file in try regularFiles(in: scratch, extensions: ["json"])
+    for file in try regularFiles(in: symbolGraphOutput, extensions: ["json"])
         .filter({ $0.lastPathComponent.hasSuffix(".symbols.json") })
         .sorted(by: { $0.path < $1.path })
     {
@@ -47,7 +135,7 @@ func compilerPublicAPIReport(
 
         graphs.append(graph)
         try graphFiles.append([
-            "file": relativePathForGuard(file, to: scratch),
+            "file": relativePathForGuard(file, to: symbolGraphOutput),
             "sha256": sha256File(file)
         ])
     }
@@ -69,26 +157,114 @@ func compilerPublicAPIReport(
     report["symbol_graph_files"] = graphFiles
     report["reachability_attribute_hits"] = reachabilityHits
     report["passed"] = report["passed"] as? Bool == true && reachabilityHits.isEmpty
-    report["duration_ms"] = result.durationMilliseconds
+    report["duration_ms"] = buildResult.durationMilliseconds
+        + binPathResult.durationMilliseconds
+        + targetInfoResult.durationMilliseconds
+        + extractResult.durationMilliseconds
     return report
 }
 
-func symbolGraphCommand(package: URL, scratch: URL) -> [String] {
+func symbolGraphBuildCommand(
+    package: URL,
+    scratch: URL,
+    target: String,
+    swift: URL
+) -> [String] {
     [
-        "xcrun",
-        "swift",
-        "package",
+        swift.path,
+        "build",
         "--package-path",
         package.path,
         "--scratch-path",
         scratch.path,
         "--force-resolved-versions",
-        "dump-symbol-graph",
-        "--minimum-access-level",
-        "public",
-        "--skip-synthesized-members",
-        "--emit-extension-block-symbols"
+        "--target",
+        target
     ]
+}
+
+func symbolGraphBinPathCommand(package: URL, scratch: URL, swift: URL) -> [String] {
+    [
+        swift.path,
+        "build",
+        "--package-path",
+        package.path,
+        "--scratch-path",
+        scratch.path,
+        "--force-resolved-versions",
+        "--show-bin-path"
+    ]
+}
+
+func symbolGraphExtractCommand(
+    extractor: URL,
+    target: String,
+    targetTriple: String,
+    sdk: URL,
+    modules: URL,
+    output: URL
+) -> [String] {
+    [
+        extractor.path,
+        "-module-name",
+        target,
+        "-target",
+        targetTriple,
+        "-sdk",
+        sdk.path,
+        "-I",
+        modules.path,
+        "-minimum-access-level",
+        "public",
+        "-skip-synthesized-members",
+        "-emit-extension-block-symbols",
+        "-output-dir",
+        output.path
+    ]
+}
+
+func swiftTargetTriple(_ output: String) throws -> String {
+    let object: JSONObject
+    do {
+        guard let decoded = try JSONSerialization.jsonObject(with: Data(output.utf8)) as? JSONObject else {
+            throw AcceptanceFailure.unknown("Swift target identity root is not an object")
+        }
+
+        object = decoded
+    }
+    catch let error as AcceptanceFailure {
+        throw error
+    }
+    catch {
+        throw AcceptanceFailure.unknown("Swift target identity is invalid JSON: \(error)")
+    }
+
+    let triple = try object.object("target").string("triple")
+    guard !triple.isEmpty else {
+        throw AcceptanceFailure.unknown("Swift target identity has an empty triple")
+    }
+
+    return triple
+}
+
+private func strictAbsolutePath(_ output: String, context: String) throws -> URL {
+    let lines = output.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+    guard lines.count == 2,
+          lines[1].isEmpty,
+          lines[0].hasPrefix("/")
+    else {
+        throw AcceptanceFailure.unknown("\(context) emitted an unsupported path")
+    }
+
+    return URL(fileURLWithPath: lines[0]).standardizedFileURL
+}
+
+private func environmentValue(_ environment: [String: String], key: String) throws -> String {
+    guard let value = environment[key], !value.isEmpty else {
+        throw AcceptanceFailure.unknown("selected toolchain environment is missing \(key)")
+    }
+
+    return value
 }
 
 func analyzePublicAPISymbolGraphs(

--- a/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
+++ b/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
@@ -498,14 +498,21 @@ struct AcceptanceTests {
         #expect(extract.contains("public"))
         #expect(extract.contains("SwamaCore"))
 
-        #expect((try? swiftTargetTriple(#"{"target":{"triple":"arm64-apple-macosx15.4"}}"#))
+        let validTarget =
+            #"{"target":{"triple":"arm64-apple-macosx15.4","unversionedTriple":"arm64-apple-macosx","platform":"macosx","arch":"arm64"}}"#
+        #expect((try? swiftTargetTriple(validTarget))
             == "arm64-apple-macosx15.4"
         )
         for malformed in [
             "not-json",
             #"{"target":{}}"#,
-            #"{"target":{"triple":""}}"#,
-            #"{"target":{"triple":42}}"#
+            #"{"target":{"triple":"","unversionedTriple":"arm64-apple-macosx","platform":"macosx","arch":"arm64"}}"#,
+            #"{"target":{"triple":" arm64-apple-macosx15.4 ","unversionedTriple":"arm64-apple-macosx","platform":"macosx","arch":"arm64"}}"#,
+            #"{"target":{"triple":"arm64-apple15.4","unversionedTriple":"arm64-apple","platform":"macosx","arch":"arm64"}}"#,
+            #"{"target":{"triple":"arm64-apple-macosx15.4","unversionedTriple":"x86_64-apple-macosx","platform":"macosx","arch":"arm64"}}"#,
+            #"{"target":{"triple":"arm64-apple-ios15.4","unversionedTriple":"arm64-apple-ios","platform":"ios","arch":"arm64"}}"#,
+            #"{"target":{"triple":"mips-apple-macosx15.4","unversionedTriple":"mips-apple-macosx","platform":"macosx","arch":"mips"}}"#,
+            #"{"target":{"triple":42,"unversionedTriple":"arm64-apple-macosx","platform":"macosx","arch":"arm64"}}"#
         ] {
             #expect(throws: AcceptanceFailure.self) {
                 _ = try swiftTargetTriple(malformed)
@@ -519,6 +526,7 @@ struct AcceptanceTests {
             .appendingPathComponent("swama-target-symbol-graph-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: temporary) }
         let package = temporary.appendingPathComponent("swama")
+        let foreignPackage = temporary.appendingPathComponent("ForeignKit")
         try FileManager.default.createDirectory(
             at: package.appendingPathComponent("Sources/SwamaCore"),
             withIntermediateDirectories: true
@@ -526,6 +534,24 @@ struct AcceptanceTests {
         try FileManager.default.createDirectory(
             at: package.appendingPathComponent("Tests/BrokenTests"),
             withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: foreignPackage.appendingPathComponent("Sources/ForeignKit"),
+            withIntermediateDirectories: true
+        )
+        try Data("""
+        // swift-tools-version: 6.2
+        import PackageDescription
+
+        let package = Package(
+            name: "ForeignKit",
+            platforms: [.macOS("15.4")],
+            products: [.library(name: "ForeignKit", targets: ["ForeignKit"])],
+            targets: [.target(name: "ForeignKit")]
+        )
+        """.utf8).write(to: foreignPackage.appendingPathComponent("Package.swift"))
+        try Data("public struct ExternalType {}\n".utf8).write(
+            to: foreignPackage.appendingPathComponent("Sources/ForeignKit/ForeignKit.swift")
         )
         try Data("""
         // swift-tools-version: 6.2
@@ -535,13 +561,23 @@ struct AcceptanceTests {
             name: "TargetScopedGraph",
             platforms: [.macOS("15.4")],
             products: [.library(name: "SwamaCore", targets: ["SwamaCore"])],
+            dependencies: [.package(path: "../ForeignKit")],
             targets: [
-                .target(name: "SwamaCore"),
+                .target(
+                    name: "SwamaCore",
+                    dependencies: [.product(name: "ForeignKit", package: "ForeignKit")]
+                ),
                 .testTarget(name: "BrokenTests", dependencies: ["SwamaCore"])
             ]
         )
         """.utf8).write(to: package.appendingPathComponent("Package.swift"))
-        try Data("public struct CoreMarker: Sendable {}\n".utf8).write(
+        try Data("""
+        import ForeignKit
+
+        extension ExternalType {
+            public func leaked() {}
+        }
+        """.utf8).write(
             to: package.appendingPathComponent("Sources/SwamaCore/SwamaCore.swift")
         )
         try Data("let broken = MissingType()\n".utf8).write(
@@ -557,9 +593,11 @@ struct AcceptanceTests {
             developerDirectory: URL(fileURLWithPath: "/Applications/Xcode.app/Contents/Developer"),
             contract: contract.coreGuards
         )
-        #expect(try report.boolean("passed"))
-        #expect(try report.integer("graph_count") == 1)
-        #expect(try report.array("violations").isEmpty)
+        #expect(try report.boolean("passed") == false)
+        #expect(try report.integer("graph_count") == 2)
+        #expect(try report.array("violations").contains { value in
+            (value as? JSONObject)?["module"] as? String == "ForeignKit"
+        })
 
         let developerDirectory = URL(fileURLWithPath: "/Applications/Xcode.app/Contents/Developer")
         let swift = developerDirectory.appendingPathComponent(

--- a/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
+++ b/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
@@ -708,6 +708,35 @@ struct AcceptanceTests {
             "identifier": "swift.extension",
             "displayName": "Extension"
         ]
+        let extensionIdentifier = "s:e:s:10ForeignKit12ExternalTypeV9SwamaCoreE"
+        var publicExtensionSymbol = extensionWithoutTargetSymbol
+        publicExtensionSymbol["identifier"] = [
+            "precise": extensionIdentifier,
+            "interfaceLanguage": "swift"
+        ]
+        publicExtensionSymbol["declarationFragments"] = [
+            ["kind": "keyword", "spelling": "extension"],
+            ["kind": "text", "spelling": " ExternalType"]
+        ]
+        var internalExtensionSymbol = publicExtensionSymbol
+        internalExtensionSymbol["accessLevel"] = "internal"
+        var opaqueFragmentSymbol = validSymbol
+        opaqueFragmentSymbol["declarationFragments"] = [[
+            "kind": "typeIdentifier",
+            "spelling": "ExternalType",
+            "preciseIdentifier": extensionIdentifier
+        ]]
+        let publicMember = symbolGraphSymbol(
+            precise: "s:9SwamaCore11publicMemberyyF",
+            path: ["publicMember"],
+            declaration: [["kind": "identifier", "spelling": "publicMember"]]
+        )
+        let validExtensionTarget: JSONObject = [
+            "kind": "extensionTo",
+            "source": extensionIdentifier,
+            "target": "s:10ForeignKit12ExternalTypeV",
+            "targetFallback": "ForeignKit.ExternalType"
+        ]
         let malformedGraphs: [JSONObject] = [
             ["module": ["name": "SwamaCore"], "symbols": [42], "relationships": []],
             ["module": ["name": "SwamaCore"], "symbols": [validSymbol], "relationships": [42]],
@@ -726,6 +755,44 @@ struct AcceptanceTests {
             ["module": ["name": "SwamaCore"], "symbols": [unknownFragmentKindSymbol], "relationships": []],
             ["module": ["name": "SwamaCore"], "symbols": [unknownAccessSymbol], "relationships": []],
             ["module": ["name": "SwamaCore"], "symbols": [extensionWithoutTargetSymbol], "relationships": []],
+            [
+                "module": ["name": "SwamaCore"],
+                "symbols": [publicExtensionSymbol],
+                "relationships": [[
+                    "kind": "extensionTo",
+                    "source": extensionIdentifier,
+                    "target": extensionIdentifier
+                ]]
+            ],
+            [
+                "module": ["name": "SwamaCore"],
+                "symbols": [publicExtensionSymbol, opaqueFragmentSymbol],
+                "relationships": [validExtensionTarget]
+            ],
+            [
+                "module": ["name": "SwamaCore"],
+                "symbols": [publicExtensionSymbol, validSymbol],
+                "relationships": [
+                    validExtensionTarget,
+                    [
+                        "kind": "conformsTo",
+                        "source": "s:9SwamaCore7PayloadV",
+                        "target": extensionIdentifier
+                    ]
+                ]
+            ],
+            [
+                "module": ["name": "SwamaCore"],
+                "symbols": [internalExtensionSymbol, publicMember],
+                "relationships": [
+                    validExtensionTarget,
+                    [
+                        "kind": "memberOf",
+                        "source": "s:9SwamaCore11publicMemberyyF",
+                        "target": extensionIdentifier
+                    ]
+                ]
+            ],
             [
                 "module": ["name": "SwamaCore"],
                 "symbols": [validSymbol],

--- a/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
+++ b/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
@@ -474,13 +474,105 @@ struct AcceptanceTests {
     }
 
     @Test func compilerSymbolGraphIncludesExtensionBlocks() {
-        let command = symbolGraphCommand(
+        let swift = URL(fileURLWithPath: "/toolchain/swift")
+        let build = symbolGraphBuildCommand(
             package: URL(fileURLWithPath: "/package"),
-            scratch: URL(fileURLWithPath: "/scratch")
+            scratch: URL(fileURLWithPath: "/scratch"),
+            target: "SwamaCore",
+            swift: swift
         )
-        #expect(command.contains("--emit-extension-block-symbols"))
-        #expect(command.contains("--skip-synthesized-members"))
-        #expect(command.contains("public"))
+        #expect(build.contains("--target"))
+        #expect(build.contains("SwamaCore"))
+        #expect(!build.contains("dump-symbol-graph"))
+
+        let extract = symbolGraphExtractCommand(
+            extractor: URL(fileURLWithPath: "/toolchain/swift-symbolgraph-extract"),
+            target: "SwamaCore",
+            targetTriple: "arm64-apple-macosx15.4",
+            sdk: URL(fileURLWithPath: "/sdk"),
+            modules: URL(fileURLWithPath: "/modules"),
+            output: URL(fileURLWithPath: "/output")
+        )
+        #expect(extract.contains("-emit-extension-block-symbols"))
+        #expect(extract.contains("-skip-synthesized-members"))
+        #expect(extract.contains("public"))
+        #expect(extract.contains("SwamaCore"))
+
+        #expect((try? swiftTargetTriple(#"{"target":{"triple":"arm64-apple-macosx15.4"}}"#))
+            == "arm64-apple-macosx15.4"
+        )
+        for malformed in [
+            "not-json",
+            #"{"target":{}}"#,
+            #"{"target":{"triple":""}}"#,
+            #"{"target":{"triple":42}}"#
+        ] {
+            #expect(throws: AcceptanceFailure.self) {
+                _ = try swiftTargetTriple(malformed)
+            }
+        }
+    }
+
+    @Test func compilerSymbolGraphBuildIsScopedToTheCoreTarget() throws {
+        let temporary = FileManager.default
+            .temporaryDirectory
+            .appendingPathComponent("swama-target-symbol-graph-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: temporary) }
+        let package = temporary.appendingPathComponent("swama")
+        try FileManager.default.createDirectory(
+            at: package.appendingPathComponent("Sources/SwamaCore"),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: package.appendingPathComponent("Tests/BrokenTests"),
+            withIntermediateDirectories: true
+        )
+        try Data("""
+        // swift-tools-version: 6.2
+        import PackageDescription
+
+        let package = Package(
+            name: "TargetScopedGraph",
+            platforms: [.macOS("15.4")],
+            products: [.library(name: "SwamaCore", targets: ["SwamaCore"])],
+            targets: [
+                .target(name: "SwamaCore"),
+                .testTarget(name: "BrokenTests", dependencies: ["SwamaCore"])
+            ]
+        )
+        """.utf8).write(to: package.appendingPathComponent("Package.swift"))
+        try Data("public struct CoreMarker: Sendable {}\n".utf8).write(
+            to: package.appendingPathComponent("Sources/SwamaCore/SwamaCore.swift")
+        )
+        try Data("let broken = MissingType()\n".utf8).write(
+            to: package.appendingPathComponent("Tests/BrokenTests/BrokenTests.swift")
+        )
+
+        let contract = try AcceptanceContract.load(
+            from: repositoryRoot.appendingPathComponent("Tools/SwamaAcceptance/contract.json")
+        )
+        let report = try compilerPublicAPIReport(
+            target: "SwamaCore",
+            paths: WorkspacePaths(repository: temporary),
+            developerDirectory: URL(fileURLWithPath: "/Applications/Xcode.app/Contents/Developer"),
+            contract: contract.coreGuards
+        )
+        #expect(try report.boolean("passed"))
+        #expect(try report.integer("graph_count") == 1)
+        #expect(try report.array("violations").isEmpty)
+
+        let developerDirectory = URL(fileURLWithPath: "/Applications/Xcode.app/Contents/Developer")
+        let swift = developerDirectory.appendingPathComponent(
+            "Toolchains/XcodeDefault.xctoolchain/usr/bin/swift"
+        )
+        let brokenTestBuild = try runCommand(
+            [swift.path, "test", "--package-path", package.path],
+            currentDirectory: package,
+            environment: developerEnvironment(developerDirectory),
+            timeout: 60,
+            sampleMemory: false
+        )
+        #expect(brokenTestBuild.returnCode != 0)
     }
 
     @Test func compilerPublicAPIGateRejectsMalformedSymbolGraphEntries() throws {

--- a/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
+++ b/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
@@ -471,6 +471,29 @@ struct AcceptanceTests {
             "Payload"
         ])
         #expect((report["manifest_sha256"] as? String)?.count == 64)
+
+        let contradictoryPrecise = "s:11MLXLMCommon14ModelContainerC"
+        let contradictoryReport = try analyzePublicAPISymbolGraphs(
+            [[
+                "module": ["name": "SwamaCore"],
+                "symbols": [
+                    symbolGraphSymbol(
+                        precise: contradictoryPrecise,
+                        path: ["ContradictoryContainer"],
+                        declaration: [
+                            typeFragment("ModelContainer", precise: contradictoryPrecise)
+                        ]
+                    )
+                ],
+                "relationships": []
+            ]],
+            target: "SwamaCore",
+            allowedModules: ["Swift", "Foundation", "SwamaCore"]
+        )
+        #expect(try contradictoryReport.boolean("passed") == false)
+        #expect(try contradictoryReport.array("violations").contains { value in
+            (value as? JSONObject)?["module"] as? String == "MLXLMCommon"
+        })
     }
 
     @Test func compilerSymbolGraphIncludesExtensionBlocks() {
@@ -596,7 +619,12 @@ struct AcceptanceTests {
         #expect(try report.boolean("passed") == false)
         #expect(try report.integer("graph_count") == 2)
         #expect(try report.array("violations").contains { value in
-            (value as? JSONObject)?["module"] as? String == "ForeignKit"
+            guard let violation = value as? JSONObject else {
+                return false
+            }
+
+            return violation["module"] as? String == "ForeignKit"
+                && violation["source"] as? String == "extensionTo"
         })
 
         let developerDirectory = URL(fileURLWithPath: "/Applications/Xcode.app/Contents/Developer")
@@ -671,6 +699,15 @@ struct AcceptanceTests {
         ]]
         var unknownAccessSymbol = validSymbol
         unknownAccessSymbol["accessLevel"] = "futurePublic"
+        var extensionWithoutTargetSymbol = validSymbol
+        extensionWithoutTargetSymbol["identifier"] = [
+            "precise": "s:e:s:10ForeignKit12ExternalTypeV9SwamaCoreE",
+            "interfaceLanguage": "swift"
+        ]
+        extensionWithoutTargetSymbol["kind"] = [
+            "identifier": "swift.extension",
+            "displayName": "Extension"
+        ]
         let malformedGraphs: [JSONObject] = [
             ["module": ["name": "SwamaCore"], "symbols": [42], "relationships": []],
             ["module": ["name": "SwamaCore"], "symbols": [validSymbol], "relationships": [42]],
@@ -688,6 +725,7 @@ struct AcceptanceTests {
             ["module": ["name": "SwamaCore"], "symbols": [concatenatedPreciseSymbol], "relationships": []],
             ["module": ["name": "SwamaCore"], "symbols": [unknownFragmentKindSymbol], "relationships": []],
             ["module": ["name": "SwamaCore"], "symbols": [unknownAccessSymbol], "relationships": []],
+            ["module": ["name": "SwamaCore"], "symbols": [extensionWithoutTargetSymbol], "relationships": []],
             [
                 "module": ["name": "SwamaCore"],
                 "symbols": [validSymbol],


### PR DESCRIPTION
## Summary

- build only the requested `SwamaCore` target before public API inspection
- invoke the selected Xcode's `swift-symbolgraph-extract` directly against that module instead of dumping every package and test module
- bind the build product path, SDK, architecture, platform, and versioned target triple through strict machine-output validation
- treat compiler extension-block identities as local only for public/open `memberOf` relationships; all other identities still pass through the selected demangler

This is an acceptance-only hotfix. It changes no production source, product target, public API, concurrency, or runtime behavior.

## Why

The first real additive `SwamaCore` target exposed that `swift package dump-symbol-graph` scans synthesized package-test modules too. A broken or unloaded neighboring test module could prevent the Core graph from being produced at all. The target-scoped path isolates the public API oracle without hiding public extensions or upstream type leaks.

## Verification

- `swift test --package-path Tools/SwamaAcceptance`: 42/42
- stable Swift 6.3 release build: pass
- target-scoped integration: valid Core plus intentionally uncompilable test target still produces the Core graph; whole-package test build is confirmed red
- real external-type extension produces a `ForeignKit` violation through `extensionTo`
- malformed target-info, contradictory graph identities, internal/self/fragment/conformance extension identities all fail closed
- Cindy second-machine custody: GO, baseline `dbc30dbf`
- Miyabi final exact-bound review: GO, 0 findings

Reviewed exact: `be287f0ad626aadf6a30735106ab24f2731d4d1a`.
