### PR TITLE
Add the additive SwamaCore target shell

### DIFF
--- a/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
+++ b/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
@@ -995,7 +995,7 @@ struct AcceptanceTests {
         #expect(concatenatedModules == [nil])
     }
 
-    @Test func coreBoundaryReportsCompilerOracleAsUnmetWhenTargetIsAbsent() throws {
+    @Test func coreBoundaryTurnsGreenWhenTheDependencyFreeTargetExists() throws {
         let paths = try WorkspacePaths.discover(explicit: repositoryRoot.path)
         let contract = try AcceptanceContract.load(from: paths.contract)
         let report = try architectureReport(
@@ -1005,10 +1005,24 @@ struct AcceptanceTests {
             paths: paths
         )
 
-        #expect(report["passed"] as? Bool == false)
+        #expect(try report.boolean("passed"))
+        #expect(try report.boolean("core_target_present"))
         let compiler = try report.object("compiler_public_api")
-        #expect(try compiler.string("status") == "unmet")
-        #expect(try compiler.boolean("passed") == false)
+        #expect(try compiler.string("status") == "ready")
+        #expect(try compiler.boolean("passed"))
+        #expect(try compiler.array("violations").isEmpty)
+        let dependencies = try report.object("core_target_dependencies")
+        #expect(try dependencies.string("status") == "ready")
+        #expect(try dependencies.boolean("passed"))
+
+        let consumerReport = try architectureReport(
+            contract: contract.architecture,
+            coreGuards: contract.coreGuards,
+            stage: .consumerBoundary,
+            paths: paths
+        )
+        #expect(try consumerReport.boolean("passed") == false)
+        #expect(try consumerReport.object("external_consumer_boundary").boolean("passed") == false)
     }
 
     @Test func consumerBoundaryNamesEveryCurrentMLXDependencyAndImport() throws {

--- a/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
+++ b/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
@@ -1010,7 +1010,12 @@ struct AcceptanceTests {
         let compiler = try report.object("compiler_public_api")
         #expect(try compiler.string("status") == "ready")
         #expect(try compiler.boolean("passed"))
+        #expect(try compiler.integer("symbol_count") == 0)
+        #expect(try compiler.array("symbols").isEmpty)
         #expect(try compiler.array("violations").isEmpty)
+        #expect(try compiler.string("manifest_sha256")
+            == "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
+        )
         let dependencies = try report.object("core_target_dependencies")
         #expect(try dependencies.string("status") == "ready")
         #expect(try dependencies.boolean("passed"))

--- a/swama/Package.swift
+++ b/swama/Package.swift
@@ -8,6 +8,10 @@ let package = Package(
     ],
     products: [
         .library(
+            name: "SwamaCore",
+            targets: ["SwamaCore"]
+        ),
+        .library(
             name: "SwamaKit",
             targets: ["SwamaKit"]
         ),
@@ -40,6 +44,10 @@ let package = Package(
         ),
     ],
     targets: [
+        .target(
+            name: "SwamaCore",
+            path: "Sources/SwamaCore"
+        ),
         .target(
             name: "SwamaKit",
             dependencies: [

--- a/swama/Sources/SwamaCore/SwamaCore.swift
+++ b/swama/Sources/SwamaCore/SwamaCore.swift
@@ -1,0 +1,1 @@
+enum SwamaCoreModule {}


### PR DESCRIPTION
## Summary

- add a `SwamaCore` library product
- add a dependency-free `SwamaCore` target with an internal-only module shell
- turn the staged Core boundary from explicitly unmet to green while leaving the external-consumer boundary red until the public API migration
- freeze the empty compiler-derived public surface as the baseline for the next public-API PR

This is an additive topology change only. It does not change `SwamaKit`, server, app, CLI, behavior, concurrency, cancellation, or legacy public API, and it does not migrate the external fixture yet.

## Verification

- Core compiler report: ready/passed, `symbol_count=0`, no violations/reachability, manifest `4f53cda1…`
- Core target graph: library product maps only to the same-name zero-dependency target; no transitive MLX Audio
- Core boundary: green; consumer boundary: still intentionally red
- acceptance harness: 42/42
- product stable release build: pass
- product tests: 171/171 with a freshly compiled/co-located current MLX metallib (the known #130 packaging gap remains intentionally unresolved here)
- removing the product or target turns the gate red; making the internal shell public turns three frozen-public-surface checks red
- Cindy second-machine architecture custody: GO, baseline `fa1c431c`
- Miyabi final exact-bound review: GO, 0 findings

Reviewed exact: `fd5e0aefd050f46cf80bf8ae635204e1a37e6d9f`.
