### PR TITLE
Add package-only no-Audio SwamaRuntime

### DIFF
--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/CoreContractGuards.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/CoreContractGuards.swift
@@ -1191,6 +1191,29 @@ func analyzeResolvedTargetDependencyGraph(
         && libraryProductTargets == [target]
         && rootTargets[target] != nil
 
+    var directTargets: [String] = []
+    var directProducts: [String] = []
+    var directByName: [String] = []
+    if let rootTarget = rootTargets[target] {
+        let traits = activeTraits?[rootIdentity] ?? ["default"]
+        for dependency in try targetDependencyDescriptors(rootTarget) {
+            guard try dependency.isActive(platform: "macos", traits: traits) else {
+                continue
+            }
+
+            switch dependency.kind {
+            case "target":
+                directTargets.append("\(rootIdentity):\(dependency.name)")
+            case "product":
+                directProducts.append("\(dependency.package ?? "<implicit>"):\(dependency.name)")
+            case "byName":
+                directByName.append(dependency.name)
+            default:
+                throw AcceptanceFailure.unknown("resolved direct target dependency kind is unsupported")
+            }
+        }
+    }
+
     var queue = [ResolvedTarget(package: rootIdentity, name: target)]
     var visitedTargets: Set<ResolvedTarget> = []
     var visitedProducts: Set<ResolvedProduct> = []
@@ -1291,6 +1314,9 @@ func analyzeResolvedTargetDependencyGraph(
         "root_package": rootIdentity,
         "library_product_present": libraryProductPresent,
         "library_product_targets": libraryProductTargets,
+        "direct_target_dependencies": directTargets.sorted(),
+        "direct_product_dependencies": directProducts.sorted(),
+        "direct_by_name_dependencies": directByName.sorted(),
         "target_dependencies": visitedTargets.map(\.description).sorted(),
         "product_dependencies": visitedProducts.map(\.description).sorted(),
         "forbidden_products": forbidden,

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/CoreContractGuards.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/CoreContractGuards.swift
@@ -99,6 +99,10 @@ func compilerPublicAPIReport(
 
     let targetTriple = try swiftTargetTriple(targetInfoResult.stdout)
     let sdk = try URL(fileURLWithPath: environmentValue(environment, key: "SDKROOT"))
+    let clangArguments = try symbolGraphClangArguments(
+        description: binPath.appendingPathComponent("description.json"),
+        target: target
+    )
 
     let extractResult = try runCommand(
         symbolGraphExtractCommand(
@@ -107,7 +111,8 @@ func compilerPublicAPIReport(
             targetTriple: targetTriple,
             sdk: sdk,
             modules: modules,
-            output: symbolGraphOutput
+            output: symbolGraphOutput,
+            clangArguments: clangArguments
         ),
         currentDirectory: paths.repository,
         environment: environment,
@@ -202,7 +207,8 @@ func symbolGraphExtractCommand(
     targetTriple: String,
     sdk: URL,
     modules: URL,
-    output: URL
+    output: URL,
+    clangArguments: [String] = []
 ) -> [String] {
     [
         extractor.path,
@@ -220,7 +226,47 @@ func symbolGraphExtractCommand(
         "-emit-extension-block-symbols",
         "-output-dir",
         output.path
-    ]
+    ] + clangArguments
+}
+
+func symbolGraphClangArguments(description: URL, target: String) throws -> [String] {
+    let root = try loadJSONObject(description)
+    let commands = try root.object("swiftCommands")
+    let matches = try commands.values.compactMap { raw -> JSONObject? in
+        guard let command = raw as? JSONObject else {
+            throw AcceptanceFailure.unknown("Swift build description command is not an object")
+        }
+
+        return try command.string("moduleName") == target ? command : nil
+    }
+    guard matches.count == 1, let command = matches.first else {
+        throw AcceptanceFailure.unknown("Swift build description has no unique command for \(target)")
+    }
+
+    let arguments = try command.array("otherArguments")
+    var result: [String] = []
+    var index = 0
+    while index < arguments.count {
+        guard let argument = arguments[index] as? String else {
+            throw AcceptanceFailure.unknown("Swift build description has a non-string argument")
+        }
+
+        if argument == "-Xcc" {
+            guard index + 1 < arguments.count,
+                  let clangArgument = arguments[index + 1] as? String,
+                  !clangArgument.isEmpty
+            else {
+                throw AcceptanceFailure.unknown("Swift build description has a truncated -Xcc argument")
+            }
+
+            result.append(contentsOf: [argument, clangArgument])
+            index += 2
+        }
+        else {
+            index += 1
+        }
+    }
+    return result
 }
 
 func swiftTargetTriple(_ output: String) throws -> String {
@@ -1162,6 +1208,22 @@ func analyzeResolvedTargetDependencyGraph(
         guard let targetDescription = targets[node.name] else {
             unresolved.insert("missing target \(node.package):\(node.name)")
             continue
+        }
+
+        // Macro and plugin targets execute in the host toolchain while building; their own
+        // dependencies do not enter the linked runtime closure being audited here. Some Swift
+        // versions consequently omit those host-only packages from `show-dependencies`, even
+        // though `dump-package` still describes their target edges.
+        if let rawType = targetDescription["type"] {
+            guard let targetType = rawType as? String, !targetType.isEmpty else {
+                throw AcceptanceFailure.unknown(
+                    "resolved target type is invalid: \(node.package):\(node.name)"
+                )
+            }
+
+            if targetType == "macro" || targetType == "plugin" {
+                continue
+            }
         }
 
         let aliases = aliasesByPackage[node.package] ?? [:]

--- a/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
+++ b/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
@@ -1240,6 +1240,9 @@ struct AcceptanceTests {
         #expect(try core.boolean("passed"))
         #expect(try core.array("forbidden_products").isEmpty)
         #expect(try core.array("unresolved_dependencies").isEmpty)
+        #expect(try core.array("direct_target_dependencies") as? [String] == ["swama:SwamaRuntime"])
+        #expect(try core.array("direct_product_dependencies").isEmpty)
+        #expect(try core.array("direct_by_name_dependencies").isEmpty)
         #expect(try Set(core.array("target_dependencies").compactMap { $0 as? String }).isSuperset(of: [
             "swama:SwamaCore",
             "swama:SwamaRuntime"

--- a/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
+++ b/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
@@ -1213,6 +1213,60 @@ struct AcceptanceTests {
         #expect(try report.object("resolved_package_traits").array("swama") as? [String] == ["default"])
     }
 
+    @Test func runtimeAndCoreResolvedClosuresContainNoAudioProducts() throws {
+        let paths = try WorkspacePaths.discover(explicit: repositoryRoot.path)
+        let contract = try AcceptanceContract.load(from: paths.contract).coreGuards
+        let developerDirectory = URL(fileURLWithPath: "/Applications/Xcode.app/Contents/Developer")
+
+        let runtime = try coreTargetDependencyReport(
+            target: "SwamaRuntime",
+            paths: paths,
+            developerDirectory: developerDirectory,
+            contract: contract
+        )
+        #expect(try runtime.boolean("library_product_present") == false)
+        #expect(try runtime.array("forbidden_products").isEmpty)
+        #expect(try runtime.array("unresolved_dependencies").isEmpty)
+        #expect(try Set(runtime.array("target_dependencies").compactMap { $0 as? String })
+            .contains("swama:SwamaRuntime")
+        )
+
+        let core = try coreTargetDependencyReport(
+            target: "SwamaCore",
+            paths: paths,
+            developerDirectory: developerDirectory,
+            contract: contract
+        )
+        #expect(try core.boolean("passed"))
+        #expect(try core.array("forbidden_products").isEmpty)
+        #expect(try core.array("unresolved_dependencies").isEmpty)
+        #expect(try Set(core.array("target_dependencies").compactMap { $0 as? String }).isSuperset(of: [
+            "swama:SwamaCore",
+            "swama:SwamaRuntime"
+        ]))
+    }
+
+    @Test func runtimeAndCoreCompilerPublicManifestsStayEmpty() throws {
+        let paths = try WorkspacePaths.discover(explicit: repositoryRoot.path)
+        let contract = try AcceptanceContract.load(from: paths.contract).coreGuards
+        let developerDirectory = URL(fileURLWithPath: "/Applications/Xcode.app/Contents/Developer")
+
+        for target in ["SwamaRuntime", "SwamaCore"] {
+            let report = try compilerPublicAPIReport(
+                target: target,
+                paths: paths,
+                developerDirectory: developerDirectory,
+                contract: contract
+            )
+            #expect(try report.boolean("passed"), "\(target) public API guard failed")
+            #expect(try report.integer("symbol_count") == 0)
+            #expect(try report.array("symbols").isEmpty)
+            #expect(try report
+                .string("manifest_sha256") == "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
+            )
+        }
+    }
+
     @Test func targetDependencyGraphRejectsAMissingLibraryProduct() throws {
         let missingProduct: [String: JSONObject] = [
             "swama": [
@@ -1283,6 +1337,63 @@ struct AcceptanceTests {
         #expect(try report.boolean("passed") == false)
         #expect(try report.array("unresolved_dependencies") as? [String] == [
             "unresolved product swama:HiddenProduct"
+        ])
+    }
+
+    @Test func targetDependencyGraphExcludesHostOnlyMacroDependenciesFromRuntimeClosure() throws {
+        var manifests: [String: JSONObject] = [
+            "swama": [
+                "dependencies": [],
+                "products": [[
+                    "name": "SwamaCore",
+                    "targets": ["SwamaCore"],
+                    "type": ["library": ["automatic"]]
+                ]],
+                "targets": [[
+                    "name": "SwamaCore",
+                    "dependencies": [["product": ["Macros", "tools", NSNull(), NSNull()]]]
+                ]]
+            ],
+            "tools": [
+                "dependencies": [],
+                "products": [[
+                    "name": "Macros",
+                    "targets": ["MacroImpl"],
+                    "type": ["library": ["automatic"]]
+                ]],
+                "targets": [[
+                    "name": "MacroImpl",
+                    "type": "macro",
+                    "dependencies": [[
+                        "product": ["SwiftSyntaxMacros", "swift-syntax", NSNull(), NSNull()]
+                    ]]
+                ]]
+            ]
+        ]
+        let aliases = ["swama": ["tools": "tools"]]
+        let report = try analyzeResolvedTargetDependencyGraph(
+            rootIdentity: "swama",
+            manifests: manifests,
+            packageAliases: aliases,
+            target: "SwamaCore",
+            forbiddenProducts: ["MLXAudioCore", "MLXAudioSTT", "MLXAudioTTS"]
+        )
+        #expect(try report.boolean("passed"))
+        #expect(try report.array("unresolved_dependencies").isEmpty)
+
+        var macroTarget = try #require((manifests["tools"]?["targets"] as? [JSONObject])?.first)
+        macroTarget["type"] = "regular"
+        manifests["tools"]?["targets"] = [macroTarget]
+        let regularReport = try analyzeResolvedTargetDependencyGraph(
+            rootIdentity: "swama",
+            manifests: manifests,
+            packageAliases: aliases,
+            target: "SwamaCore",
+            forbiddenProducts: ["MLXAudioCore", "MLXAudioSTT", "MLXAudioTTS"]
+        )
+        #expect(try regularReport.boolean("passed") == false)
+        #expect(try regularReport.array("unresolved_dependencies") as? [String] == [
+            "unresolved product tools:SwiftSyntaxMacros"
         ])
     }
 

--- a/swama/Package.swift
+++ b/swama/Package.swift
@@ -31,6 +31,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
+        .package(url: "https://github.com/huggingface/swift-transformers.git", from: "1.3.3"),
         // Last revision before FoundationModelsIntegration became a default trait;
         // newer commits require a newer Xcode 27 FoundationModels SDK.
         .package(
@@ -46,7 +47,26 @@ let package = Package(
     targets: [
         .target(
             name: "SwamaCore",
+            dependencies: [
+                .target(name: "SwamaRuntime"),
+            ],
             path: "Sources/SwamaCore"
+        ),
+        // Transitional package-only no-Audio runtime. SwamaKit remains byte-stable through v2;
+        // this derived implementation is lineage-gated and is removed with the v3 migration.
+        .target(
+            name: "SwamaRuntime",
+            dependencies: [
+                .product(name: "MLXLLM", package: "mlx-swift-lm"),
+                .product(name: "MLXVLM", package: "mlx-swift-lm"),
+                .product(name: "MLXLMCommon", package: "mlx-swift-lm"),
+                .product(name: "MLXEmbedders", package: "mlx-swift-lm"),
+                .product(name: "MLXHuggingFace", package: "mlx-swift-lm"),
+                .product(name: "MLXRandom", package: "mlx-swift"),
+                .product(name: "MLXFast", package: "mlx-swift"),
+                .product(name: "Tokenizers", package: "swift-transformers"),
+            ],
+            path: "Sources/SwamaRuntime"
         ),
         .target(
             name: "SwamaKit",
@@ -102,6 +122,15 @@ let package = Package(
                 "SwamaKit",
                 "SwamaServer",
                 .product(name: "NIOEmbedded", package: "swift-nio"),
+            ]
+        ),
+        .testTarget(
+            name: "SwamaRuntimeTests",
+            dependencies: [
+                "SwamaRuntime",
+                "SwamaKit",
+                .product(name: "MLXEmbedders", package: "mlx-swift-lm"),
+                .product(name: "MLXNN", package: "mlx-swift"),
             ]
         ),
     ]

--- a/swama/Sources/SwamaRuntime/Config/ContextLimitConfig.swift
+++ b/swama/Sources/SwamaRuntime/Config/ContextLimitConfig.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// Shared configuration for context window limits.
+/// Defaults to 16_384 tokens unless overridden by the SWAMA_CONTEXT_LIMIT environment variable
+/// or updated at runtime (CLI flag / macOS UI).
+package actor ContextLimitConfig {
+    package static let shared: ContextLimitConfig = .init()
+
+    package enum Constants {
+        package static let defaultLimit = 16384
+    }
+
+    private var limit: Int
+
+    private init() {
+        if let envValue = ProcessInfo.processInfo.environment["SWAMA_CONTEXT_LIMIT"],
+           let parsed = Int(envValue),
+           parsed > 0
+        {
+            limit = parsed
+        }
+        else {
+            limit = Constants.defaultLimit
+        }
+    }
+
+    /// Returns the current context limit (tokens for the prompt).
+    package func currentLimit() -> Int {
+        limit
+    }
+
+    /// Updates the context limit. Values <= 0 are ignored.
+    package func updateLimit(_ newValue: Int) {
+        guard newValue > 0 else {
+            return
+        }
+
+        limit = newValue
+    }
+}

--- a/swama/Sources/SwamaRuntime/Config/ContextLimitError.swift
+++ b/swama/Sources/SwamaRuntime/Config/ContextLimitError.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+package enum ContextLimitError: Error, LocalizedError {
+    case exceededAfterTrimming(limit: Int, promptTokens: Int)
+
+    package var errorDescription: String? {
+        switch self {
+        case let .exceededAfterTrimming(limit, promptTokens):
+            "Prompt still exceeds context limit (\(promptTokens) > \(limit)) after trimming."
+        }
+    }
+}

--- a/swama/Sources/SwamaRuntime/Config/PromptCacheConfig.swift
+++ b/swama/Sources/SwamaRuntime/Config/PromptCacheConfig.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Whether the OpenAI-compatible chat path reuses KV-cache state between requests on the same
+/// model (longest-common-prefix restore against `PromptCacheStore`, suffix-only prefill).
+///
+/// On by default. Set `SWAMA_PROMPT_CACHE=0` to force every request through the uncached
+/// full-prefill path -- an escape hatch for A/B latency comparisons, or to rule out a
+/// cache-related issue in the field without a redeploy. The environment is re-read on every
+/// access (rather than cached once at process start) so the switch can be toggled within a
+/// single process, which is also what lets it be exercised directly in tests; the cost is one
+/// dictionary lookup per chat request, not per token.
+package enum PromptCacheConfig {
+    package static var isEnabled: Bool {
+        ProcessInfo.processInfo.environment["SWAMA_PROMPT_CACHE"] != "0"
+    }
+}

--- a/swama/Sources/SwamaRuntime/Diagnostics/DiagnosticTokenizerLoader.swift
+++ b/swama/Sources/SwamaRuntime/Diagnostics/DiagnosticTokenizerLoader.swift
@@ -1,0 +1,59 @@
+import Foundation
+import MLXLMCommon
+
+// MARK: - ModelLoadPhaseRecorder
+
+final class ModelLoadPhaseRecorder: @unchecked Sendable {
+    var phases: SwamaModelLoadPhases {
+        lock.withLock {
+            .init(tokenizerMs: tokenizerMilliseconds)
+        }
+    }
+
+    func recordTokenizer(milliseconds: Double) {
+        lock.withLock {
+            tokenizerMilliseconds = milliseconds
+        }
+    }
+
+    private let lock: NSLock = .init()
+    private var tokenizerMilliseconds: Double?
+}
+
+// MARK: - DiagnosticTokenizerLoader
+
+struct DiagnosticTokenizerLoader: TokenizerLoader {
+    let upstream: any TokenizerLoader
+    let phases: ModelLoadPhaseRecorder
+    let cache: TokenizerCache
+    let owner: TokenizerCacheOwner
+
+    init(
+        upstream: any TokenizerLoader,
+        phases: ModelLoadPhaseRecorder,
+        cache: TokenizerCache = .shared,
+        owner: TokenizerCacheOwner = .standalone
+    ) {
+        self.upstream = upstream
+        self.phases = phases
+        self.cache = cache
+        self.owner = owner
+    }
+
+    func load(from directory: URL) async throws -> any Tokenizer {
+        let startedAt = DispatchTime.now().uptimeNanoseconds
+        do {
+            let tokenizer = try await cache.load(from: directory, using: upstream, owner: owner)
+            phases.recordTokenizer(milliseconds: elapsedMilliseconds(since: startedAt))
+            return tokenizer
+        }
+        catch {
+            phases.recordTokenizer(milliseconds: elapsedMilliseconds(since: startedAt))
+            throw error
+        }
+    }
+
+    private func elapsedMilliseconds(since startedAt: UInt64) -> Double {
+        Double(DispatchTime.now().uptimeNanoseconds - startedAt) / 1_000_000
+    }
+}

--- a/swama/Sources/SwamaRuntime/Diagnostics/SwamaDiagnostics.swift
+++ b/swama/Sources/SwamaRuntime/Diagnostics/SwamaDiagnostics.swift
@@ -1,0 +1,1468 @@
+import CryptoKit
+import Darwin
+import Foundation
+
+private let maximumDiagnosticModelIdentityBytes = 256
+private let maximumDiagnosticModelIdentityComponentBytes = 96
+
+private func requiresOpaqueDiagnosticModelIdentity(_ value: String) -> Bool {
+    guard value.utf8.count <= maximumDiagnosticModelIdentityBytes else {
+        return true
+    }
+
+    if value.hasPrefix("local:") {
+        let digest = value.dropFirst("local:".count)
+        return digest.count != 64 || !digest.unicodeScalars.allSatisfy { scalar in
+            (0x30 ... 0x39).contains(scalar.value) || (0x61 ... 0x66).contains(scalar.value)
+        }
+    }
+
+    let components = value.split(separator: "/", omittingEmptySubsequences: false)
+    guard (1 ... 2).contains(components.count) else {
+        return true
+    }
+
+    return !components.allSatisfy { component in
+        guard !component.isEmpty,
+              component.utf8.count <= maximumDiagnosticModelIdentityComponentBytes,
+              let first = component.unicodeScalars.first,
+              let last = component.unicodeScalars.last,
+              isASCIIAlphanumeric(first),
+              isASCIIAlphanumeric(last)
+        else {
+            return false
+        }
+
+        return component.unicodeScalars.allSatisfy { scalar in
+            isASCIIAlphanumeric(scalar) || scalar.value == 0x2D || scalar.value == 0x2E || scalar.value == 0x5F
+        }
+    }
+}
+
+private func isASCIIAlphanumeric(_ scalar: Unicode.Scalar) -> Bool {
+    (0x30 ... 0x39).contains(scalar.value)
+        || (0x41 ... 0x5A).contains(scalar.value)
+        || (0x61 ... 0x7A).contains(scalar.value)
+}
+
+// MARK: - SwamaDiagnosticMode
+
+package enum SwamaDiagnosticMode: String, Codable, Sendable {
+    case app
+    case serve
+    case cli
+}
+
+// MARK: - SwamaDiagnosticOutcome
+
+package enum SwamaDiagnosticOutcome: String, Codable, Sendable {
+    case ok
+    case error
+    case cancelled
+}
+
+// MARK: - SwamaDiagnosticErrorCode
+
+package enum SwamaDiagnosticErrorCode: String, Codable, Sendable {
+    case sessionFailed = "session_failed"
+    case modelNotFound = "model_not_found"
+    case modelLoadFailed = "model_load_failed"
+    case tokenizerRejected = "tokenizer_rejected"
+    case evictionFailed = "eviction_failed"
+    case generationFailed = "generation_failed"
+}
+
+// MARK: - SwamaDiagnosticError
+
+package struct SwamaDiagnosticError: Codable, Equatable, Sendable {
+    package let code: SwamaDiagnosticErrorCode
+    package let transient: Bool
+}
+
+// MARK: - SwamaModelLoadPhases
+
+/// Timings exposed by the current upstream loader. A `nil` field means the upstream package API
+/// does not expose that boundary; it must never be serialized as a fabricated zero.
+package struct SwamaModelLoadPhases: Codable, Equatable, Sendable {
+    package let configReadMs: Double?
+    package let configDecodeMs: Double?
+    package let modelGraphMs: Double?
+    package let tokenizerMs: Double?
+    package let weightsMs: Double?
+
+    package init(
+        configReadMs: Double? = nil,
+        configDecodeMs: Double? = nil,
+        modelGraphMs: Double? = nil,
+        tokenizerMs: Double? = nil,
+        weightsMs: Double? = nil
+    ) {
+        self.configReadMs = configReadMs
+        self.configDecodeMs = configDecodeMs
+        self.modelGraphMs = modelGraphMs
+        self.tokenizerMs = tokenizerMs
+        self.weightsMs = weightsMs
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case configReadMs = "config_read"
+        case configDecodeMs = "config_decode"
+        case modelGraphMs = "model_graph"
+        case tokenizerMs = "tokenizer"
+        case weightsMs = "weights"
+    }
+}
+
+// MARK: - SwamaDiagnosticOperation
+
+package struct SwamaDiagnosticOperation: Equatable, Sendable {
+    fileprivate let id: UUID
+    fileprivate let startedAtNanoseconds: UInt64
+    fileprivate let isActive: Bool
+
+    package var identifier: String { id.uuidString.lowercased() }
+
+    fileprivate func elapsedMilliseconds(nowNanoseconds: UInt64 = DispatchTime.now().uptimeNanoseconds) -> Double {
+        Double(nowNanoseconds - startedAtNanoseconds) / 1_000_000
+    }
+}
+
+// MARK: - SwamaDiagnosticEventName
+
+enum SwamaDiagnosticEventName: String, Codable, CaseIterable, Sendable {
+    case sessionStarted = "swama.session.started"
+    case sessionStopped = "swama.session.stopped"
+    case modelLoadStarted = "model.load.started"
+    case modelLoadCompleted = "model.load.completed"
+    case modelLoadCancelled = "model.load.cancelled"
+    case modelLoadFailed = "model.load.failed"
+    case tokenizerCacheHit = "tokenizer.cache.hit"
+    case tokenizerCacheMiss = "tokenizer.cache.miss"
+    case tokenizerCacheEvicted = "tokenizer.cache.evicted"
+    case tokenizerCacheRejected = "tokenizer.cache.rejected"
+    case modelEvictionStarted = "model.eviction.started"
+    case modelEvictionCompleted = "model.eviction.completed"
+    case modelEvictionFailed = "model.eviction.failed"
+    case generationStarted = "generation.started"
+    case generationFirstToken = "generation.first_token"
+    case generationCompleted = "generation.completed"
+    case generationCancelled = "generation.cancelled"
+    case generationFailed = "generation.failed"
+    case logDropped = "log.dropped"
+}
+
+// MARK: - SwamaDiagnosticLevel
+
+enum SwamaDiagnosticLevel: String, Codable, Sendable {
+    case debug
+    case info
+    case warn
+    case error
+}
+
+// MARK: - SwamaDiagnosticValue
+
+enum SwamaDiagnosticValue: Codable, Equatable, Sendable {
+    case null
+    case string(String)
+    case integer(Int64)
+    case number(Double)
+    case boolean(Bool)
+    case object([String: SwamaDiagnosticValue])
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+        }
+        else if let value = try? container.decode(Bool.self) {
+            self = .boolean(value)
+        }
+        else if let value = try? container.decode(Int64.self) {
+            self = .integer(value)
+        }
+        else if let value = try? container.decode(Double.self) {
+            self = .number(value)
+        }
+        else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        }
+        else {
+            self = try .object(container.decode([String: SwamaDiagnosticValue].self))
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .null:
+            try container.encodeNil()
+        case let .string(value):
+            try container.encode(value)
+        case let .integer(value):
+            try container.encode(value)
+        case let .number(value):
+            try container.encode(value)
+        case let .boolean(value):
+            try container.encode(value)
+        case let .object(value):
+            try container.encode(value)
+        }
+    }
+}
+
+// MARK: - SwamaDiagnosticEvent
+
+struct SwamaDiagnosticEvent: Codable, Equatable, Sendable {
+    let schema: String
+    let ts: String
+    let seq: UInt64
+    let level: SwamaDiagnosticLevel
+    let subsystem: String
+    let event: SwamaDiagnosticEventName
+    let session: String
+    let op: String?
+    let model: String?
+    let durationMs: Double?
+    let outcome: SwamaDiagnosticOutcome?
+    let error: SwamaDiagnosticError?
+    let data: [String: SwamaDiagnosticValue]?
+
+    private enum CodingKeys: String, CodingKey {
+        case schema
+        case ts
+        case seq
+        case level
+        case subsystem
+        case event
+        case session
+        case op
+        case model
+        case durationMs = "duration_ms"
+        case outcome
+        case error
+        case data
+    }
+}
+
+// MARK: - SwamaDiagnosticTimeline
+
+enum SwamaDiagnosticTimeline: Equatable {
+    case valid([SwamaDiagnosticEvent])
+    case degraded([SwamaDiagnosticEvent])
+    case unknown
+
+    static func parse(_ data: Data) -> SwamaDiagnosticTimeline {
+        guard data.isEmpty || data.last == 0x0A else {
+            return .unknown
+        }
+
+        let lines = data.split(separator: 0x0A, omittingEmptySubsequences: true)
+        let decoder = JSONDecoder()
+        var events: [SwamaDiagnosticEvent] = []
+        for line in lines {
+            let lineData = Data(line)
+            guard let object = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
+                  let event = try? decoder.decode(SwamaDiagnosticEvent.self, from: lineData),
+                  hasValidEnvelopeKeys(object, event: event),
+                  hasValidEventShape(event, object: object)
+            else {
+                return .unknown
+            }
+            guard event.schema == "swama.diag/1",
+                  (event.outcome == .error) == (event.error != nil)
+            else {
+                return .unknown
+            }
+
+            let terminalEvents: Set<SwamaDiagnosticEventName> = [
+                .sessionStopped,
+                .modelLoadCompleted,
+                .modelLoadCancelled,
+                .modelLoadFailed,
+                .tokenizerCacheRejected,
+                .modelEvictionCompleted,
+                .modelEvictionFailed,
+                .generationCompleted,
+                .generationCancelled,
+                .generationFailed
+            ]
+            let isTerminal = terminalEvents.contains(event.event)
+            guard isTerminal == (event.durationMs != nil),
+                  isTerminal == (event.outcome != nil)
+            else {
+                return .unknown
+            }
+
+            switch event.event {
+            case .generationCompleted,
+                 .modelEvictionCompleted,
+                 .modelLoadCompleted:
+                guard event.outcome == .ok else {
+                    return .unknown
+                }
+
+            case .generationFailed,
+                 .modelEvictionFailed,
+                 .modelLoadFailed,
+                 .tokenizerCacheRejected:
+                guard event.outcome == .error else {
+                    return .unknown
+                }
+
+            case .generationCancelled:
+                guard event.outcome == .cancelled else {
+                    return .unknown
+                }
+
+            case .modelLoadCancelled:
+                guard event.outcome == .cancelled else {
+                    return .unknown
+                }
+
+            default:
+                break
+            }
+
+            if event.event == .modelLoadCompleted
+                || event.event == .modelLoadCancelled
+                || event.event == .modelLoadFailed
+            {
+                guard let duration = event.durationMs,
+                      case let .object(phases)? = event.data?["phases"],
+                      Set(phases.keys) == ["config_read", "config_decode", "model_graph", "tokenizer", "weights"]
+                else {
+                    return .unknown
+                }
+
+                for phase in phases.values {
+                    switch phase {
+                    case .null:
+                        continue
+                    case let .number(value) where value >= 0 && value <= duration:
+                        continue
+                    case let .integer(value) where value >= 0 && Double(value) <= duration:
+                        continue
+                    default:
+                        return .unknown
+                    }
+                }
+            }
+            events.append(event)
+        }
+
+        var expectedSequenceBySession: [String: UInt64] = [:]
+        var degraded = false
+        for event in events {
+            let expected = expectedSequenceBySession[event.session, default: 0]
+            if event.seq != expected {
+                degraded = true
+            }
+            expectedSequenceBySession[event.session] = event.seq &+ 1
+        }
+        return degraded ? .degraded(events) : .valid(events)
+    }
+
+    private static func hasValidEnvelopeKeys(_ object: [String: Any], event: SwamaDiagnosticEvent) -> Bool {
+        let base: Set<String> = ["schema", "ts", "seq", "level", "subsystem", "event", "session"]
+        let operation = Set(["op", "model"])
+        let terminal = Set(["duration_ms", "outcome"])
+        let data = Set(["data"])
+        let error = Set(["error"])
+        let expected: Set<String> =
+            switch event.event {
+            case .sessionStarted:
+                base.union(data)
+            case .sessionStopped:
+                base.union(terminal).union(event.outcome == .error ? error : [])
+            case .modelLoadStarted:
+                base.union(operation).union(data)
+            case .modelLoadCancelled,
+                 .modelLoadCompleted:
+                base.union(operation).union(terminal).union(data)
+            case .modelLoadFailed:
+                base.union(operation).union(terminal).union(error).union(data)
+            case .tokenizerCacheEvicted,
+                 .tokenizerCacheHit,
+                 .tokenizerCacheMiss:
+                base.union(data)
+            case .tokenizerCacheRejected:
+                base.union(terminal).union(error).union(data)
+            case .generationStarted,
+                 .modelEvictionStarted:
+                base.union(operation)
+            case .modelEvictionCompleted:
+                base.union(operation).union(terminal).union(data)
+            case .generationFailed,
+                 .modelEvictionFailed:
+                base.union(operation).union(terminal).union(error)
+            case .generationFirstToken:
+                base.union(operation).union(data)
+            case .generationCancelled,
+                 .generationCompleted:
+                base.union(operation).union(terminal).union(data)
+            case .logDropped:
+                base.union(data)
+            }
+
+        return Set(object.keys) == expected && !object.values.contains { $0 is NSNull }
+    }
+
+    private static func hasValidEventShape(_ event: SwamaDiagnosticEvent, object: [String: Any]) -> Bool {
+        guard UUID(uuidString: event.session) != nil,
+              hasTimestamp(event.ts),
+              event.durationMs.map({ $0 >= 0 }) ?? true,
+              event.subsystem == expectedSubsystem(for: event.event),
+              hasExpectedOperationAndModel(event),
+              hasCompatibleErrorCode(event)
+        else {
+            return false
+        }
+
+        if let operation = event.op, UUID(uuidString: operation) == nil {
+            return false
+        }
+        if let model = event.model, requiresOpaqueDiagnosticModelIdentity(model) {
+            return false
+        }
+        if let rawError = object["error"] as? [String: Any], Set(rawError.keys) != ["code", "transient"] {
+            return false
+        }
+
+        let dataKeys = Set(event.data?.keys.map(\.self) ?? [])
+        switch event.event {
+        case .sessionStarted:
+            guard dataKeys == ["pid", "version", "mode"],
+                  case let .integer(pid)? = event.data?["pid"],
+                  pid > 0,
+                  case .string? = event.data?["version"],
+                  case let .string(mode)? = event.data?["mode"]
+            else {
+                return false
+            }
+
+            return SwamaDiagnosticMode(rawValue: mode) != nil
+
+        case .sessionStopped:
+            return dataKeys.isEmpty
+
+        case .modelLoadStarted:
+            return event.op != nil && event.model != nil && dataKeys.isEmpty
+
+        case .modelLoadCancelled,
+             .modelLoadCompleted,
+             .modelLoadFailed:
+            return event.op != nil && event.model != nil && dataKeys == ["phases"]
+
+        case .tokenizerCacheHit,
+             .tokenizerCacheMiss,
+             .tokenizerCacheRejected:
+            return dataKeys == ["fingerprint"] && hasFingerprint(event.data?["fingerprint"])
+
+        case .tokenizerCacheEvicted:
+            guard dataKeys == ["fingerprint", "reason"],
+                  hasFingerprint(event.data?["fingerprint"]),
+                  case let .string(reason)? = event.data?["reason"]
+            else {
+                return false
+            }
+
+            return reason == "budget" || reason == "explicit"
+
+        case .modelEvictionFailed,
+             .modelEvictionStarted:
+            return event.op != nil && event.model != nil && dataKeys.isEmpty
+
+        case .modelEvictionCompleted:
+            return event.op != nil
+                && event.model != nil
+                && dataKeys == ["generation", "resident_bytes_after"]
+                && hasNonnegativeInteger(event.data?["generation"])
+                && hasNonnegativeInteger(event.data?["resident_bytes_after"])
+
+        case .generationFailed,
+             .generationStarted:
+            return event.op != nil && event.model != nil && dataKeys.isEmpty
+
+        case .generationFirstToken:
+            return event.op != nil
+                && event.model != nil
+                && dataKeys == ["ttft_ms"]
+                && hasNonnegativeNumber(event.data?["ttft_ms"])
+
+        case .generationCompleted:
+            return event.op != nil
+                && event.model != nil
+                && dataKeys == ["input_tokens", "output_tokens"]
+                && hasNonnegativeInteger(event.data?["input_tokens"])
+                && hasNonnegativeInteger(event.data?["output_tokens"])
+
+        case .generationCancelled:
+            return event.op != nil
+                && event.model != nil
+                && dataKeys == ["output_tokens"]
+                && hasNonnegativeInteger(event.data?["output_tokens"])
+
+        case .logDropped:
+            guard dataKeys == ["dropped_count"],
+                  case let .integer(count)? = event.data?["dropped_count"]
+            else {
+                return false
+            }
+
+            return count > 0
+        }
+    }
+
+    private static func expectedSubsystem(for event: SwamaDiagnosticEventName) -> String {
+        switch event {
+        case .sessionStarted,
+             .sessionStopped:
+            "session"
+        case .modelEvictionCompleted,
+             .modelEvictionFailed,
+             .modelEvictionStarted,
+             .modelLoadCancelled,
+             .modelLoadCompleted,
+             .modelLoadFailed,
+             .modelLoadStarted:
+            "model"
+        case .tokenizerCacheEvicted,
+             .tokenizerCacheHit,
+             .tokenizerCacheMiss,
+             .tokenizerCacheRejected:
+            "tokenizer"
+        case .generationCancelled,
+             .generationCompleted,
+             .generationFailed,
+             .generationFirstToken,
+             .generationStarted:
+            "generation"
+        case .logDropped:
+            "diagnostics"
+        }
+    }
+
+    private static func hasExpectedOperationAndModel(_ event: SwamaDiagnosticEvent) -> Bool {
+        switch event.event {
+        case .generationCancelled,
+             .generationCompleted,
+             .generationFailed,
+             .generationFirstToken,
+             .generationStarted,
+             .modelEvictionCompleted,
+             .modelEvictionFailed,
+             .modelEvictionStarted,
+             .modelLoadCancelled,
+             .modelLoadCompleted,
+             .modelLoadFailed,
+             .modelLoadStarted:
+            event.op != nil && event.model != nil
+        case .logDropped,
+             .sessionStarted,
+             .sessionStopped,
+             .tokenizerCacheEvicted,
+             .tokenizerCacheHit,
+             .tokenizerCacheMiss,
+             .tokenizerCacheRejected:
+            event.op == nil && event.model == nil
+        }
+    }
+
+    private static func hasCompatibleErrorCode(_ event: SwamaDiagnosticEvent) -> Bool {
+        switch event.event {
+        case .sessionStopped where event.outcome == .error:
+            event.error?.code == .sessionFailed
+        case .modelLoadFailed:
+            event.error?.code == .modelLoadFailed || event.error?.code == .modelNotFound
+        case .tokenizerCacheRejected:
+            event.error?.code == .tokenizerRejected
+        case .modelEvictionFailed:
+            event.error?.code == .evictionFailed
+        case .generationFailed:
+            event.error?.code == .generationFailed
+        default:
+            event.error == nil
+        }
+    }
+
+    private static func hasFingerprint(_ value: SwamaDiagnosticValue?) -> Bool {
+        guard case let .string(fingerprint)? = value, fingerprint.count == 64 else {
+            return false
+        }
+
+        return fingerprint.allSatisfy { $0.isHexDigit && !$0.isUppercase }
+    }
+
+    private static func hasTimestamp(_ value: String) -> Bool {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        return formatter.date(from: value) != nil && value.hasSuffix("Z")
+    }
+
+    private static func hasNonnegativeInteger(_ value: SwamaDiagnosticValue?) -> Bool {
+        guard case let .integer(number)? = value else {
+            return false
+        }
+
+        return number >= 0
+    }
+
+    private static func hasNonnegativeNumber(_ value: SwamaDiagnosticValue?) -> Bool {
+        switch value {
+        case let .integer(number):
+            number >= 0
+        case let .number(number):
+            number >= 0
+        default:
+            false
+        }
+    }
+
+    static func hasCompleteOperations(_ events: [SwamaDiagnosticEvent]) -> Bool {
+        var openOperations: [String: (
+            session: String,
+            start: SwamaDiagnosticEventName,
+            model: String?,
+            invalidated: Bool
+        )] = [:]
+        for event in events {
+            guard let operation = event.op else {
+                continue
+            }
+
+            let key = "\(event.session):\(operation)"
+            switch event.event {
+            case .generationStarted,
+                 .modelLoadStarted:
+                guard openOperations[key] == nil else {
+                    return false
+                }
+
+                openOperations[key] = (event.session, event.event, event.model, false)
+
+            case .modelEvictionStarted:
+                guard openOperations[key] == nil else {
+                    return false
+                }
+
+                for openKey in Array(openOperations.keys) {
+                    guard var open = openOperations[openKey],
+                          open.session == event.session,
+                          open.start == .modelLoadStarted,
+                          open.model == event.model
+                    else {
+                        continue
+                    }
+
+                    open.invalidated = true
+                    openOperations[openKey] = open
+                }
+                openOperations[key] = (event.session, event.event, event.model, false)
+
+            case .generationFirstToken:
+                guard let open = openOperations[key],
+                      open.start == .generationStarted,
+                      open.model == event.model
+                else {
+                    return false
+                }
+
+            case .modelLoadCompleted,
+                 .modelLoadFailed:
+                guard let open = openOperations.removeValue(forKey: key),
+                      open.start == .modelLoadStarted,
+                      open.model == event.model,
+                      !open.invalidated
+                else {
+                    return false
+                }
+
+            case .modelLoadCancelled:
+                guard let open = openOperations.removeValue(forKey: key),
+                      open.start == .modelLoadStarted,
+                      open.model == event.model
+                else {
+                    return false
+                }
+
+            case .modelEvictionCompleted,
+                 .modelEvictionFailed:
+                guard let open = openOperations.removeValue(forKey: key),
+                      open.start == .modelEvictionStarted,
+                      open.model == event.model
+                else {
+                    return false
+                }
+
+            case .generationCancelled,
+                 .generationCompleted,
+                 .generationFailed:
+                guard let open = openOperations.removeValue(forKey: key),
+                      open.start == .generationStarted,
+                      open.model == event.model
+                else {
+                    return false
+                }
+
+            default:
+                break
+            }
+        }
+        return openOperations.isEmpty
+    }
+}
+
+// MARK: - SwamaDiagnosticRecorder
+
+final class SwamaDiagnosticRecorder: @unchecked Sendable {
+    typealias Write = @Sendable (Data) throws -> Void
+    typealias Now = @Sendable () -> Date
+
+    init(
+        enabled: Bool,
+        sessionID: UUID = UUID(),
+        primaryWrite: @escaping Write,
+        fallbackWrite: @escaping @Sendable (Data) -> Void,
+        maximumPendingWrites: Int = 1024,
+        now: @escaping Now = { Date() }
+    ) {
+        self.enabled = enabled
+        self.sessionID = sessionID
+        self.primaryWrite = primaryWrite
+        self.fallbackWrite = fallbackWrite
+        self.maximumPendingWrites = maximumPendingWrites
+        self.now = now
+    }
+
+    func start(mode: SwamaDiagnosticMode) {
+        guard enabled else {
+            return
+        }
+
+        lock.withLock {
+            startIfNeededLocked(mode: mode)
+        }
+    }
+
+    func stop(outcome: SwamaDiagnosticOutcome, error: SwamaDiagnosticError? = nil) {
+        guard enabled else {
+            return
+        }
+
+        lock.withLock {
+            guard started, !stopped else {
+                return
+            }
+
+            stopped = true
+            enqueueLocked(
+                level: outcome == .error ? .error : .info,
+                subsystem: "session",
+                event: .sessionStopped,
+                durationMs: sessionStartedAt.map(elapsedMilliseconds),
+                outcome: outcome,
+                error: error
+            )
+        }
+        flush()
+    }
+
+    func makeOperation() -> SwamaDiagnosticOperation {
+        .init(
+            id: UUID(),
+            startedAtNanoseconds: DispatchTime.now().uptimeNanoseconds,
+            isActive: lock.withLock { enabled && started && !stopped }
+        )
+    }
+
+    func record(
+        level: SwamaDiagnosticLevel,
+        subsystem: String,
+        event: SwamaDiagnosticEventName,
+        operation: SwamaDiagnosticOperation? = nil,
+        model: String? = nil,
+        durationMs: Double? = nil,
+        outcome: SwamaDiagnosticOutcome? = nil,
+        error: SwamaDiagnosticError? = nil,
+        data: [String: SwamaDiagnosticValue]? = nil
+    ) {
+        guard enabled else {
+            return
+        }
+
+        if let operation, !operation.isActive {
+            return
+        }
+
+        lock.withLock {
+            guard started, !stopped else {
+                return
+            }
+
+            enqueueLocked(
+                level: level,
+                subsystem: subsystem,
+                event: event,
+                operation: operation,
+                model: model.map(safeModelIdentity),
+                durationMs: durationMs,
+                outcome: outcome,
+                error: error,
+                data: data
+            )
+        }
+    }
+
+    func flush() {
+        guard enabled else {
+            return
+        }
+
+        ioQueue.sync {}
+        fallbackQueue.sync {}
+    }
+
+    private let enabled: Bool
+    private let sessionID: UUID
+    private let primaryWrite: Write
+    private let fallbackWrite: @Sendable (Data) -> Void
+    private let maximumPendingWrites: Int
+    private let now: Now
+    private let lock: NSLock = .init()
+    private let ioQueue: DispatchQueue = .init(label: "ai.transn.swama.diagnostics", qos: .utility)
+    private let fallbackQueue: DispatchQueue = .init(label: "ai.transn.swama.diagnostics.fallback", qos: .utility)
+    private var nextSequence: UInt64 = 0
+    private var pendingWrites = 0
+    private var pendingDropCount = 0
+    private var dropNotificationScheduled = false
+    private var started = false
+    private var stopped = false
+    private var sessionStartedAt: UInt64?
+
+    private func startIfNeededLocked(mode: SwamaDiagnosticMode) {
+        guard !started else {
+            return
+        }
+
+        started = true
+        sessionStartedAt = DispatchTime.now().uptimeNanoseconds
+        enqueueLocked(
+            level: .info,
+            subsystem: "session",
+            event: .sessionStarted,
+            data: [
+                "pid": .integer(Int64(ProcessInfo.processInfo.processIdentifier)),
+                "version": .string(Self.version),
+                "mode": .string(mode.rawValue)
+            ]
+        )
+    }
+
+    private func enqueueLocked(
+        level: SwamaDiagnosticLevel,
+        subsystem: String,
+        event: SwamaDiagnosticEventName,
+        operation: SwamaDiagnosticOperation? = nil,
+        model: String? = nil,
+        durationMs: Double? = nil,
+        outcome: SwamaDiagnosticOutcome? = nil,
+        error: SwamaDiagnosticError? = nil,
+        data: [String: SwamaDiagnosticValue]? = nil
+    ) {
+        let envelope = SwamaDiagnosticEvent(
+            schema: "swama.diag/1",
+            ts: timestamp(now()),
+            seq: nextSequence,
+            level: level,
+            subsystem: subsystem,
+            event: event,
+            session: sessionID.uuidString.lowercased(),
+            op: operation?.identifier,
+            model: model,
+            durationMs: durationMs,
+            outcome: outcome,
+            error: error,
+            data: data
+        )
+        nextSequence &+= 1
+        guard pendingWrites < maximumPendingWrites else {
+            scheduleDropNotificationLocked()
+            return
+        }
+
+        pendingWrites += 1
+        ioQueue.async { [self] in
+            defer { lock.withLock { pendingWrites -= 1 } }
+            write(envelope)
+        }
+    }
+
+    private func scheduleDropNotificationLocked() {
+        pendingDropCount += 1
+        guard !dropNotificationScheduled else {
+            return
+        }
+
+        dropNotificationScheduled = true
+        fallbackQueue.async { [self] in
+            let count = lock.withLock { () -> Int in
+                let count = pendingDropCount
+                pendingDropCount = 0
+                dropNotificationScheduled = false
+                return count
+            }
+            writeDropFallback(count: count)
+        }
+    }
+
+    private func write(_ event: SwamaDiagnosticEvent) {
+        guard let line = encodeLine(event) else {
+            writeDropFallback(count: 1)
+            return
+        }
+
+        do {
+            try primaryWrite(line)
+        }
+        catch {
+            writeDropFallback(count: 1)
+        }
+    }
+
+    private func writeDropFallback(count: Int) {
+        let dropEvent = lock.withLock { () -> SwamaDiagnosticEvent in
+            let event = SwamaDiagnosticEvent(
+                schema: "swama.diag/1",
+                ts: timestamp(now()),
+                seq: nextSequence,
+                level: .warn,
+                subsystem: "diagnostics",
+                event: .logDropped,
+                session: sessionID.uuidString.lowercased(),
+                op: nil,
+                model: nil,
+                durationMs: nil,
+                outcome: nil,
+                error: nil,
+                data: ["dropped_count": .integer(Int64(count))]
+            )
+            nextSequence &+= 1
+            return event
+        }
+        if let line = encodeLine(dropEvent) {
+            fallbackWrite(line)
+        }
+    }
+
+    private func encodeLine(_ event: SwamaDiagnosticEvent) -> Data? {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        guard var data = try? encoder.encode(event) else {
+            return nil
+        }
+
+        data.append(0x0A)
+        return data
+    }
+
+    private func timestamp(_ date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        return formatter.string(from: date)
+    }
+
+    private func safeModelIdentity(_ value: String) -> String {
+        guard requiresOpaqueDiagnosticModelIdentity(value) else {
+            return value
+        }
+
+        let digest = SHA256.hash(data: Data(value.utf8)).map { String(format: "%02x", $0) }.joined()
+        return "local:\(digest)"
+    }
+
+    private func elapsedMilliseconds(_ startedAt: UInt64) -> Double {
+        Double(DispatchTime.now().uptimeNanoseconds - startedAt) / 1_000_000
+    }
+
+    private static var version: String {
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "2.3.0"
+    }
+}
+
+// MARK: - SwamaDiagnosticFileWriter
+
+final class SwamaDiagnosticFileWriter: @unchecked Sendable {
+    init(url: URL, maximumBytes: Int = 8 * 1024 * 1024) {
+        self.url = url
+        self.maximumBytes = maximumBytes
+    }
+
+    func write(_ data: Data) throws {
+        guard data.count <= maximumBytes else {
+            throw SwamaDiagnosticFileWriterError.eventTooLarge
+        }
+
+        try prepareDirectory()
+        try withFileLock {
+            try rotateIfNeeded(incomingBytes: data.count)
+            let descriptor = Darwin.open(url.path, O_CREAT | O_WRONLY | O_APPEND, S_IRUSR | S_IWUSR)
+            guard descriptor >= 0 else {
+                throw POSIXError(.init(rawValue: errno) ?? .EIO)
+            }
+
+            defer { Darwin.close(descriptor) }
+
+            try data.withUnsafeBytes { rawBuffer in
+                guard var pointer = rawBuffer.baseAddress else {
+                    return
+                }
+
+                var remaining = rawBuffer.count
+                while remaining > 0 {
+                    let written = Darwin.write(descriptor, pointer, remaining)
+                    guard written > 0 else {
+                        throw POSIXError(.init(rawValue: errno) ?? .EIO)
+                    }
+
+                    remaining -= written
+                    pointer = pointer.advanced(by: written)
+                }
+            }
+        }
+    }
+
+    func readSnapshot() throws -> Data {
+        try prepareDirectory()
+        return try withFileLock {
+            let rotatedURL = url.appendingPathExtension("1")
+            var snapshot = (try? Data(contentsOf: rotatedURL)) ?? Data()
+            snapshot.append((try? Data(contentsOf: url)) ?? Data())
+            return snapshot
+        }
+    }
+
+    private let url: URL
+    private let maximumBytes: Int
+
+    private func prepareDirectory() throws {
+        let directory = url.deletingLastPathComponent()
+        guard !FileManager.default.fileExists(atPath: directory.path) else {
+            return
+        }
+
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: directory.path)
+    }
+
+    private func withFileLock<T>(_ operation: () throws -> T) throws -> T {
+        let lockURL = url.appendingPathExtension("lock")
+        let lockDescriptor = Darwin.open(lockURL.path, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)
+        guard lockDescriptor >= 0 else {
+            throw POSIXError(.init(rawValue: errno) ?? .EIO)
+        }
+
+        defer { Darwin.close(lockDescriptor) }
+        guard flock(lockDescriptor, LOCK_EX) == 0 else {
+            throw POSIXError(.init(rawValue: errno) ?? .EIO)
+        }
+
+        defer { flock(lockDescriptor, LOCK_UN) }
+        return try operation()
+    }
+
+    private func rotateIfNeeded(incomingBytes: Int) throws {
+        let size = (try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
+        guard size + incomingBytes > maximumBytes else {
+            return
+        }
+
+        let rotatedURL = url.appendingPathExtension("1")
+        try? FileManager.default.removeItem(at: rotatedURL)
+        if FileManager.default.fileExists(atPath: url.path) {
+            try FileManager.default.moveItem(at: url, to: rotatedURL)
+        }
+    }
+}
+
+// MARK: - SwamaDiagnosticFileWriterError
+
+private enum SwamaDiagnosticFileWriterError: Error {
+    case eventTooLarge
+}
+
+// MARK: - SwamaDiagnostics
+
+package enum SwamaDiagnostics {
+    package static var logFileURL: URL {
+        if let override = ProcessInfo.processInfo.environment["SWAMA_DIAGNOSTICS_PATH"], !override.isEmpty {
+            return URL(fileURLWithPath: override)
+        }
+        return FileManager.default
+            .homeDirectoryForCurrentUser
+            .appendingPathComponent(".swama/logs/events.jsonl")
+    }
+
+    package static func startSession(mode: SwamaDiagnosticMode) {
+        recorder.start(mode: mode)
+    }
+
+    package static func stopSession(outcome: SwamaDiagnosticOutcome, error: SwamaDiagnosticError? = nil) {
+        recorder.stop(outcome: outcome, error: error)
+    }
+
+    package static func withSession<T>(
+        mode: SwamaDiagnosticMode,
+        operation: () async throws -> T
+    ) async throws -> T {
+        startSession(mode: mode)
+        do {
+            let value = try await operation()
+            stopSession(outcome: .ok)
+            return value
+        }
+        catch is CancellationError {
+            stopSession(outcome: .cancelled)
+            throw CancellationError()
+        }
+        catch {
+            stopSession(
+                outcome: .error,
+                error: .init(code: .sessionFailed, transient: false)
+            )
+            throw error
+        }
+    }
+
+    package static func hitTokenizerCache(fingerprint: String) {
+        recorder.record(
+            level: .debug,
+            subsystem: "tokenizer",
+            event: .tokenizerCacheHit,
+            data: ["fingerprint": .string(fingerprint)]
+        )
+    }
+
+    package static func missTokenizerCache(fingerprint: String) {
+        recorder.record(
+            level: .debug,
+            subsystem: "tokenizer",
+            event: .tokenizerCacheMiss,
+            data: ["fingerprint": .string(fingerprint)]
+        )
+    }
+
+    package static func evictTokenizerCache(fingerprint: String, reason: String) {
+        recorder.record(
+            level: .debug,
+            subsystem: "tokenizer",
+            event: .tokenizerCacheEvicted,
+            data: [
+                "fingerprint": .string(fingerprint),
+                "reason": .string(reason)
+            ]
+        )
+    }
+
+    package static func rejectTokenizerCache(
+        fingerprint: String,
+        durationMilliseconds: Double
+    ) {
+        recorder.record(
+            level: .warn,
+            subsystem: "tokenizer",
+            event: .tokenizerCacheRejected,
+            durationMs: durationMilliseconds,
+            outcome: .error,
+            error: .init(code: .tokenizerRejected, transient: true),
+            data: ["fingerprint": .string(fingerprint)]
+        )
+    }
+
+    package static func startModelLoad(model: String) -> SwamaDiagnosticOperation {
+        let operation = recorder.makeOperation()
+        recorder.record(
+            level: .info,
+            subsystem: "model",
+            event: .modelLoadStarted,
+            operation: operation,
+            model: model,
+            data: [:]
+        )
+        return operation
+    }
+
+    package static func completeModelLoad(
+        _ operation: SwamaDiagnosticOperation,
+        model: String,
+        phases: SwamaModelLoadPhases
+    ) {
+        recorder.record(
+            level: .info,
+            subsystem: "model",
+            event: .modelLoadCompleted,
+            operation: operation,
+            model: model,
+            durationMs: operation.elapsedMilliseconds(),
+            outcome: .ok,
+            data: ["phases": .object(phases.values)]
+        )
+    }
+
+    package static func failModelLoad(
+        _ operation: SwamaDiagnosticOperation,
+        model: String,
+        code: SwamaDiagnosticErrorCode = .modelLoadFailed,
+        transient: Bool = false,
+        phases: SwamaModelLoadPhases = .init()
+    ) {
+        recorder.record(
+            level: .error,
+            subsystem: "model",
+            event: .modelLoadFailed,
+            operation: operation,
+            model: model,
+            durationMs: operation.elapsedMilliseconds(),
+            outcome: .error,
+            error: .init(code: code, transient: transient),
+            data: ["phases": .object(phases.values)]
+        )
+    }
+
+    package static func cancelModelLoad(
+        _ operation: SwamaDiagnosticOperation,
+        model: String,
+        phases: SwamaModelLoadPhases
+    ) {
+        recorder.record(
+            level: .info,
+            subsystem: "model",
+            event: .modelLoadCancelled,
+            operation: operation,
+            model: model,
+            durationMs: operation.elapsedMilliseconds(),
+            outcome: .cancelled,
+            data: ["phases": .object(phases.values)]
+        )
+    }
+
+    package static func startEviction(model: String) -> SwamaDiagnosticOperation {
+        let operation = recorder.makeOperation()
+        recorder.record(
+            level: .info,
+            subsystem: "model",
+            event: .modelEvictionStarted,
+            operation: operation,
+            model: model
+        )
+        return operation
+    }
+
+    package static func completeEviction(
+        _ operation: SwamaDiagnosticOperation,
+        model: String,
+        generation: UInt64,
+        residentBytesAfter: Int
+    ) {
+        recorder.record(
+            level: .info,
+            subsystem: "model",
+            event: .modelEvictionCompleted,
+            operation: operation,
+            model: model,
+            durationMs: operation.elapsedMilliseconds(),
+            outcome: .ok,
+            data: [
+                "generation": .integer(Int64(generation)),
+                "resident_bytes_after": .integer(Int64(residentBytesAfter))
+            ]
+        )
+    }
+
+    package static func startGeneration(model: String) -> SwamaDiagnosticOperation {
+        let operation = recorder.makeOperation()
+        recorder.record(
+            level: .info,
+            subsystem: "generation",
+            event: .generationStarted,
+            operation: operation,
+            model: model
+        )
+        return operation
+    }
+
+    package static func firstToken(_ operation: SwamaDiagnosticOperation, model: String) {
+        recorder.record(
+            level: .info,
+            subsystem: "generation",
+            event: .generationFirstToken,
+            operation: operation,
+            model: model,
+            data: ["ttft_ms": .number(operation.elapsedMilliseconds())]
+        )
+    }
+
+    package static func completeGeneration(
+        _ operation: SwamaDiagnosticOperation,
+        model: String,
+        inputTokens: Int,
+        outputTokens: Int
+    ) {
+        recorder.record(
+            level: .info,
+            subsystem: "generation",
+            event: .generationCompleted,
+            operation: operation,
+            model: model,
+            durationMs: operation.elapsedMilliseconds(),
+            outcome: .ok,
+            data: [
+                "input_tokens": .integer(Int64(inputTokens)),
+                "output_tokens": .integer(Int64(outputTokens))
+            ]
+        )
+    }
+
+    package static func cancelGeneration(
+        _ operation: SwamaDiagnosticOperation,
+        model: String,
+        outputTokens: Int
+    ) {
+        recorder.record(
+            level: .info,
+            subsystem: "generation",
+            event: .generationCancelled,
+            operation: operation,
+            model: model,
+            durationMs: operation.elapsedMilliseconds(),
+            outcome: .cancelled,
+            data: ["output_tokens": .integer(Int64(outputTokens))]
+        )
+    }
+
+    package static func failGeneration(
+        _ operation: SwamaDiagnosticOperation,
+        model: String,
+        transient: Bool = false
+    ) {
+        recorder.record(
+            level: .error,
+            subsystem: "generation",
+            event: .generationFailed,
+            operation: operation,
+            model: model,
+            durationMs: operation.elapsedMilliseconds(),
+            outcome: .error,
+            error: .init(code: .generationFailed, transient: transient)
+        )
+    }
+
+    package static func flush() {
+        recorder.flush()
+    }
+
+    package static func isValidSnapshot(_ data: Data) -> Bool {
+        switch SwamaDiagnosticTimeline.parse(data) {
+        case .degraded,
+             .valid:
+            true
+        case .unknown:
+            false
+        }
+    }
+
+    package static func readLogSnapshot() throws -> Data {
+        try SwamaDiagnosticFileWriter(url: logFileURL).readSnapshot()
+    }
+
+    package static func residentBytes() -> Int {
+        var info = mach_task_basic_info()
+        var count = mach_msg_type_number_t(MemoryLayout<mach_task_basic_info_data_t>.size / MemoryLayout<natural_t>
+            .size
+        )
+        let result = withUnsafeMutablePointer(to: &info) { infoPointer in
+            infoPointer.withMemoryRebound(to: integer_t.self, capacity: Int(count)) { integerPointer in
+                task_info(
+                    mach_task_self_,
+                    task_flavor_t(MACH_TASK_BASIC_INFO),
+                    integerPointer,
+                    &count
+                )
+            }
+        }
+        guard result == KERN_SUCCESS else {
+            return 0
+        }
+
+        return Int(info.resident_size)
+    }
+
+    #if DEBUG
+        @discardableResult
+        static func installRecorderForTesting(_ replacement: SwamaDiagnosticRecorder) -> SwamaDiagnosticRecorder {
+            recorderHolder.swap(replacement)
+        }
+
+        static func restoreRecorderForTesting(_ previous: SwamaDiagnosticRecorder) {
+            _ = recorderHolder.swap(previous)
+        }
+    #endif
+
+    private static var recorder: SwamaDiagnosticRecorder {
+        recorderHolder.current
+    }
+
+    private static let recorderHolder: SwamaDiagnosticRecorderHolder = .init(liveRecorder)
+
+    private static let liveRecorder: SwamaDiagnosticRecorder = {
+        let environment = ProcessInfo.processInfo.environment
+        let processName = ProcessInfo.processInfo.processName.lowercased()
+        let isTestProcess = environment["XCTestConfigurationFilePath"] != nil
+            || processName.contains("xctest")
+            || processName.contains("packagetests")
+        let enabled = environment["SWAMA_DIAGNOSTICS_DISABLED"] != "1" && !isTestProcess
+        let writer = SwamaDiagnosticFileWriter(url: logFileURL)
+        return .init(
+            enabled: enabled,
+            primaryWrite: { data in try writer.write(data) },
+            fallbackWrite: { data in try? FileHandle.standardError.write(contentsOf: data) }
+        )
+    }()
+}
+
+// MARK: - SwamaDiagnosticRecorderHolder
+
+private final class SwamaDiagnosticRecorderHolder: @unchecked Sendable {
+    init(_ recorder: SwamaDiagnosticRecorder) {
+        currentRecorder = recorder
+    }
+
+    var current: SwamaDiagnosticRecorder {
+        lock.withLock { currentRecorder }
+    }
+
+    func swap(_ replacement: SwamaDiagnosticRecorder) -> SwamaDiagnosticRecorder {
+        lock.withLock {
+            let previous = currentRecorder
+            currentRecorder = replacement
+            return previous
+        }
+    }
+
+    private let lock: NSLock = .init()
+    private var currentRecorder: SwamaDiagnosticRecorder
+}
+
+private extension SwamaModelLoadPhases {
+    var values: [String: SwamaDiagnosticValue] {
+        [
+            "config_read": configReadMs.map(SwamaDiagnosticValue.number) ?? .null,
+            "config_decode": configDecodeMs.map(SwamaDiagnosticValue.number) ?? .null,
+            "model_graph": modelGraphMs.map(SwamaDiagnosticValue.number) ?? .null,
+            "tokenizer": tokenizerMs.map(SwamaDiagnosticValue.number) ?? .null,
+            "weights": weightsMs.map(SwamaDiagnosticValue.number) ?? .null
+        ]
+    }
+}

--- a/swama/Sources/SwamaRuntime/Model/Downloaders/BaseDownloader.swift
+++ b/swama/Sources/SwamaRuntime/Model/Downloaders/BaseDownloader.swift
@@ -1,0 +1,193 @@
+//
+//  BaseDownloader.swift
+//  swama
+//
+//  Created by BBBOND on 2025/6/24.
+//
+import Foundation
+
+package class BaseDownloader: IDownloader {
+    package required init() {}
+
+    /// get list model files with size api
+    /// - Parameters:
+    ///   - repo: model repo
+    ///   - subDir: sub directory
+    /// - Returns: api url
+    package func getListModelFilesWithSizeApi(repo _: String, subDir _: String) -> String {
+        fatalError("Must be implemented by subclass")
+    }
+
+    /// model files response adapter
+    /// - Parameters:
+    ///   - data: data
+    /// - Returns: [(path: String, size: Int64)]
+    package func modelFilesResponseAdapter(data _: Data) throws -> [(path: String, size: Int64)] {
+        fatalError("Must be implemented by subclass")
+    }
+
+    /// get download url
+    /// - Parameters:
+    ///   - repo: model repo
+    ///   - file: file name
+    /// - Returns: download url
+    package func getDownloadUrl(repo _: String, file _: String) -> String {
+        fatalError("Must be implemented by subclass")
+    }
+
+    /// list model files with size
+    /// - Parameters:
+    ///   - repo: model repo
+    /// - Returns: [(path: String, size: Int64)]
+    package func listModelFilesWithSize(repo: String) async throws -> [(path: String, size: Int64)] {
+        try await listModelFilesWithSize(repo: repo, subDir: "")
+    }
+
+    package func listModelFilesWithSize(repo: String, subDir: String) async throws -> [(path: String, size: Int64)] {
+        guard let url = URL(string: getListModelFilesWithSizeApi(repo: repo, subDir: subDir)) else {
+            throw NSError(
+                domain: "BaseDownloader",
+                code: 3,
+                userInfo: [NSLocalizedDescriptionKey: "Invalid URL for API."]
+            )
+        }
+
+        var req = URLRequest(url: url)
+        req.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await URLSession.shared.data(for: req)
+        }
+        catch {
+            throw NSError(
+                domain: "BaseDownloader",
+                code: 4,
+                userInfo: [
+                    NSLocalizedDescriptionKey: "Failed to fetch model file list: \(error.localizedDescription)"
+                ]
+            )
+        }
+
+        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+            let statusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+            var errorMessage = "Failed to fetch model file list from \(url). Status code: \(statusCode)."
+            if statusCode == 404 {
+                errorMessage += " Model repository not found or private."
+            }
+            throw NSError(domain: "BaseDownloader", code: 5, userInfo: [NSLocalizedDescriptionKey: errorMessage])
+        }
+
+        do {
+            return try modelFilesResponseAdapter(data: data)
+        }
+        catch {
+            throw NSError(
+                domain: "BaseDownloader",
+                code: 7,
+                userInfo: [NSLocalizedDescriptionKey: "JSON parsing error: \(error.localizedDescription)"]
+            )
+        }
+    }
+
+    package func downloadWithResume(
+        repo: String,
+        file: String,
+        dest: URL,
+        totalSize: Int64,
+        localSize: Int64
+    ) async throws {
+        guard let url = URL(string: getDownloadUrl(repo: repo, file: file))
+        else {
+            throw NSError(
+                domain: "BaseDownloader",
+                code: 8,
+                userInfo: [NSLocalizedDescriptionKey: "Invalid URL for downloading file \(file)."]
+            )
+        }
+
+        var request = URLRequest(url: url)
+        var isResuming = false
+        if localSize > 0, localSize < totalSize {
+            request.setValue("bytes=\(localSize)-", forHTTPHeaderField: "Range")
+            isResuming = true
+        }
+
+        let (byteStream, response) = try await URLSession.shared.bytes(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw NSError(
+                domain: "BaseDownloader",
+                code: 9,
+                userInfo: [NSLocalizedDescriptionKey: "Invalid response from server for file \(file)."]
+            )
+        }
+
+        let statusCode = httpResponse.statusCode
+
+        // Handle common HTTP errors
+        if !(200 ... 299).contains(statusCode) {
+            if statusCode == 404 {
+                throw NSError(
+                    domain: "BaseDownloader",
+                    code: 10,
+                    userInfo: [NSLocalizedDescriptionKey: "File not found on server (404): \(file)"]
+                )
+            }
+            throw NSError(
+                domain: "BaseDownloader",
+                code: 11,
+                userInfo: [NSLocalizedDescriptionKey: "HTTP error \(statusCode) while downloading \(file)."]
+            )
+        }
+
+        let shouldResume = isResuming && statusCode == 206 // 206 Partial Content
+
+        if !FileManager.default.fileExists(atPath: dest.path) {
+            FileManager.default.createFile(atPath: dest.path, contents: nil)
+        }
+
+        let handle: FileHandle
+        do {
+            handle = try FileHandle(forWritingTo: dest)
+        }
+        catch {
+            throw NSError(
+                domain: "BaseDownloader",
+                code: 12,
+                userInfo: [
+                    NSLocalizedDescriptionKey: "Cannot open file for writing at \(dest.path): \(error.localizedDescription)"
+                ]
+            )
+        }
+        defer { try? handle.close() }
+
+        if shouldResume {
+            try handle.seekToEnd()
+        }
+        else {
+            // If not resuming or if server doesn't support range, truncate and start over.
+            // This handles cases where localSize > 0 but server sends 200 OK instead of 206.
+            try handle.truncate(atOffset: 0)
+        }
+
+        let progressBar = ProgressBar(total: totalSize, initial: shouldResume ? localSize : 0)
+        var buffer: [UInt8] = []
+        // No need for downloadedBytes, progressBar handles its own downloaded count
+
+        for try await byte in byteStream {
+            buffer.append(byte)
+            if buffer.count >= 8192 { // Increased buffer size
+                try handle.write(contentsOf: Data(buffer))
+                progressBar.update(bytes: Int64(buffer.count))
+                buffer.removeAll(keepingCapacity: true)
+            }
+        }
+        if !buffer.isEmpty {
+            try handle.write(contentsOf: Data(buffer))
+            progressBar.update(bytes: Int64(buffer.count))
+        }
+
+        progressBar.finish()
+    }
+}

--- a/swama/Sources/SwamaRuntime/Model/Downloaders/HuggingFaceDownloader.swift
+++ b/swama/Sources/SwamaRuntime/Model/Downloaders/HuggingFaceDownloader.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+// MARK: - HuggingFaceDownloader
+
+/// HuggingFace model downloader, implements IDownloader protocol
+package class HuggingFaceDownloader: BaseDownloader {
+    // MARK: - Public
+
+    package required init() {}
+
+    override package func getListModelFilesWithSizeApi(repo: String, subDir _: String) -> String {
+        "https://huggingface.co/api/models/\(repo)/tree/main"
+    }
+
+    override package func modelFilesResponseAdapter(data: Data) throws -> [(path: String, size: Int64)] {
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
+            throw NSError(
+                domain: "BaseDownloader",
+                code: 6,
+                userInfo: [NSLocalizedDescriptionKey: "Failed to parse JSON response from API."]
+            )
+        }
+
+        return json.compactMap { dict -> (String, Int64)? in
+            guard let path = dict["path"] as? String else { return nil }
+
+            let size = (dict["size"] as? NSNumber)?.int64Value ?? 0
+            return (path, size)
+        }
+    }
+
+    override package func getDownloadUrl(repo: String, file: String) -> String {
+        "https://huggingface.co/\(repo)/resolve/main/\(file.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? file)"
+    }
+}

--- a/swama/Sources/SwamaRuntime/Model/Downloaders/IDownloader.swift
+++ b/swama/Sources/SwamaRuntime/Model/Downloaders/IDownloader.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// downloader protocol
+package protocol IDownloader {
+    /// Required initializer
+    init()
+
+    /// list model files with size
+    /// - Parameter repo: model repo
+    func listModelFilesWithSize(repo: String) async throws -> [(path: String, size: Int64)]
+
+    /// list model files with size
+    /// - Parameter repo: model repo
+    /// - Parameter subDir: sub directory
+    func listModelFilesWithSize(repo: String, subDir: String) async throws -> [(path: String, size: Int64)]
+
+    /// download with resume
+    /// - Parameters:
+    ///   - repo: model repo
+    ///   - file: file name
+    ///   - dest: destination url
+    ///   - totalSize: total size
+    ///   - localSize: local size
+    func downloadWithResume(repo: String, file: String, dest: URL, totalSize: Int64, localSize: Int64) async throws
+}

--- a/swama/Sources/SwamaRuntime/Model/Downloaders/ModelScopeDownloader.swift
+++ b/swama/Sources/SwamaRuntime/Model/Downloaders/ModelScopeDownloader.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+// MARK: - ModelScopeDownloader
+
+/// ModelScope model downloader, implements IDownloader protocol
+package class ModelScopeDownloader: BaseDownloader {
+    // MARK: - Public
+
+    package required init() {}
+
+    override package func getListModelFilesWithSizeApi(repo: String, subDir: String) -> String {
+        "https://www.modelscope.cn/api/v1/models/\(repo)/repo/files?Revision=master&Root=\(subDir.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? subDir)"
+    }
+
+    override package func modelFilesResponseAdapter(data: Data) throws -> [(path: String, size: Int64)] {
+        guard let json =
+            try ((JSONSerialization
+                    .jsonObject(with: data) as? [String: Any]
+            )?["Data"] as? [String: Any])?["Files"] as? [[String: Any]]
+        else {
+            throw NSError(
+                domain: "ModelScopeDownloader",
+                code: 6,
+                userInfo: [NSLocalizedDescriptionKey: "Failed to parse JSON response from ModelScop."]
+            )
+        }
+
+        return json.compactMap { dict -> (String, Int64)? in
+            guard let path = dict["Path"] as? String else { return nil }
+
+            let size = (dict["Size"] as? NSNumber)?.int64Value ?? 0
+            return (path, size)
+        }
+    }
+
+    override package func getDownloadUrl(repo: String, file: String) -> String {
+        "https://www.modelscope.cn/api/v1/models/\(repo)/repo?Revision=master&FilePath=\(file.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? file)"
+    }
+}

--- a/swama/Sources/SwamaRuntime/Model/EmbeddingRunner.swift
+++ b/swama/Sources/SwamaRuntime/Model/EmbeddingRunner.swift
@@ -1,0 +1,206 @@
+import Foundation
+import MLX
+import MLXEmbedders
+import MLXHuggingFace
+import MLXLMCommon
+import Tokenizers
+
+/// Loads an embedding model container for the given model name.
+package func loadEmbeddingModelContainer(modelName: String) async throws -> EmbedderModelContainer {
+    try await loadEmbeddingModelContainer(
+        modelName: modelName,
+        tokenizerLoader: CachedTokenizerLoader(upstream: #huggingFaceTokenizerLoader())
+    )
+}
+
+func loadEmbeddingModelContainer(
+    modelName: String,
+    tokenizerLoader: any TokenizerLoader
+) async throws -> EmbedderModelContainer {
+    let config = MLXLMCommon.ModelConfiguration(directory: ModelPaths.getModelDirectory(for: modelName))
+
+    let container: EmbedderModelContainer
+    do {
+        container = try await EmbedderModelFactory.shared.loadContainer(
+            from: LocalOnlyModelDownloader(),
+            using: tokenizerLoader,
+            configuration: config
+        )
+    }
+    catch {
+        fputs(
+            "SwamaKit.EmbeddingRunner: Error loading embedding model container for '\(modelName)': \(error.localizedDescription)\n",
+            stderr
+        )
+        if let nsError = error as NSError? {
+            fputs("  Error Code: \(nsError.code), Domain: \(nsError.domain)\n", stderr)
+            if let underlying = nsError.userInfo[NSUnderlyingErrorKey] as? Error {
+                fputs("  Underlying Error: \(underlying.localizedDescription)\n", stderr)
+            }
+        }
+        throw error
+    }
+
+    return container
+}
+
+// MARK: - EmbeddingRunner
+
+/// An actor responsible for running embedding model inference.
+package actor EmbeddingRunner {
+    // MARK: Lifecycle
+
+    package init(container: EmbedderModelContainer) {
+        self.container = container
+        self.isRunning = false
+    }
+
+    // MARK: Public
+
+    /// Generates embeddings for the given input texts.
+    package func generateEmbeddings(inputs: [String]) async throws -> (
+        embeddings: [[Float]], usage: EmbeddingUsage
+    ) {
+        try await container.perform { context throws -> (
+            embeddings: [[Float]], usage: EmbeddingUsage
+        ) in
+            let model = context.model
+            let tokenizer = context.tokenizer
+            let pooler = context.pooling
+            var totalTokens = 0
+
+            // Tokenize all inputs
+            let padTokenId = tokenizer.eosTokenId ?? 0
+            let tokenizedInputs = inputs.enumerated().map { index, input in
+                let tokens = tokenizer.encode(text: input, addSpecialTokens: true)
+                totalTokens += tokens.count
+                return (index: index, tokens: tokens)
+            }
+
+            let sortedInputs = tokenizedInputs.sorted { $0.tokens.count < $1.tokens.count }
+            var allEmbeddings = Array(repeating: [Float](), count: inputs.count)
+
+            var startIndex = 0
+            while startIndex < sortedInputs.count {
+                let endIndex = min(startIndex + maxBatchSize, sortedInputs.count)
+                let batch = Array(sortedInputs[startIndex ..< endIndex])
+
+                let maxLength = batch.reduce(into: 0) { acc, item in
+                    acc = max(acc, item.tokens.count)
+                }
+
+                let paddedInputIds = MLX.stacked(
+                    batch.map { item -> MLXArray in
+                        let paddingCount = maxLength - item.tokens.count
+                        let paddedTokens = item.tokens + Array(repeating: padTokenId, count: paddingCount)
+                        return MLXArray(paddedTokens)
+                    }
+                )
+
+                // Create attention mask from original token lengths.
+                // This avoids treating real tokens as padding when they share the pad token id.
+                let attentionMask = MLX.stacked(
+                    batch.map { item -> MLXArray in
+                        let paddingCount = maxLength - item.tokens.count
+                        let mask = Array(repeating: 1, count: item.tokens.count)
+                            + Array(repeating: 0, count: paddingCount)
+                        return MLXArray(mask)
+                    }
+                ) .== MLXArray(1)
+
+                // Run the model with batched input
+                let output = model(
+                    paddedInputIds,
+                    positionIds: nil,
+                    tokenTypeIds: nil,
+                    attentionMask: attentionMask
+                )
+
+                // Pool hidden states according to the model's configured strategy
+                let pooledEmbeddings = pooler(
+                    output,
+                    mask: attentionMask,
+                    normalize: true,
+                    applyLayerNorm: true
+                )
+
+                // Convert each embedding to Float array and evaluate
+                eval(pooledEmbeddings)
+
+                for (offset, item) in batch.enumerated() {
+                    allEmbeddings[item.index] = pooledEmbeddings[offset].asArray(Float.self)
+                }
+
+                startIndex = endIndex
+            }
+
+            let usage = EmbeddingUsage(
+                promptTokens: totalTokens,
+                totalTokens: totalTokens
+            )
+
+            return (embeddings: allEmbeddings, usage: usage)
+        }
+    }
+
+    /// Generates a single embedding for the given input text.
+    package func generateEmbedding(input: String) async throws -> (embedding: [Float], usage: EmbeddingUsage) {
+        // Wait for any ongoing inference to complete
+        while isRunning {
+            try await Task.sleep(nanoseconds: 10_000_000) // 10ms
+        }
+
+        isRunning = true
+        defer { isRunning = false }
+
+        let result = try await generateEmbeddings(inputs: [input])
+        guard let firstEmbedding = result.embeddings.first else {
+            throw EmbeddingError.noEmbeddingGenerated
+        }
+
+        return (embedding: firstEmbedding, usage: result.usage)
+    }
+
+    // MARK: Private
+
+    private let container: EmbedderModelContainer
+    private var isRunning: Bool
+    private let maxBatchSize = 8
+}
+
+// MARK: - EmbeddingUsage
+
+package struct EmbeddingUsage: Sendable {
+    package let promptTokens: Int
+    package let totalTokens: Int
+
+    package init(promptTokens: Int, totalTokens: Int) {
+        self.promptTokens = promptTokens
+        self.totalTokens = totalTokens
+    }
+}
+
+// MARK: - EmbeddingError
+
+package enum EmbeddingError: Error, LocalizedError {
+    case noEmbeddingGenerated
+    case invalidInput
+    case modelNotSupported
+    case modelLoadFailed(String, underlying: Error)
+    case tokenizationFailed(String)
+
+    package var errorDescription: String? {
+        switch self {
+        case .noEmbeddingGenerated:
+            "No embedding was generated"
+        case .invalidInput:
+            "Invalid input provided"
+        case .modelNotSupported:
+            "Model is not supported for embeddings"
+        case let .modelLoadFailed(modelName, underlying):
+            "Failed to load embedding model '\(modelName)': \(underlying.localizedDescription)"
+        case let .tokenizationFailed(text):
+            "Failed to tokenize text: '\(text)'"
+        }
+    }
+}

--- a/swama/Sources/SwamaRuntime/Model/LocalOnlyModelDownloader.swift
+++ b/swama/Sources/SwamaRuntime/Model/LocalOnlyModelDownloader.swift
@@ -1,0 +1,14 @@
+import Foundation
+import MLXLMCommon
+
+struct LocalOnlyModelDownloader: Downloader {
+    func download(
+        id: String,
+        revision _: String?,
+        matching _: [String],
+        useLatest _: Bool,
+        progressHandler _: @Sendable @escaping (Progress) -> Void
+    ) async throws -> URL {
+        throw ModelPoolError.modelNotFoundLocally(id)
+    }
+}

--- a/swama/Sources/SwamaRuntime/Model/ModelAliases.swift
+++ b/swama/Sources/SwamaRuntime/Model/ModelAliases.swift
@@ -1,0 +1,108 @@
+
+//
+//  ModelAliases.swift
+//  SwamaKit
+//
+
+import Foundation
+
+package enum ModelAliasResolver {
+    // MARK: Public
+
+    /// Resolves a user-provided model name to its full Hugging Face model ID if an alias exists.
+    ///
+    /// - Parameter name: The model name or alias provided by the user.
+    /// - Returns: The resolved full model ID, or the original name if no alias is found.
+    package static func resolve(name: String) -> String {
+        let lowercasedName = name.lowercased()
+
+        // Check LLM aliases first
+        if let resolvedName = aliases[lowercasedName] {
+            return resolvedName
+        }
+
+        return name
+    }
+
+    // MARK: Internal
+
+    /// All keys should be lowercase for case-insensitive matching.
+    static let aliases: [String: String] = [
+        // DeepSeek Family
+        "deepseek-r1": "mlx-community/DeepSeek-R1-0528-4bit",
+        "deepseek-v3": "mlx-community/DeepSeek-V3-4bit",
+        "deepseek-v2.5": "mlx-community/DeepSeek-V2.5-1210-4bit",
+        "deepseek-coder": "mlx-community/DeepSeek-Coder-V2-Lite-Instruct-4bit-mlx",
+        "deepseek-r1-8b": "mlx-community/DeepSeek-R1-0528-Qwen3-8B-8bit",
+
+        // Qwen2.5 Family
+        "qwen2.5": "mlx-community/Qwen2.5-7B-Instruct-4bit", // Default for "qwen2.5"
+        "qwen2.5-0.5b": "mlx-community/Qwen2.5-0.5B-Instruct-4bit",
+        "qwen2.5-1.5b": "mlx-community/Qwen2.5-1.5B-Instruct-4bit",
+        "qwen2.5-3b": "mlx-community/Qwen2.5-3B-Instruct-4bit",
+        "qwen2.5-7b": "mlx-community/Qwen2.5-7B-Instruct-4bit",
+        "qwen2.5-14b": "mlx-community/Qwen2.5-14B-Instruct-4bit",
+        "qwen2.5-32b": "mlx-community/Qwen2.5-32B-Instruct-4bit",
+        "qwen2.5-72b": "mlx-community/Qwen2.5-72B-Instruct-4bit",
+
+        // Qwen3 Family
+        "qwen3": "mlx-community/Qwen3-8B-4bit", // Default for "qwen3"
+        "qwen3-30b": "mlx-community/Qwen3-30B-A3B-4bit",
+        "qwen3-30b-2507": "lmstudio-community/Qwen3-30B-A3B-Instruct-2507-MLX-4bit",
+        "qwen3-1.7b": "mlx-community/Qwen3-1.7B-4bit",
+        "qwen3-32b": "mlx-community/Qwen3-32B-4bit",
+        "qwen3-235b": "mlx-community/Qwen3-235B-A22B-4bit",
+
+        // Qwen3.5 Family (multimodal, no explicit "vl" suffix in model names)
+        "qwen3.5": "mlx-community/Qwen3.5-35B-A3B-4bit", // Default for "qwen3.5"
+        "qwen3.5-0.8b": "mlx-community/Qwen3.5-0.8B-4bit",
+        "qwen3.5-2b": "mlx-community/Qwen3.5-2B-4bit",
+        "qwen3.5-4b": "mlx-community/Qwen3.5-4B-4bit",
+        "qwen3.5-9b": "mlx-community/Qwen3.5-9B-4bit",
+        "qwen3.5-27b": "mlx-community/Qwen3.5-27B-4bit",
+        "qwen3.5-35b": "mlx-community/Qwen3.5-35B-A3B-4bit",
+        "qwen3.5-35b-a3b": "mlx-community/Qwen3.5-35B-A3B-4bit",
+        "qwen3.5-122b-a10b": "mlx-community/Qwen3.5-122B-A10B-4bit",
+        "qwen3.5-397b-a17b": "mlx-community/Qwen3.5-397B-A17B-4bit",
+
+        // Qwen3-VL Family (Vision-Language)
+        "qwen3-vl": "mlx-community/Qwen3-VL-4B-Instruct-4bit", // Default for "qwen3-vl"
+        "qwen3-vl-2b": "mlx-community/Qwen3-VL-2B-Instruct-4bit",
+        "qwen3-vl-4b": "mlx-community/Qwen3-VL-4B-Instruct-4bit",
+        "qwen3-vl-8b": "mlx-community/Qwen3-VL-8B-Instruct-4bit",
+        "qwen3-vl-32b": "mlx-community/Qwen3-VL-32B-Instruct-4bit",
+        "qwen3-vl-30b": "mlx-community/Qwen3-VL-30B-A3B-Instruct-4bit",
+        "qwen3-vl-235b": "mlx-community/Qwen3-VL-235B-A22B-Instruct-4bit",
+        // Thinking variants
+        "qwen3-vl-2b-thinking": "mlx-community/Qwen3-VL-2B-Thinking-4bit",
+        "qwen3-vl-4b-thinking": "mlx-community/Qwen3-VL-4B-Thinking-4bit",
+        "qwen3-vl-8b-thinking": "mlx-community/Qwen3-VL-8B-Thinking-4bit",
+        "qwen3-vl-32b-thinking": "mlx-community/Qwen3-VL-32B-Thinking-4bit",
+        "qwen3-vl-30b-thinking": "mlx-community/Qwen3-VL-30B-A3B-Thinking-4bit",
+        "qwen3-vl-235b-thinking": "mlx-community/Qwen3-VL-235B-A22B-Thinking-3bit",
+
+        // Gemma3 Famaly
+        "gemma3": "mlx-community/gemma-3-4b-it-4bit", // Default for "gemma3"
+        "gemma3-1b": "mlx-community/gemma-3-1b-it-4bit",
+        "gemma3-4b": "mlx-community/gemma-3-4b-it-4bit",
+        "gemma3-12b": "mlx-community/gemma-3-12b-it-4bit",
+        "gemma3-27b": "mlx-community/gemma-3-27b-it-4bit",
+
+        // Llama 3.x Family
+        "llama3": "mlx-community/Llama-3-8B-Instruct-4bit", // Default for "llama3"
+        "llama3-8b": "mlx-community/Llama-3-8B-Instruct-4bit",
+        "llama3.2": "mlx-community/Llama-3.2-3B-Instruct-4bit", // Default for "llama3.2"
+        "llama3.2-1b": "mlx-community/Llama-3.2-1B-Instruct-4bit",
+        "llama3.2-3b": "mlx-community/Llama-3.2-3B-Instruct-4bit",
+        "llama3.3": "mlx-community/Llama-3.3-70B-Instruct-4bit-DWQ", // Default for "llama3.3"
+        "llama3.3-70b": "mlx-community/Llama-3.3-70B-Instruct-4bit-DWQ",
+
+        // SmolLM Family
+        "smollm": "mlx-community/SmolLM-135M-Instruct-4bit",
+
+        // GPT-OSS Family
+        "gpt-oss": "lmstudio-community/gpt-oss-20b-MLX-8bit", // Default for "gpt-oss"
+        "gpt-oss-20b": "lmstudio-community/gpt-oss-20b-MLX-8bit",
+        "gpt-oss-120b": "lmstudio-community/gpt-oss-120b-MLX-8bit",
+    ]
+}

--- a/swama/Sources/SwamaRuntime/Model/ModelCreator.swift
+++ b/swama/Sources/SwamaRuntime/Model/ModelCreator.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+package enum ModelCreator {
+    package static func run(from path: String, name: String) async throws {
+        ModelDownloader.printMessage("Creating model from path: \(path) with name: \(name)")
+
+        let modelDir = ModelPaths.activeModelsDirectory.appendingPathComponent(name)
+        let sourceURL = URL(fileURLWithPath: path)
+
+        // Check if the model directory already exists
+        if FileManager.default.fileExists(atPath: modelDir.path) {
+            throw NSError(
+                domain: "ModelCreatorError",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Model directory already exists at \(modelDir.path)"]
+            )
+        }
+
+        // Create the model directory
+        try FileManager.default.createDirectory(at: modelDir, withIntermediateDirectories: true, attributes: nil)
+
+        // Copy all files from source to target directory
+        let fileManager = FileManager.default
+        let sourceFiles = try fileManager.contentsOfDirectory(at: sourceURL, includingPropertiesForKeys: nil)
+
+        for sourceFile in sourceFiles {
+            let fileName = sourceFile.lastPathComponent
+            let destinationFile = modelDir.appendingPathComponent(fileName)
+            try fileManager.copyItem(at: sourceFile, to: destinationFile)
+        }
+
+        // Write metadata to the target model directory
+        try ModelDownloader.writeModelMetadata(modelName: name, modelDir: modelDir)
+    }
+}

--- a/swama/Sources/SwamaRuntime/Model/ModelDownloader.swift
+++ b/swama/Sources/SwamaRuntime/Model/ModelDownloader.swift
@@ -1,0 +1,182 @@
+import Foundation
+
+// MARK: - ModelDownloader
+
+let Downloaders: [String: AnyClass] = [
+    "MODEL_SCOPE": ModelScopeDownloader.self,
+    "HUGGING_FACE": HuggingFaceDownloader.self
+]
+
+// MARK: - ModelDownloader
+
+package enum ModelDownloader {
+    // MARK: Public
+
+    package static func downloadModel(resolvedModelName: String) async throws {
+        printMessage("Pulling model: \(resolvedModelName)")
+
+        let modelDir = ModelPaths.getModelDirectory(for: resolvedModelName)
+        try FileManager.default.createDirectory(at: modelDir, withIntermediateDirectories: true)
+        let swamaRegistry = ProcessInfo.processInfo.environment["SWAMA_REGISTRY"] ?? "HUGGING_FACE"
+
+        guard let downloaderClass: IDownloader.Type = Downloaders[swamaRegistry] as? IDownloader.Type else {
+            throw NSError(
+                domain: "ModelDownloader",
+                code: 1,
+                userInfo: [
+                    NSLocalizedDescriptionKey: "Invalid registry: \(swamaRegistry). Supported: MODEL_SCOPE, HUGGING_FACE"
+                ]
+            )
+        }
+
+        printMessage("Using downloader: \(swamaRegistry)")
+        let downloader = downloaderClass.init()
+        let fileInfos = try await downloader.listModelFilesWithSize(repo: resolvedModelName)
+        let allowedExtensions = [
+            "safetensors",
+            "bin",
+            "json",
+            "model",
+            "txt",
+            "pt",
+            "params",
+            "tiktoken",
+            "vocab",
+            "jinja"
+        ]
+        let filteredFileInfos = fileInfos.filter { info in
+            allowedExtensions.contains(where: { info.path.hasSuffix(".\($0)") })
+        }
+
+        if filteredFileInfos.isEmpty, !fileInfos.isEmpty {
+            printMessage(
+                "Warning: No files with allowed extensions found for model \(resolvedModelName). Allowed: \(allowedExtensions.joined(separator: ", "))"
+            )
+        }
+
+        if filteredFileInfos.isEmpty, fileInfos.isEmpty {
+            printMessage("Warning: No files found on Hugging Face repo for model \(resolvedModelName).")
+            throw NSError(
+                domain: "ModelDownloader",
+                code: 2,
+                userInfo: [
+                    NSLocalizedDescriptionKey: "No files found on Hugging Face repository for model \(resolvedModelName)."
+                ]
+            )
+        }
+
+        for (idx, info) in filteredFileInfos.enumerated() {
+            let file = info.path
+            let remoteSize = info.size
+            let dest = modelDir.appendingPathComponent(file)
+
+            try FileManager.default.createDirectory(
+                at: dest.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+
+            var localSize: Int64 = 0
+            if FileManager.default.fileExists(atPath: dest.path) {
+                localSize = (try? FileManager.default.attributesOfItem(atPath: dest.path)[.size] as? NSNumber)?
+                    .int64Value ?? 0
+            }
+
+            if localSize == remoteSize, remoteSize > 0 {
+                printMessage("[\(idx + 1)/\(filteredFileInfos.count)] Exists: \(file), skip")
+                continue
+            }
+
+            printMessage("[\(idx + 1)/\(filteredFileInfos.count)] Downloading: \(file)")
+            try await downloader.downloadWithResume(
+                repo: resolvedModelName,
+                file: file,
+                dest: dest,
+                totalSize: remoteSize,
+                localSize: localSize
+            )
+        }
+
+        printMessage("✅ Model pull complete: \(resolvedModelName)")
+        try writeModelMetadata(modelName: resolvedModelName, modelDir: modelDir)
+    }
+
+    package static func fetchModel(modelName: String) async throws -> String {
+        let resolved = ModelAliasResolver.resolve(name: modelName)
+        let repoIds = resolveRepoIDs(resolvedName: resolved)
+        let allExists = repoIds.allSatisfy { ModelPaths.modelExistsLocally($0) }
+
+        // Check if model already exists locally
+        if allExists {
+            print("✅ Model already exists: \(resolved)")
+            return resolved
+        }
+
+        for repoId in repoIds {
+            try await ModelDownloader.downloadModel(resolvedModelName: repoId)
+        }
+
+        return resolved
+    }
+
+    private static func resolveRepoIDs(resolvedName: String) -> [String] {
+        [resolvedName]
+    }
+
+    // MARK: Internal
+
+    package static func printMessage(_ message: String) {
+        // Use fputs to stdout to behave like print
+        fputs(message + "\n", stdout)
+        fflush(stdout)
+    }
+
+    static func writeModelMetadata(modelName: String, modelDir: URL) throws {
+        let size = try calculateFolderSize(at: modelDir)
+        let created = Int(Date().timeIntervalSince1970)
+
+        // Write metadata file directly to the model directory
+        let metaURL = modelDir.appendingPathComponent(".swama-meta.json")
+
+        let metadata: [String: Any] = [
+            "id": modelName,
+            "object": "model",
+            "created": created,
+            "owned_by": "swama",
+            "size_in_bytes": size,
+            "path": modelDir.path
+        ]
+
+        let data = try JSONSerialization.data(withJSONObject: metadata, options: [.prettyPrinted])
+        try data.write(to: metaURL)
+        printMessage("📝 Metadata written to .swama-meta.json")
+    }
+
+    package static func calculateFolderSize(at url: URL) throws -> Int64 {
+        var total: Int64 = 0
+        let resourceKeys: [URLResourceKey] = [.isRegularFileKey, .fileSizeKey]
+        guard let enumerator = FileManager.default.enumerator(
+            at: url,
+            includingPropertiesForKeys: resourceKeys,
+            options: [.skipsHiddenFiles]
+        )
+        else {
+            return 0
+        }
+
+        for case let fileURL as URL in enumerator {
+            do {
+                let values = try fileURL.resourceValues(forKeys: Set(resourceKeys))
+                if values.isRegularFile == true {
+                    total += Int64(values.fileSize ?? 0)
+                }
+            }
+            catch {
+                fputs(
+                    "SwamaKit.ModelDownloader: Error getting resource values for \(fileURL.path): \(error.localizedDescription)\n",
+                    stderr
+                )
+            }
+        }
+        return total
+    }
+}

--- a/swama/Sources/SwamaRuntime/Model/ModelManager.swift
+++ b/swama/Sources/SwamaRuntime/Model/ModelManager.swift
@@ -20,13 +20,18 @@ package enum ModelManager {
 
     /// Scans a models directory and returns ModelInfo array.
     ///
-    /// A model is recognised solely by a `.swama-meta.json` file in its directory —
-    /// uniform across LLM, STT and TTS. Two on-disk shapes are supported:
+    /// A model is recognised solely by a `.swama-meta.json` file in its directory.
+    /// Two on-disk shapes are supported:
     ///   • flat:   `{root}/{model}/.swama-meta.json`
     ///   • nested: `{root}/{org}/{model}/.swama-meta.json`
-    /// The nested case also covers the audio layout `{root}/mlx-audio/{repo_underscore}/`.
+    ///
+    /// Intentional lineage divergence: this no-Audio runtime must not advertise models it
+    /// cannot serve, so the legacy `{root}/mlx-audio/` subtree is excluded explicitly.
     package static func scanModelsDirectory(at modelsRootDirectory: URL) -> [ModelInfo] {
         var modelInfos: [ModelInfo] = []
+        let canonicalAudioRoot = modelsRootDirectory
+            .appendingPathComponent("mlx-audio", isDirectory: true)
+            .standardizedFileURL
 
         let topLevel: [URL]
         do {
@@ -49,6 +54,9 @@ package enum ModelManager {
 
         for entry in topLevel {
             guard entry.hasDirectoryPath else {
+                continue
+            }
+            guard entry.standardizedFileURL != canonicalAudioRoot else {
                 continue
             }
 
@@ -89,10 +97,7 @@ package enum ModelManager {
     }
 
     /// Parse a `.swama-meta.json`. The displayed model id comes from the file's `id`
-    /// field (the canonical repo, e.g. `mlx-community/Qwen3-ASR-1.7B-bf16`); the
-    /// directory-derived `fallbackID` is used only when the file omits it. This matters
-    /// for audio models whose directory name is the underscore-joined repo, which cannot
-    /// be reliably reversed back into `{org}/{model}`.
+    /// field; the directory-derived `fallbackID` is used only when the file omits it.
     private static func parseModelMetadata(metaURL: URL, fallbackID: String) -> ModelInfo? {
         do {
             let data = try Data(contentsOf: metaURL)

--- a/swama/Sources/SwamaRuntime/Model/ModelManager.swift
+++ b/swama/Sources/SwamaRuntime/Model/ModelManager.swift
@@ -1,0 +1,187 @@
+import Foundation
+
+// MARK: - ModelManager
+
+/// Manages available MLX models, providing functionalities to list and load them.
+package enum ModelManager {
+    /// Lists all locally available models.
+    /// It scans both preferred and legacy directories for models and their metadata.
+    package static func models() -> [ModelInfo] {
+        var modelInfos: [ModelInfo] = []
+
+        // Scan all model directories (both preferred and legacy)
+        for modelsRootDirectory in ModelPaths.allModelsDirectories {
+            let directoryModels = scanModelsDirectory(at: modelsRootDirectory)
+            modelInfos.append(contentsOf: directoryModels)
+        }
+
+        return modelInfos
+    }
+
+    /// Scans a models directory and returns ModelInfo array.
+    ///
+    /// A model is recognised solely by a `.swama-meta.json` file in its directory —
+    /// uniform across LLM, STT and TTS. Two on-disk shapes are supported:
+    ///   • flat:   `{root}/{model}/.swama-meta.json`
+    ///   • nested: `{root}/{org}/{model}/.swama-meta.json`
+    /// The nested case also covers the audio layout `{root}/mlx-audio/{repo_underscore}/`.
+    package static func scanModelsDirectory(at modelsRootDirectory: URL) -> [ModelInfo] {
+        var modelInfos: [ModelInfo] = []
+
+        let topLevel: [URL]
+        do {
+            topLevel = try FileManager.default.contentsOfDirectory(
+                at: modelsRootDirectory,
+                includingPropertiesForKeys: [.isDirectoryKey],
+                options: [.skipsHiddenFiles]
+            )
+        }
+        catch {
+            // Only log error if the directory should exist (not for optional paths)
+            if FileManager.default.fileExists(atPath: modelsRootDirectory.path) {
+                fputs(
+                    "SwamaKit.ModelManager: Error reading models root directory \(modelsRootDirectory.path): \(error.localizedDescription)\n",
+                    stderr
+                )
+            }
+            return [] // Return empty if the root directory is inaccessible
+        }
+
+        for entry in topLevel {
+            guard entry.hasDirectoryPath else {
+                continue
+            }
+
+            // Flat layout: {root}/{model}/.swama-meta.json
+            let flatMeta = entry.appendingPathComponent(".swama-meta.json")
+            if FileManager.default.fileExists(atPath: flatMeta.path) {
+                if let info = parseModelMetadata(metaURL: flatMeta, fallbackID: entry.lastPathComponent) {
+                    modelInfos.append(info)
+                }
+                continue
+            }
+
+            // Nested layout: {root}/{org}/{model}/.swama-meta.json
+            let children = (try? FileManager.default.contentsOfDirectory(
+                at: entry,
+                includingPropertiesForKeys: [.isDirectoryKey],
+                options: [.skipsHiddenFiles]
+            )) ?? []
+
+            for child in children {
+                guard child.hasDirectoryPath else {
+                    continue
+                }
+
+                let metaURL = child.appendingPathComponent(".swama-meta.json")
+                guard FileManager.default.fileExists(atPath: metaURL.path) else {
+                    continue
+                }
+
+                let fallbackID = "\(entry.lastPathComponent)/\(child.lastPathComponent)"
+                if let info = parseModelMetadata(metaURL: metaURL, fallbackID: fallbackID) {
+                    modelInfos.append(info)
+                }
+            }
+        }
+
+        return modelInfos
+    }
+
+    /// Parse a `.swama-meta.json`. The displayed model id comes from the file's `id`
+    /// field (the canonical repo, e.g. `mlx-community/Qwen3-ASR-1.7B-bf16`); the
+    /// directory-derived `fallbackID` is used only when the file omits it. This matters
+    /// for audio models whose directory name is the underscore-joined repo, which cannot
+    /// be reliably reversed back into `{org}/{model}`.
+    private static func parseModelMetadata(metaURL: URL, fallbackID: String) -> ModelInfo? {
+        do {
+            let data = try Data(contentsOf: metaURL)
+            guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let created = json["created"] as? Int,
+                  let size = (json["size_in_bytes"] as? NSNumber)?.int64Value
+            else {
+                fputs("SwamaKit.ModelManager: Invalid .swama-meta.json for \(fallbackID)\n", stderr)
+                return nil
+            }
+
+            let id = (json["id"] as? String) ?? fallbackID
+            return ModelInfo(
+                id: id,
+                created: created,
+                sizeInBytes: size,
+                source: .metaFile,
+                rawMetadata: json
+            )
+        }
+        catch {
+            fputs(
+                "SwamaKit.ModelManager: Error reading .swama-meta.json for \(fallbackID): \(error.localizedDescription)\n",
+                stderr
+            )
+            return nil
+        }
+    }
+}
+
+// MARK: - MetadataSource
+
+/// Describes the source of the model's metadata.
+package enum MetadataSource {
+    case metaFile
+    case directoryScan
+}
+
+// MARK: - ModelInfo
+
+/// Basic information about a model.
+package struct ModelInfo: Identifiable { // Added Identifiable for potential UI usage
+    package let id: String
+    package let created: Int // Unix timestamp of creation
+    package let sizeInBytes: Int64
+    package let source: MetadataSource
+    package let rawMetadata: [String: Any]? // Full metadata from .swama-meta.json, if available
+
+    package init(
+        id: String,
+        created: Int,
+        sizeInBytes: Int64,
+        source: MetadataSource,
+        rawMetadata: [String: Any]? = nil
+    ) {
+        self.id = id
+        self.created = created
+        self.sizeInBytes = sizeInBytes
+        self.source = source
+        self.rawMetadata = rawMetadata
+    }
+}
+
+/// Utility extension to check if a URL points to a directory.
+private extension URL {
+    var hasDirectoryPath: Bool {
+        (try? resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false
+    }
+}
+
+/// Extension for URLSession to provide modern async data fetching.
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+extension URLSession {
+    /// Asynchronously fetches data from a URL.
+    /// This is a convenience wrapper around the instance method.
+    func data(from url: URL) async throws -> (Data, URLResponse) {
+        try await withCheckedThrowingContinuation { continuation in
+            let task = self.dataTask(with: url) { data, response, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                }
+                else if let data, let response {
+                    continuation.resume(returning: (data, response))
+                }
+                else {
+                    continuation.resume(throwing: URLError(.unknown))
+                }
+            }
+            task.resume()
+        }
+    }
+}

--- a/swama/Sources/SwamaRuntime/Model/ModelPaths.swift
+++ b/swama/Sources/SwamaRuntime/Model/ModelPaths.swift
@@ -1,0 +1,120 @@
+import Foundation
+
+// MARK: - ModelPaths
+
+/// Centralized configuration for model storage paths.
+///
+/// Every language, vision, or embedding model is identified on disk by a
+/// `.swama-meta.json` file inside its directory.
+package enum ModelPaths {
+    // MARK: - Root directories
+
+    /// The custom path for storing models (dynamically read from environment).
+    package static var customModelsDirectory: URL? {
+        if let customPath = ProcessInfo.processInfo.environment["SWAMA_MODELS"],
+           !customPath.isEmpty
+        {
+            return URL(fileURLWithPath: customPath)
+        }
+        return nil
+    }
+
+    /// The preferred path for storing models (new installations).
+    package static let preferredModelsDirectory: URL = {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        return home.appendingPathComponent(".swama/models")
+    }()
+
+    /// The legacy path for models (for compatibility).
+    package static let legacyModelsDirectory: URL = {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        return home.appendingPathComponent("Documents/huggingface/models")
+    }()
+
+    /// The actual directory used for storing new models (respects SWAMA_MODELS).
+    package static var activeModelsDirectory: URL {
+        customModelsDirectory ?? preferredModelsDirectory
+    }
+
+    // MARK: - Model directory resolution
+
+    /// Get the local directory for a model, checking custom → preferred → legacy locations.
+    package static func getModelDirectory(for modelName: String) -> URL {
+        let customPath = customModelsDirectory?.appendingPathComponent(modelName)
+        let preferredPath = preferredModelsDirectory.appendingPathComponent(modelName)
+        let legacyPath = legacyModelsDirectory.appendingPathComponent(modelName)
+
+        // Check if model exists in custom location first
+        if let customPath,
+           FileManager.default.fileExists(atPath: customPath.appendingPathComponent(".swama-meta.json").path)
+        {
+            return parseModelMetadataPath(from: customPath.appendingPathComponent(".swama-meta.json"))
+        }
+
+        // Check if model exists in preferred location
+        if FileManager.default.fileExists(atPath: preferredPath.appendingPathComponent(".swama-meta.json").path) {
+            return parseModelMetadataPath(from: preferredPath.appendingPathComponent(".swama-meta.json"))
+        }
+
+        // Check if model exists in legacy location
+        if FileManager.default.fileExists(atPath: legacyPath.appendingPathComponent(".swama-meta.json").path) {
+            return legacyPath
+        }
+
+        // Not found anywhere — return the location new downloads should use.
+        if let customPath {
+            return customPath
+        }
+        return preferredPath
+    }
+
+    private static func parseModelMetadataPath(from metaURL: URL) -> URL {
+        guard let data = try? Data(contentsOf: metaURL),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let path = json["path"] as? String
+        else {
+            return metaURL.deletingLastPathComponent()
+        }
+
+        return URL(fileURLWithPath: path)
+    }
+
+    // MARK: - Existence & listing
+
+    /// A model exists locally iff its directory contains a `.swama-meta.json`.
+    package static func modelExistsLocally(_ modelName: String) -> Bool {
+        let metaPath = getModelDirectory(for: modelName).appendingPathComponent(".swama-meta.json").path
+        return FileManager.default.fileExists(atPath: metaPath)
+    }
+
+    /// All directories that should be scanned for models.
+    package static var allModelsDirectories: [URL] {
+        var directories = [preferredModelsDirectory, legacyModelsDirectory]
+        if let customDirectory = customModelsDirectory {
+            directories.insert(customDirectory, at: 0)
+        }
+        return directories
+    }
+
+    // MARK: - Removal
+
+    /// Remove a model from disk. Returns true if found and deleted, false otherwise.
+    package static func removeModel(_ modelName: String) throws -> Bool {
+        // Check all candidate locations in priority order for a metadata file.
+        let locations = [
+            customModelsDirectory?.appendingPathComponent(modelName),
+            preferredModelsDirectory.appendingPathComponent(modelName),
+            legacyModelsDirectory.appendingPathComponent(modelName)
+        ].compactMap(\.self)
+
+        for location in locations {
+            let metadataFile = location.appendingPathComponent(".swama-meta.json")
+            if FileManager.default.fileExists(atPath: metadataFile.path) {
+                try FileManager.default.removeItem(at: location)
+                return true
+            }
+        }
+
+        return false // Model not found
+    }
+}

--- a/swama/Sources/SwamaRuntime/Model/ModelPool.swift
+++ b/swama/Sources/SwamaRuntime/Model/ModelPool.swift
@@ -1,0 +1,1453 @@
+import Foundation
+import MLX
+import MLXEmbedders
+import MLXHuggingFace
+import MLXLLM
+import MLXLMCommon
+import MLXVLM
+import Tokenizers
+
+// MARK: - ModelPoolError
+
+/// Errors specific to ModelPool operations
+package enum ModelPoolError: Error, LocalizedError {
+    case modelNotFoundLocally(String)
+    case failedToLoadModel(String, Error)
+
+    package var errorDescription: String? {
+        switch self {
+        case let .modelNotFoundLocally(modelName):
+            "Model '\(modelName)' not found locally. ModelPool only works with locally available models."
+        case let .failedToLoadModel(modelName, underlyingError):
+            "Failed to load model '\(modelName)': \(underlyingError.localizedDescription)"
+        }
+    }
+}
+
+// MARK: - ModelUsageInfo
+
+/// Statistics for tracking model usage patterns
+private struct ModelUsageInfo {
+    var lastUsedTime: Date
+    var usageCount: Int
+    var loadTime: Date
+
+    init() {
+        let now = Date()
+        self.lastUsedTime = now
+        self.usageCount = 1
+        self.loadTime = now
+    }
+
+    mutating func recordUsage() {
+        self.lastUsedTime = Date()
+        self.usageCount += 1
+    }
+
+    var idleTime: TimeInterval {
+        Date().timeIntervalSince(lastUsedTime)
+    }
+
+    var ageTime: TimeInterval {
+        Date().timeIntervalSince(loadTime)
+    }
+}
+
+// MARK: - ModelPoolMemoryHooks
+
+struct ModelPoolMemoryHooks: Sendable {
+    let activeMemory: @Sendable () -> Int
+    let clearCache: @Sendable () -> Void
+
+    static let live: ModelPoolMemoryHooks = .init(
+        activeMemory: { MLX.Memory.snapshot().activeMemory },
+        clearCache: { MLX.Memory.clearCache() }
+    )
+}
+
+// MARK: - ModelPoolLoadOverrides
+
+/// Test-only seams for making each asynchronous load path deterministic without touching MLX.
+/// Production pools leave this nil and use the real model factories below.
+struct ModelPoolLoadOverrides: Sendable {
+    let modelExistsLocally: @Sendable (String) -> Bool
+    let determineIsVLM: @Sendable (String) -> Bool
+    let loadLanguage: @Sendable (String, Bool) async throws -> MLXLMCommon.ModelContainer
+    let loadEmbedding: @Sendable (String) async throws -> EmbeddingRunner
+}
+
+// MARK: - ModelLoadToken
+
+private struct ModelLoadToken: Equatable, Sendable {
+    let globalGeneration: UInt64
+    let modelGeneration: UInt64
+    let sequence: UInt64
+}
+
+// MARK: - LoadedValueOwner
+
+/// A completed Task normally retains its success value. Keeping that value behind a releasable
+/// owner lets a stale load drop the last Task-owned model reference *before* the follow-up MLX
+/// cleanup runs.
+private final class LoadedValueOwner<Value: AnyObject>: @unchecked Sendable {
+    init(_ value: Value) {
+        self.value = value
+    }
+
+    func retainedValue() -> Value? {
+        lock.withLock { value }
+    }
+
+    @discardableResult
+    func release() -> Bool {
+        lock.withLock {
+            guard value != nil else {
+                return false
+            }
+
+            value = nil
+            return true
+        }
+    }
+
+    private let lock: NSLock = .init()
+    private var value: Value?
+}
+
+// MARK: - PendingModelLoad
+
+private struct PendingModelLoad<Value: AnyObject>: Sendable {
+    init(
+        token: ModelLoadToken,
+        task: Task<LoadedValueOwner<Value>, Error>,
+        diagnosticOperation: SwamaDiagnosticOperation,
+        diagnosticPhases: ModelLoadPhaseRecorder
+    ) {
+        self.token = token
+        self.task = task
+        self.diagnosticOperation = diagnosticOperation
+        self.diagnosticPhases = diagnosticPhases
+    }
+
+    let token: ModelLoadToken
+    let task: Task<LoadedValueOwner<Value>, Error>
+    let diagnosticOperation: SwamaDiagnosticOperation
+    let diagnosticPhases: ModelLoadPhaseRecorder
+    let postLoadCleanupGate: OneShotGate = .init()
+    let diagnosticTerminalGate: OneShotGate = .init()
+}
+
+// MARK: - OneShotGate
+
+private final class OneShotGate: @unchecked Sendable {
+    func claim() -> Bool {
+        lock.withLock {
+            guard !claimed else {
+                return false
+            }
+
+            claimed = true
+            return true
+        }
+    }
+
+    private let lock: NSLock = .init()
+    private var claimed = false
+}
+
+// MARK: - ModelPoolModelKind
+
+enum ModelPoolModelKind: CaseIterable, Sendable {
+    case language
+    case embedding
+}
+
+// MARK: - ModelPool
+
+/// A pool to manage and cache `ModelContainer` instances with built-in concurrency control.
+/// This helps in reusing already loaded models to save resources and time while preventing
+/// MLX heap corruption through controlled concurrent access.
+///
+/// Features intelligent memory management with automatic model eviction based on idle time
+/// to prevent GPU memory exhaustion when loading multiple models.
+package actor ModelPool {
+    // MARK: Lifecycle
+
+    package init() {
+        memoryHooks = .live
+        loadOverrides = nil
+        tokenizerCache = .shared
+        tokenizerCacheOwner = .init()
+        // Cache limit and memory management timer are both deferred: the former until MLX is
+        // genuinely about to be used (see `ensureCacheLimitConfigured()`), the latter until
+        // first model access (see `ensureMemoryManagementStarted()`). Neither may run here --
+        // `configureCacheLimit()` touches `MLX.Memory`, which triggers MLX's Metal/device
+        // library load, so calling it eagerly from `init()` would force that initialization
+        // just to construct a `ModelPool`, which is what made `ModelPool` impossible to
+        // construct under `swift test` (no colocated `mlx.metallib` for the test binary).
+    }
+
+    init(
+        memoryHooks: ModelPoolMemoryHooks,
+        loadOverrides: ModelPoolLoadOverrides? = nil,
+        tokenizerCache: TokenizerCache = .shared,
+        tokenizerCacheOwner: TokenizerCacheOwner = .init()
+    ) {
+        self.memoryHooks = memoryHooks
+        self.loadOverrides = loadOverrides
+        self.tokenizerCache = tokenizerCache
+        self.tokenizerCacheOwner = tokenizerCacheOwner
+    }
+
+    deinit {
+        tokenizerCache.purge(owner: tokenizerCacheOwner)
+    }
+
+    /// Ensures memory management timer is running (called on first model access)
+    private func ensureMemoryManagementStarted() {
+        guard memoryManagementTask == nil else {
+            return
+        }
+
+        startMemoryManagementTimer()
+    }
+
+    /// Ensures the MLX cache limit has been configured. Idempotent -- safe to call from every
+    /// site that's about to actually load a model.
+    ///
+    /// Must only be called immediately before code that will genuinely touch MLX (i.e. right
+    /// before loading a model container/runner), never from MLX-free paths like
+    /// `ensureMemoryManagementStarted()` or `getContainer`'s cache/task lookups -- those must
+    /// stay MLX-free so a test can reach `ModelPoolError.modelNotFoundLocally` without
+    /// initializing Metal.
+    private func ensureCacheLimitConfigured() {
+        guard !didConfigureCacheLimit else {
+            return
+        }
+
+        didConfigureCacheLimit = true
+        if loadOverrides == nil {
+            Self.configureCacheLimit()
+        }
+    }
+
+    /// Whether `configureCacheLimit()` has already run for this pool.
+    private var didConfigureCacheLimit = false
+
+    private static func configureCacheLimit() {
+        let ramBytes = ProcessInfo.processInfo.physicalMemory
+        let maxCacheBytes: UInt64 = 8 * 1024 * 1024 * 1024
+        let limit = min(maxCacheBytes, ramBytes / 10)
+        if limit > 0 {
+            MLX.Memory.cacheLimit = Int(limit)
+        }
+    }
+
+    // MARK: Public
+
+    package static let shared: ModelPool = .init()
+
+    // MARK: - Memory Management Configuration
+
+    /// Maximum idle time before a model becomes eligible for eviction (5 minutes for production)
+    private let maxIdleTime: TimeInterval = 5 * 60
+
+    /// Interval for checking and evicting idle models (1 minute for production)
+    private let memoryCheckInterval: TimeInterval = 60
+
+    /// Maximum number of models to keep in cache before triggering aggressive cleanup
+    private let maxCacheSize = 4
+
+    /// Limit idle evictions per cleanup cycle to reduce churn
+    private let maxIdleEvictionsPerCycle = 1
+
+    /// Task for periodic memory management
+    private var memoryManagementTask: Task<Void, Never>?
+
+    // MARK: - Concurrency Control
+
+    private var runningInferences = 0
+    private let maxConcurrentInferences = 3 // Optimal for high-performance machines
+
+    /// Per-model concurrency control: map each reserved model to its owning operation token.
+    private var runningModels: [String: UInt64] = [:]
+
+    /// The same operation token remains here only until its model load finishes. Matching tokens
+    /// are an explicit credential for eviction to cancel a load without touching a live operation.
+    private var loadingModels: [String: UInt64] = [:]
+    private var nextOperationSequence: UInt64 = 0
+
+    private func beginModelOperation(_ modelName: String) -> UInt64 {
+        nextOperationSequence &+= 1
+        let token = nextOperationSequence
+        runningModels[modelName] = token
+        loadingModels[modelName] = token
+        return token
+    }
+
+    private func finishLoadingPhase(_ modelName: String, token: UInt64) {
+        if loadingModels[modelName] == token {
+            loadingModels.removeValue(forKey: modelName)
+        }
+    }
+
+    private func endModelOperation(_ modelName: String, token: UInt64) {
+        finishLoadingPhase(modelName, token: token)
+        if runningModels[modelName] == token {
+            runningModels.removeValue(forKey: modelName)
+        }
+    }
+
+    /// Safely run a model operation with concurrency control to prevent MLX heap corruption
+    package func run<T: Sendable>(
+        modelName: String,
+        operation: @Sendable @escaping (ModelRunner) async throws -> T
+    ) async throws -> T {
+        // Wait for available slot AND ensure the specific model is not already running
+        while runningInferences >= maxConcurrentInferences || runningModels[modelName] != nil {
+            try await Task.sleep(nanoseconds: 50_000_000) // 50ms
+        }
+
+        try Task.checkCancellation()
+
+        runningInferences += 1
+        let operationToken = beginModelOperation(modelName)
+        defer {
+            runningInferences = max(0, runningInferences - 1)
+            endModelOperation(modelName, token: operationToken)
+        }
+
+        // Get or load the model container
+        let container = try await getContainer(modelName: modelName)
+        finishLoadingPhase(modelName, token: operationToken)
+        let runner = ModelRunner(container: container)
+
+        // Execute the operation
+        return try await operation(runner)
+    }
+
+    /// Safely run an embedding operation with concurrency control to prevent MLX heap corruption
+    package func runEmbeddingWithConcurrencyControl<T: Sendable>(
+        modelName: String,
+        operation: @Sendable @escaping (EmbeddingRunner) async throws -> T
+    ) async throws -> T {
+        // Embedding requests share the global pool limit but deliberately do not reserve
+        // `runningModels`: EmbeddingRunner is an actor and EmbedderModelContainer serializes
+        // access internally, so same-model callers may coalesce one load and then queue there.
+        while runningInferences >= maxConcurrentInferences {
+            try await Task.sleep(nanoseconds: 50_000_000) // 50ms
+        }
+
+        try Task.checkCancellation()
+
+        runningInferences += 1
+        defer {
+            runningInferences = max(0, runningInferences - 1)
+        }
+
+        let runner = try await getOrLoadEmbeddingRunner(modelName: modelName)
+
+        // Execute the operation
+        return try await operation(runner)
+    }
+
+    /// Gets or loads a ModelContainer
+    private func getContainer(modelName: String) async throws -> MLXLMCommon.ModelContainer {
+        // Ensure memory management is started
+        ensureMemoryManagementStarted()
+
+        if let container = cache[modelName] {
+            // Record usage for existing cached model
+            modelUsageInfo[modelName]?.recordUsage()
+            return container
+        }
+
+        if let pending = tasks[modelName] {
+            return try await finishLanguageLoad(pending, modelName: modelName)
+        }
+
+        // Check if we need to free up memory before loading a new model
+        await performMemoryPressureCheck()
+
+        guard modelExistsLocally(modelName) else {
+            modelTypeCache.removeValue(forKey: modelName)
+            throw ModelPoolError.modelNotFoundLocally(modelName)
+        }
+
+        let isVLM = modelTypeCache[modelName] ?? determineModelType(modelName)
+        modelTypeCache[modelName] = isVLM
+
+        let token = makeLoadToken(for: modelName)
+        let diagnosticPhases = ModelLoadPhaseRecorder()
+        let diagnosticOperation = SwamaDiagnostics.startModelLoad(model: modelName)
+        let task = Task { [self] in
+            let container = try await loadLanguageContainer(
+                modelName: modelName,
+                isVLM: isVLM,
+                diagnosticPhases: diagnosticPhases
+            )
+            return LoadedValueOwner(container)
+        }
+        let pending = PendingModelLoad(
+            token: token,
+            task: task,
+            diagnosticOperation: diagnosticOperation,
+            diagnosticPhases: diagnosticPhases
+        )
+        tasks[modelName] = pending
+        return try await finishLanguageLoad(pending, modelName: modelName)
+    }
+
+    /// Gets or loads an embedding model runner for the given model name.
+    package func getEmbeddingRunner(for modelName: String) async -> EmbeddingRunner? {
+        embeddingRunnerCache[modelName]
+    }
+
+    /// Sets an embedding model runner for the given model name.
+    package func setEmbeddingRunner(_ runner: EmbeddingRunner, for modelName: String) async {
+        embeddingRunnerCache[modelName] = runner
+    }
+
+    /// Clears the entire model cache and cancels any ongoing loading tasks.
+    package func clearCache() {
+        let memoryBefore = memoryHooks.activeMemory()
+        let evictedCount = cache.count
+        let modelNames = Set(cache.keys)
+            .union(tasks.keys)
+            .union(embeddingRunnerCache.keys)
+            .union(embeddingTasks.keys)
+        let diagnosticOperations = Dictionary(uniqueKeysWithValues: modelNames.map {
+            ($0, SwamaDiagnostics.startEviction(model: $0))
+        })
+
+        invalidateAllLoads()
+
+        // Cancel loading work before dropping the task dictionaries. Do not snapshot their
+        // values into local arrays: completed Task values can retain loaded model containers.
+        for pending in tasks.values {
+            pending.task.cancel()
+        }
+        for pending in embeddingTasks.values {
+            pending.task.cancel()
+        }
+
+        // Release every owner before asking MLX to return unused allocations. The previous
+        // implementation copied `cache.values` into `containersToEvict`, then captured that
+        // array in an asynchronous cleanup Task. MLX therefore cleared while all model weights
+        // were still strongly retained; after the Task released them, no second clear occurred.
+        cache.removeAll()
+        tasks.removeAll()
+        embeddingTasks.removeAll()
+        modelTypeCache.removeAll()
+        vlmRegistryCache = nil
+        embeddingRunnerCache.removeAll()
+        PromptCacheStore.shared.dropAll()
+        modelUsageInfo.removeAll()
+        tokenizerCache.purge(owner: tokenizerCacheOwner)
+
+        // Synchronous completion is part of the contract: when clearCache returns, model owners
+        // are gone and MLX cleanup has run. Callers no longer race a detached cleanup Task.
+        memoryHooks.clearCache()
+
+        let memoryAfter = memoryHooks.activeMemory()
+        let memoryReleased = max(0, memoryBefore - memoryAfter)
+        let residentBytesAfter = SwamaDiagnostics.residentBytes()
+        for (modelName, operation) in diagnosticOperations {
+            SwamaDiagnostics.completeEviction(
+                operation,
+                model: modelName,
+                generation: globalLoadGeneration,
+                residentBytesAfter: residentBytesAfter
+            )
+        }
+        NSLog(
+            "SwamaKit.ModelPool: Cache cleared (\(evictedCount) models). Released \(memoryReleased / (1024 * 1024))MB active memory. Active: \(memoryAfter / (1024 * 1024))MB"
+        )
+    }
+
+    /// Removes a specific model from the cache and cancels its loading task if active.
+    package func remove(modelName: String) {
+        let hadEntry = cache[modelName] != nil
+            || tasks[modelName] != nil
+            || embeddingRunnerCache[modelName] != nil
+            || embeddingTasks[modelName] != nil
+        let diagnosticOperation = hadEntry ? SwamaDiagnostics.startEviction(model: modelName) : nil
+        invalidateLoads(for: modelName)
+
+        cache.removeValue(forKey: modelName)
+        modelTypeCache.removeValue(forKey: modelName) // Clear type cache for this model
+        embeddingRunnerCache.removeValue(forKey: modelName) // Clear embedding cache for this model
+        PromptCacheStore.shared.drop(modelName: modelName) // Clear prompt/KV-cache slot for this model
+        modelUsageInfo.removeValue(forKey: modelName) // Clear usage tracking for this model
+
+        if let pending = tasks.removeValue(forKey: modelName) {
+            pending.task.cancel()
+        }
+
+        if let pending = embeddingTasks.removeValue(forKey: modelName) {
+            pending.task.cancel()
+        }
+
+        // All strong owners have been removed before MLX cleanup runs.
+        memoryHooks.clearCache()
+        if let diagnosticOperation {
+            SwamaDiagnostics.completeEviction(
+                diagnosticOperation,
+                model: modelName,
+                generation: modelLoadGenerations[modelName, default: 0],
+                residentBytesAfter: SwamaDiagnostics.residentBytes()
+            )
+        }
+    }
+
+    #if DEBUG
+        func cacheContainerForTesting(_ container: MLXLMCommon.ModelContainer, modelName: String) {
+            cache[modelName] = container
+        }
+
+        func evictModelForTesting(modelName: String) async {
+            await evictModel(modelName: modelName, reason: "test")
+        }
+
+        func isCachedForTesting(_ kind: ModelPoolModelKind, modelName: String) -> Bool {
+            switch kind {
+            case .language:
+                cache[modelName] != nil
+            case .embedding:
+                embeddingRunnerCache[modelName] != nil
+            }
+        }
+
+        func hasPendingLoadForTesting(_ kind: ModelPoolModelKind, modelName: String) -> Bool {
+            switch kind {
+            case .language:
+                tasks[modelName] != nil
+            case .embedding:
+                embeddingTasks[modelName] != nil
+            }
+        }
+
+        func hasMatchingLoadingOperationForTesting(modelName: String) -> Bool {
+            guard let runningOwner = runningModels[modelName] else {
+                return false
+            }
+
+            return loadingModels[modelName] == runningOwner
+        }
+
+        func runningInferenceCountForTesting() -> Int {
+            runningInferences
+        }
+    #endif
+
+    // MARK: Private
+
+    private var cache: [String: MLXLMCommon.ModelContainer] = .init()
+    private var tasks: [String: PendingModelLoad<MLXLMCommon.ModelContainer>] = .init()
+    private var embeddingRunnerCache: [String: EmbeddingRunner] = .init()
+    private var embeddingTasks: [String: PendingModelLoad<EmbeddingRunner>] = .init()
+
+    /// Every teardown changes either the global generation or the named model generation.
+    /// A load may ignore cooperative cancellation, but it cannot commit across this boundary.
+    private var globalLoadGeneration: UInt64 = 0
+    private var modelLoadGenerations: [String: UInt64] = .init()
+    private var nextLoadSequence: UInt64 = 0
+
+    /// Memory management tracking
+    private var modelUsageInfo: [String: ModelUsageInfo] = .init()
+
+    private var modelTypeCache: [String: Bool] = .init()
+    private var vlmRegistryCache: [String: MLXLMCommon.ModelConfiguration]?
+    private let memoryHooks: ModelPoolMemoryHooks
+    private let loadOverrides: ModelPoolLoadOverrides?
+    private let tokenizerCache: TokenizerCache
+    private let tokenizerCacheOwner: TokenizerCacheOwner
+
+    private func makeLoadToken(for modelName: String) -> ModelLoadToken {
+        nextLoadSequence &+= 1
+        return ModelLoadToken(
+            globalGeneration: globalLoadGeneration,
+            modelGeneration: modelLoadGenerations[modelName, default: 0],
+            sequence: nextLoadSequence
+        )
+    }
+
+    private func invalidateAllLoads() {
+        globalLoadGeneration &+= 1
+        modelLoadGenerations.removeAll()
+    }
+
+    private func invalidateLoads(for modelName: String) {
+        modelLoadGenerations[modelName, default: 0] &+= 1
+    }
+
+    private func isCurrent(_ token: ModelLoadToken, modelName: String) -> Bool {
+        token.globalGeneration == globalLoadGeneration
+            && token.modelGeneration == modelLoadGenerations[modelName, default: 0]
+    }
+
+    private func resolvedLoadedValue<Value: AnyObject>(
+        _ owner: LoadedValueOwner<Value>,
+        token: ModelLoadToken,
+        modelName: String,
+        postLoadCleanupGate: OneShotGate
+    ) throws -> Value {
+        guard isCurrent(token, modelName: modelName) else {
+            // clear/remove/evict already ran one cleanup while this owner was still live. Drop
+            // the Task-retained value first, then run the bounded follow-up cleanup exactly once.
+            owner.release()
+            if postLoadCleanupGate.claim() {
+                memoryHooks.clearCache()
+            }
+            throw CancellationError()
+        }
+        guard let value = owner.retainedValue() else {
+            throw CancellationError()
+        }
+
+        return value
+    }
+
+    private func finishLanguageLoad(
+        _ pending: PendingModelLoad<MLXLMCommon.ModelContainer>,
+        modelName: String
+    ) async throws -> MLXLMCommon.ModelContainer {
+        try await finishLoad(
+            pending,
+            modelName: modelName,
+            currentPendingToken: { tasks[modelName]?.token },
+            removePending: { tasks.removeValue(forKey: modelName) },
+            cachedValue: { cache[modelName] },
+            storeLoaded: { loaded in
+                cache[modelName] = loaded
+                modelUsageInfo[modelName] = ModelUsageInfo()
+            },
+            recordCachedUse: {
+                modelUsageInfo[modelName]?.recordUsage()
+            }
+        )
+    }
+
+    private func getOrLoadEmbeddingRunner(modelName: String) async throws -> EmbeddingRunner {
+        if let runner = embeddingRunnerCache[modelName] {
+            return runner
+        }
+
+        if let pending = embeddingTasks[modelName] {
+            return try await finishEmbeddingLoad(pending, modelName: modelName)
+        }
+
+        ensureCacheLimitConfigured()
+        let token = makeLoadToken(for: modelName)
+        let diagnosticPhases = ModelLoadPhaseRecorder()
+        let diagnosticOperation = SwamaDiagnostics.startModelLoad(model: modelName)
+        let task = Task { [self] in
+            let runner = try await loadEmbeddingRunner(
+                modelName: modelName,
+                diagnosticPhases: diagnosticPhases
+            )
+            return LoadedValueOwner(runner)
+        }
+        let pending = PendingModelLoad(
+            token: token,
+            task: task,
+            diagnosticOperation: diagnosticOperation,
+            diagnosticPhases: diagnosticPhases
+        )
+        embeddingTasks[modelName] = pending
+        return try await finishEmbeddingLoad(pending, modelName: modelName)
+    }
+
+    private func finishEmbeddingLoad(
+        _ pending: PendingModelLoad<EmbeddingRunner>,
+        modelName: String
+    ) async throws -> EmbeddingRunner {
+        try await finishLoad(
+            pending,
+            modelName: modelName,
+            currentPendingToken: { embeddingTasks[modelName]?.token },
+            removePending: { embeddingTasks.removeValue(forKey: modelName) },
+            cachedValue: { embeddingRunnerCache[modelName] },
+            storeLoaded: { embeddingRunnerCache[modelName] = $0 },
+            recordCachedUse: {}
+        )
+    }
+
+    private func finishLoad<Value: AnyObject>(
+        _ pending: PendingModelLoad<Value>,
+        modelName: String,
+        currentPendingToken: () -> ModelLoadToken?,
+        removePending: () -> Void,
+        cachedValue: () -> Value?,
+        storeLoaded: (Value) -> Void,
+        recordCachedUse: () -> Void
+    ) async throws -> Value {
+        do {
+            let owner = try await pending.task.value
+
+            guard isCurrent(pending.token, modelName: modelName) else {
+                return try resolvedLoadedValue(
+                    owner,
+                    token: pending.token,
+                    modelName: modelName,
+                    postLoadCleanupGate: pending.postLoadCleanupGate
+                )
+            }
+
+            if let existing = cachedValue() {
+                recordCachedUse()
+                // Another waiter or an explicit cache setter won the commit. A completed Task
+                // must not retain its unused load; if it owned a distinct value, clean up after
+                // releasing it. Multiple waiters share this one-shot cleanup gate.
+                if owner.release(), pending.postLoadCleanupGate.claim() {
+                    memoryHooks.clearCache()
+                }
+                if currentPendingToken() == pending.token {
+                    removePending()
+                }
+                completeLoadDiagnostics(pending, modelName: modelName)
+                return existing
+            }
+
+            let loaded = try resolvedLoadedValue(
+                owner,
+                token: pending.token,
+                modelName: modelName,
+                postLoadCleanupGate: pending.postLoadCleanupGate
+            )
+            storeLoaded(loaded)
+            owner.release()
+
+            if currentPendingToken() == pending.token {
+                removePending()
+            }
+            completeLoadDiagnostics(pending, modelName: modelName)
+            return loaded
+        }
+        catch {
+            let wasInvalidated = !isCurrent(pending.token, modelName: modelName)
+            cleanupAfterStaleFailure(pending, modelName: modelName)
+            if currentPendingToken() == pending.token {
+                removePending()
+            }
+            finishLoadDiagnostics(
+                pending,
+                modelName: modelName,
+                error: error,
+                wasInvalidated: wasInvalidated
+            )
+            if wasInvalidated {
+                throw CancellationError()
+            }
+            throw error
+        }
+    }
+
+    private func modelExistsLocally(_ modelName: String) -> Bool {
+        loadOverrides?.modelExistsLocally(modelName)
+            ?? ModelPaths.modelExistsLocally(modelName)
+    }
+
+    private func cleanupAfterStaleFailure(
+        _ pending: PendingModelLoad<some AnyObject>,
+        modelName: String
+    ) {
+        guard !isCurrent(pending.token, modelName: modelName),
+              pending.postLoadCleanupGate.claim()
+        else {
+            return
+        }
+
+        memoryHooks.clearCache()
+    }
+
+    private func completeLoadDiagnostics(
+        _ pending: PendingModelLoad<some AnyObject>,
+        modelName: String
+    ) {
+        guard pending.diagnosticTerminalGate.claim() else {
+            return
+        }
+
+        SwamaDiagnostics.completeModelLoad(
+            pending.diagnosticOperation,
+            model: modelName,
+            phases: pending.diagnosticPhases.phases
+        )
+    }
+
+    private func finishLoadDiagnostics(
+        _ pending: PendingModelLoad<some AnyObject>,
+        modelName: String,
+        error: Error,
+        wasInvalidated: Bool
+    ) {
+        guard pending.diagnosticTerminalGate.claim() else {
+            return
+        }
+
+        if wasInvalidated || error is CancellationError {
+            SwamaDiagnostics.cancelModelLoad(
+                pending.diagnosticOperation,
+                model: modelName,
+                phases: pending.diagnosticPhases.phases
+            )
+            return
+        }
+
+        let code: SwamaDiagnosticErrorCode =
+            if let poolError = error as? ModelPoolError {
+                switch poolError {
+                case .modelNotFoundLocally:
+                    .modelNotFound
+                case .failedToLoadModel:
+                    .modelLoadFailed
+                }
+            }
+            else {
+                .modelLoadFailed
+            }
+        SwamaDiagnostics.failModelLoad(
+            pending.diagnosticOperation,
+            model: modelName,
+            code: code,
+            phases: pending.diagnosticPhases.phases
+        )
+    }
+
+    private func determineModelType(_ modelName: String) -> Bool {
+        loadOverrides?.determineIsVLM(modelName)
+            ?? determineIfVLMModel(modelName: modelName)
+    }
+
+    private func loadLanguageContainer(
+        modelName: String,
+        isVLM: Bool,
+        diagnosticPhases: ModelLoadPhaseRecorder
+    ) async throws -> MLXLMCommon.ModelContainer {
+        if let load = loadOverrides?.loadLanguage {
+            return try await load(modelName, isVLM)
+        }
+        return try await loadModelContainer(
+            modelName: modelName,
+            isVLM: isVLM,
+            diagnosticPhases: diagnosticPhases
+        )
+    }
+
+    private func loadEmbeddingRunner(
+        modelName: String,
+        diagnosticPhases: ModelLoadPhaseRecorder
+    ) async throws -> EmbeddingRunner {
+        if let load = loadOverrides?.loadEmbedding {
+            return try await load(modelName)
+        }
+        let container = try await loadEmbeddingModelContainer(
+            modelName: modelName,
+            tokenizerLoader: DiagnosticTokenizerLoader(
+                upstream: #huggingFaceTokenizerLoader(),
+                phases: diagnosticPhases,
+                cache: tokenizerCache,
+                owner: tokenizerCacheOwner
+            )
+        )
+        return EmbeddingRunner(container: container)
+    }
+
+    private func hasPendingLoad(for modelName: String) -> Bool {
+        tasks[modelName] != nil
+            || embeddingTasks[modelName] != nil
+    }
+
+    /// Unified VLM detection logic with registry priority
+    private func determineIfVLMModel(modelName: String) -> Bool {
+        // Ensure VLM registry is initialized
+        ensureVLMRegistryInitialized()
+
+        if vlmRegistryCache!.keys.contains(where: { $0.caseInsensitiveCompare(modelName) == .orderedSame }) {
+            return true
+        }
+
+        // Prefer local config-driven detection for multimodal models whose names do not
+        // include "vl" (for example Qwen3.5 variants).
+        if isVLMModelByLocalConfig(modelName) {
+            return true
+        }
+
+        return isVLMModelByName(modelName)
+    }
+
+    private func loadModelContainer(
+        modelName: String,
+        isVLM: Bool,
+        diagnosticPhases: ModelLoadPhaseRecorder
+    ) async throws -> MLXLMCommon.ModelContainer {
+        // About to genuinely touch MLX (loading a container triggers Metal init) -- configure
+        // the cache limit now, idempotently, rather than eagerly in `init()`.
+        ensureCacheLimitConfigured()
+
+        ensureChatTemplateIfNeeded(for: modelName)
+        // Configure extra EOS tokens for models with known issues
+        let extraEOSTokens = getExtraEOSTokens(for: modelName)
+
+        let localConfig = MLXLMCommon.ModelConfiguration(
+            directory: ModelPaths.getModelDirectory(for: modelName),
+            extraEOSTokens: extraEOSTokens
+        )
+
+        do {
+            let tokenizerLoader = DiagnosticTokenizerLoader(
+                upstream: #huggingFaceTokenizerLoader(),
+                phases: diagnosticPhases,
+                cache: tokenizerCache,
+                owner: tokenizerCacheOwner
+            )
+            if isVLM {
+                return try await VLMModelFactory.shared.loadContainer(
+                    from: LocalOnlyModelDownloader(),
+                    using: tokenizerLoader,
+                    configuration: localConfig
+                )
+            }
+            else {
+                return try await LLMModelFactory.shared.loadContainer(
+                    from: LocalOnlyModelDownloader(),
+                    using: tokenizerLoader,
+                    configuration: localConfig
+                )
+            }
+        }
+        catch {
+            throw ModelPoolError.failedToLoadModel(modelName, error)
+        }
+    }
+
+    /// Get extra EOS tokens for models with known tokenization issues
+    private func getExtraEOSTokens(for modelName: String) -> Set<String> {
+        let lowercaseName = modelName.lowercased()
+        var tokens = detectEOSTokensFromModelFiles(modelName: modelName)
+
+        if lowercaseName.contains("gemma") {
+            tokens.insert("<end_of_turn>")
+        }
+
+        if lowercaseName.contains("qwen3-coder") {
+            tokens.insert("<endoftext>")
+        }
+
+        if !tokens.isEmpty {
+            let tokenList = Array(tokens)
+            NSLog(
+                "SwamaKit.ModelPool: extra EOS tokens for %@ -> %@",
+                modelName,
+                tokenList.joined(separator: ",")
+            )
+        }
+
+        return tokens
+    }
+
+    private func detectEOSTokensFromModelFiles(modelName: String) -> Set<String> {
+        let modelDirectory = ModelPaths.getModelDirectory(for: modelName)
+        let configURL = modelDirectory.appendingPathComponent("config.json")
+        let generationConfigURL = modelDirectory.appendingPathComponent("generation_config.json")
+        let tokenizerURL = modelDirectory.appendingPathComponent("tokenizer.json")
+
+        var eosTokenIDs: Set<Int> = []
+
+        if let ids = parseEOSTokenIDs(from: configURL) {
+            eosTokenIDs.formUnion(ids)
+        }
+
+        if let ids = parseEOSTokenIDs(from: generationConfigURL) {
+            eosTokenIDs.formUnion(ids)
+        }
+
+        guard !eosTokenIDs.isEmpty,
+              let tokens = mapTokenIDsToStrings(ids: eosTokenIDs, tokenizerURL: tokenizerURL)
+        else {
+            return []
+        }
+
+        return tokens
+    }
+
+    private func ensureChatTemplateIfNeeded(for modelName: String) {
+        let modelDirectory = ModelPaths.getModelDirectory(for: modelName)
+        let tokenizerConfigURL = modelDirectory.appendingPathComponent("tokenizer_config.json")
+        let templateURL = modelDirectory.appendingPathComponent("chat_template.jinja")
+
+        guard FileManager.default.fileExists(atPath: tokenizerConfigURL.path) else {
+            return
+        }
+        guard let configData = try? Data(contentsOf: tokenizerConfigURL),
+              var jsonObject = try? JSONSerialization.jsonObject(with: configData) as? [String: Any]
+        else {
+            return
+        }
+
+        if let existingTemplate = jsonObject["chat_template"] as? String,
+           !existingTemplate.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        {
+            return
+        }
+
+        guard FileManager.default.fileExists(atPath: templateURL.path),
+              let templateString = try? String(contentsOf: templateURL, encoding: .utf8),
+              !templateString.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            return
+        }
+
+        jsonObject["chat_template"] = templateString
+
+        guard let updatedData = try? JSONSerialization
+            .data(withJSONObject: jsonObject, options: [.prettyPrinted])
+        else {
+            return
+        }
+
+        let mergedURL = tokenizerConfigURL.deletingLastPathComponent()
+            .appendingPathComponent("tokenizer_config.merged.json")
+
+        do {
+            try updatedData.write(to: mergedURL, options: .atomic)
+        }
+        catch {
+            NSLog(
+                "SwamaKit.ModelPool: failed to write merged chat template for %@ - %@",
+                modelName,
+                error.localizedDescription
+            )
+            return
+        }
+
+        do {
+            try FileManager.default.removeItem(at: tokenizerConfigURL)
+        }
+        catch {
+            NSLog(
+                "SwamaKit.ModelPool: failed to remove original tokenizer config for %@ - %@",
+                modelName,
+                error.localizedDescription
+            )
+        }
+
+        do {
+            try FileManager.default.copyItem(at: mergedURL, to: tokenizerConfigURL)
+        }
+        catch {
+            NSLog(
+                "SwamaKit.ModelPool: failed to install merged tokenizer config for %@ - %@",
+                modelName,
+                error.localizedDescription
+            )
+        }
+    }
+
+    private func parseEOSTokenIDs(from url: URL) -> Set<Int>? {
+        guard let data = try? Data(contentsOf: url),
+              let jsonObject = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return nil
+        }
+
+        var ids: Set<Int> = []
+        var eosIDs: Set<Int> = []
+
+        if let eosValue = jsonObject["eos_token_id"] {
+            eosIDs = extractIDs(from: eosValue)
+            ids.formUnion(eosIDs)
+        }
+
+        if !eosIDs.isEmpty,
+           let padValue = jsonObject["pad_token_id"]
+        {
+            let padIDs = extractIDs(from: padValue)
+            if !padIDs.isDisjoint(with: eosIDs) {
+                ids.formUnion(padIDs)
+            }
+        }
+
+        return ids
+    }
+
+    private func extractIDs(from value: Any) -> Set<Int> {
+        switch value {
+        case let intValue as Int:
+            [intValue]
+
+        case let number as NSNumber:
+            [number.intValue]
+
+        case let doubleValue as Double:
+            [Int(doubleValue)]
+
+        case let array as [Any]:
+            array.reduce(into: Set<Int>()) { result, element in
+                result.formUnion(extractIDs(from: element))
+            }
+
+        default:
+            []
+        }
+    }
+
+    private func mapTokenIDsToStrings(ids: Set<Int>, tokenizerURL: URL) -> Set<String>? {
+        guard let data = try? Data(contentsOf: tokenizerURL),
+              let jsonObject = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return nil
+        }
+
+        var remainingIDs = ids
+        var tokens: Set<String> = []
+
+        if let addedTokens = jsonObject["added_tokens"] as? [[String: Any]] {
+            for tokenInfo in addedTokens {
+                guard let idValue = tokenInfo["id"],
+                      let id = extractIDs(from: idValue).first,
+                      remainingIDs.contains(id),
+                      let content = tokenInfo["content"] as? String
+                else {
+                    continue
+                }
+
+                tokens.insert(content)
+                remainingIDs.remove(id)
+            }
+        }
+
+        if !remainingIDs.isEmpty,
+           let modelDict = jsonObject["model"] as? [String: Any],
+           let vocab = modelDict["vocab"] as? [String: Any]
+        {
+            for (token, idValue) in vocab {
+                let idSet = extractIDs(from: idValue)
+                guard let id = idSet.first,
+                      remainingIDs.contains(id)
+                else {
+                    continue
+                }
+
+                tokens.insert(token)
+                remainingIDs.remove(id)
+
+                if remainingIDs.isEmpty {
+                    break
+                }
+            }
+        }
+
+        if remainingIDs.isEmpty {
+            return tokens
+        }
+
+        if !tokens.isEmpty {
+            NSLog(
+                "SwamaKit.ModelPool: Missing tokenizer mappings for EOS token ids: %@",
+                remainingIDs.map(String.init).joined(separator: ",")
+            )
+            return tokens
+        }
+
+        return nil
+    }
+
+    private func ensureVLMRegistryInitialized() {
+        guard vlmRegistryCache == nil else {
+            return
+        }
+
+        vlmRegistryCache = [:]
+        for vlmConfigEntry in VLMRegistry.all() {
+            let configIDString: String = vlmConfigEntry.name
+            vlmRegistryCache![configIDString] = vlmConfigEntry
+        }
+    }
+
+    private func isVLMModelByLocalConfig(_ modelName: String) -> Bool {
+        let modelDirectory = ModelPaths.getModelDirectory(for: modelName)
+        let candidateConfigFiles = [
+            "config.json",
+            "preprocessor_config.json",
+            "processor_config.json"
+        ]
+
+        for fileName in candidateConfigFiles {
+            let fileURL = modelDirectory.appendingPathComponent(fileName)
+            guard let json = loadJSONDictionary(at: fileURL) else {
+                continue
+            }
+
+            if ModelTypeDetector.isVLMModelConfig(json) {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    private func loadJSONDictionary(at url: URL) -> [String: Any]? {
+        guard let data = try? Data(contentsOf: url),
+              let jsonObject = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return nil
+        }
+
+        return jsonObject
+    }
+
+    /// Helper method to detect VLM models by name pattern (heuristic for models not in registry)
+    private func isVLMModelByName(_ modelName: String) -> Bool {
+        ModelTypeDetector.isVLMModelName(modelName)
+    }
+
+    // MARK: - Memory Management
+
+    /// Starts the periodic memory management timer
+    private func startMemoryManagementTimer() {
+        // Cancel existing task if any
+        memoryManagementTask?.cancel()
+
+        // Create new task for periodic memory cleanup
+        let interval = memoryCheckInterval
+        memoryManagementTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
+
+                guard !Task.isCancelled, let self else {
+                    break
+                }
+
+                await self.performPeriodicMemoryCleanup()
+            }
+        }
+    }
+
+    /// Performs periodic cleanup of idle models
+    private func performPeriodicMemoryCleanup() async {
+        let idleModels = getIdleModels()
+
+        if !idleModels.isEmpty {
+            NSLog("SwamaKit.ModelPool: Found \(idleModels.count) idle models for cleanup: \(idleModels.map(\.name))")
+
+            for model in idleModels.prefix(maxIdleEvictionsPerCycle) {
+                await evictModel(
+                    modelName: model.name,
+                    reason: "idle timeout (\(String(format: "%.1f", model.idleTime))s)"
+                )
+            }
+        }
+    }
+
+    /// Checks for memory pressure and evicts models if needed
+    private func performMemoryPressureCheck() async {
+        let currentCacheSize = cache.count
+
+        if currentCacheSize >= maxCacheSize {
+            NSLog(
+                "SwamaKit.ModelPool: Cache size (\(currentCacheSize)) at limit (\(maxCacheSize)). Performing memory pressure cleanup."
+            )
+
+            // Get models sorted by eviction priority (best candidates first)
+            let candidates = getEvictionCandidates()
+
+            // Evict the least valuable model to make room
+            if let candidate = candidates.first {
+                await evictModel(modelName: candidate.name, reason: "memory pressure (cache size: \(currentCacheSize))")
+            }
+        }
+    }
+
+    /// Gets models that have been idle for too long
+    private func getIdleModels() -> [(name: String, idleTime: TimeInterval)] {
+        modelUsageInfo.compactMap { modelName, usage in
+            // Skip models that are currently running
+            guard runningModels[modelName] == nil else {
+                return nil
+            }
+
+            let idleTime = usage.idleTime
+            if idleTime > maxIdleTime {
+                return (name: modelName, idleTime: idleTime)
+            }
+            return nil
+        }
+        .sorted { $0.idleTime > $1.idleTime } // Sort by idle time descending
+    }
+
+    /// Gets models sorted by eviction priority (best candidates first)
+    private func getEvictionCandidates() -> [(name: String, score: Double)] {
+        modelUsageInfo.compactMap { modelName, usage in
+            // Skip models that are currently running
+            guard runningModels[modelName] == nil else {
+                return nil
+            }
+
+            // Calculate eviction score (higher score = better candidate for eviction)
+            let idleTime = usage.idleTime
+            let usageFrequency = Double(usage.usageCount) / usage.ageTime
+            let ageTime = usage.ageTime
+
+            // Score formula: prioritize older idle models with lower usage frequency
+            let score = idleTime / 60.0 + ageTime / 3600.0 - usageFrequency * 100.0
+
+            return (name: modelName, score: score)
+        }
+        .sorted { $0.score > $1.score } // Sort by score descending
+    }
+
+    /// Evicts a specific model from the cache
+    private func evictModel(modelName: String, reason: String) async {
+        // A pending load has not reached inference yet and is safe to invalidate. Continue to
+        // protect a genuinely running cached model from periodic eviction.
+        let runningOwner = runningModels[modelName]
+        let isPendingLoad = runningOwner != nil
+            && loadingModels[modelName] == runningOwner
+            && hasPendingLoad(for: modelName)
+        guard runningOwner == nil || isPendingLoad else {
+            NSLog("SwamaKit.ModelPool: Skipping eviction of \(modelName) - currently running")
+            return
+        }
+
+        let diagnosticOperation = SwamaDiagnostics.startEviction(model: modelName)
+        let memoryBefore = memoryHooks.activeMemory()
+
+        invalidateLoads(for: modelName)
+
+        // Remove from all caches to release strong references
+        cache.removeValue(forKey: modelName)
+        modelTypeCache.removeValue(forKey: modelName)
+        embeddingRunnerCache.removeValue(forKey: modelName)
+        PromptCacheStore.shared.drop(modelName: modelName)
+        modelUsageInfo.removeValue(forKey: modelName)
+
+        // Cancel loading task if active
+        if let pending = tasks.removeValue(forKey: modelName) {
+            pending.task.cancel()
+        }
+
+        if let pending = embeddingTasks.removeValue(forKey: modelName) {
+            pending.task.cancel()
+        }
+
+        // All strong owners have been removed before MLX cleanup runs.
+        memoryHooks.clearCache()
+
+        // Get memory snapshot after cleanup to measure actual release
+        let memoryAfter = memoryHooks.activeMemory()
+        let memoryReleased = max(0, memoryBefore - memoryAfter)
+        SwamaDiagnostics.completeEviction(
+            diagnosticOperation,
+            model: modelName,
+            generation: modelLoadGenerations[modelName, default: 0],
+            residentBytesAfter: SwamaDiagnostics.residentBytes()
+        )
+
+        NSLog(
+            "SwamaKit.ModelPool: Evicted model \(modelName) - \(reason). Released \(memoryReleased / (1024 * 1024))MB active memory. Active: \(memoryAfter / (1024 * 1024))MB"
+        )
+    }
+
+    // Aggressive cleanup removed to keep memory management simple and predictable.
+}
+
+// MARK: - ModelTypeDetector
+
+enum ModelTypeDetector {
+    static func isVLMModelName(_ modelName: String) -> Bool {
+        let lowercaseName = modelName.lowercased()
+
+        if lowercaseName.contains("gemma") {
+            // Gemma models with DWQ are LLM (not VLM)
+            if lowercaseName.contains("dwq") {
+                return false
+            }
+
+            if lowercaseName.contains("3n"), lowercaseName.contains("lm") {
+                return false // Gemma 3n - Text Only (LM) are LLMs
+            }
+            return true
+        }
+
+        let vlmPatterns = [
+            "-vl-", // Lowercase variant
+            "vl-", // Prefix variant
+            "vision", // Vision models
+            "visual", // Visual models
+            "multimodal", // Multimodal models
+            "omni" // Omni models are generally multimodal
+        ]
+
+        for pattern in vlmPatterns where lowercaseName.contains(pattern) {
+            return true
+        }
+
+        return false
+    }
+
+    static func isVLMModelConfig(_ json: [String: Any]) -> Bool {
+        let vlmKeyHints = [
+            "vision_config",
+            "image_token_id",
+            "video_token_id",
+            "vision_start_token_id",
+            "vision_end_token_id",
+            "vision_tower",
+            "visual",
+            "mm_projector",
+            "multi_modal_projector",
+            "image_processor"
+        ]
+
+        let vlmValueHints = [
+            "vl",
+            "vision",
+            "visual",
+            "multimodal",
+            "omni",
+            "llava",
+            "idefics",
+            "paligemma",
+            "pixtral",
+            "minicpmv",
+            "qwen3_5forconditionalgeneration"
+        ]
+
+        func containsVLMHints(in value: Any, keyContext: String? = nil) -> Bool {
+            if let dictionary = value as? [String: Any] {
+                for (rawKey, nestedValue) in dictionary {
+                    let key = rawKey.lowercased()
+
+                    if vlmKeyHints.contains(where: { key.contains($0) }) {
+                        return true
+                    }
+
+                    if containsVLMHints(in: nestedValue, keyContext: key) {
+                        return true
+                    }
+                }
+                return false
+            }
+
+            if let array = value as? [Any] {
+                for item in array where containsVLMHints(in: item, keyContext: keyContext) {
+                    return true
+                }
+                return false
+            }
+
+            if let stringValue = value as? String {
+                let normalized = stringValue.lowercased()
+                if keyContext == "architectures" || keyContext == "model_type" {
+                    return vlmValueHints.contains(where: { normalized.contains($0) })
+                }
+            }
+
+            return false
+        }
+
+        return containsVLMHints(in: json)
+    }
+}

--- a/swama/Sources/SwamaRuntime/Model/ModelRunner.swift
+++ b/swama/Sources/SwamaRuntime/Model/ModelRunner.swift
@@ -1,0 +1,886 @@
+import CoreImage
+import Foundation
+import MLX
+import MLXLLM
+@preconcurrency import MLXLMCommon
+import MLXVLM
+import OSLog
+import Tokenizers
+import struct Tokenizers.ToolSpec
+
+// MARK: - ModelRunner
+
+/// An actor responsible for running model inference.
+private let modelRunnerLogger: Logger = .init(subsystem: "SwamaKit", category: "ModelRunner")
+
+// MARK: - InferenceSafetyLimits
+
+private enum InferenceSafetyLimits {
+    static let multimodalContextLimit = 4096
+}
+
+// MARK: - ModelRunner
+
+package actor ModelRunner {
+    package struct ChatRunResult: Sendable {
+        package let output: String
+        package let analysis: String?
+        package let promptTokens: Int
+        package let completionInfo: GenerateCompletionInfo?
+        package let toolCalls: [MLXLMCommon.ToolCall]
+        package let rawText: String
+    }
+
+    // MARK: Lifecycle
+
+    /// - Parameter promptCacheStore: defaults to the process-wide singleton; overridable so
+    ///   tests can inject an isolated store instead of sharing global state.
+    package init(container: ModelContainer, promptCacheStore: PromptCacheStore = .shared) {
+        self.container = container
+        self.promptCacheStore = promptCacheStore
+    }
+
+    // MARK: Public
+
+    /// Runs the model with the given prompt and parameters, returning only the generated output string.
+    package func run(prompt: String, images _: [Data]? = nil, parameters: GenerateParameters) async throws -> String {
+        // Use new chat-based method for consistency
+        let chatMessages: [MLXLMCommon.Chat.Message] = [.user(prompt)]
+        let result = try await runWithChatUsage(chatMessages: chatMessages, parameters: parameters)
+        return result.output
+    }
+
+    /// Runs the model with chat messages, returning the generated output and token usage.
+    package nonisolated func runWithChatUsage(
+        chatMessages: [MLXLMCommon.Chat.Message],
+        parameters: GenerateParameters
+    ) async throws -> ChatRunResult {
+        let userInput = MLXLMCommon.UserInput(chat: chatMessages)
+        return try await runChat(
+            userInput: userInput,
+            parameters: parameters
+        )
+    }
+
+    /// Non-streaming chat execution - collects all output and returns at the end
+    package nonisolated func runChatNonStream(
+        userInput: MLXLMCommon.UserInput,
+        parameters: GenerateParameters
+    ) async throws -> ChatRunResult {
+        // For non-streaming, we don't provide callbacks, so runChat will accumulate internally
+        try await runChat(
+            userInput: userInput,
+            parameters: parameters
+        )
+    }
+
+    /// Unified method for running chat with optional streaming and tool calls support
+    package nonisolated func runChat(
+        userInput: MLXLMCommon.UserInput,
+        parameters: GenerateParameters,
+        onToken: (@Sendable (String) async throws -> Void)? = nil,
+        onToolCall: (@Sendable (MLXLMCommon.ToolCall) async throws -> Void)? = nil
+    ) async throws -> ChatRunResult {
+        try await withError {
+            let modelName = await container.configuration.name
+            let diagnosticOperation = SwamaDiagnostics.startGeneration(model: modelName)
+            var diagnosticOutcome: GenerationDiagnosticOutcome?
+            defer {
+                switch diagnosticOutcome {
+                case let .completed(inputTokens, outputTokens):
+                    SwamaDiagnostics.completeGeneration(
+                        diagnosticOperation,
+                        model: modelName,
+                        inputTokens: inputTokens,
+                        outputTokens: outputTokens
+                    )
+
+                case let .cancelled(outputTokens):
+                    SwamaDiagnostics.cancelGeneration(
+                        diagnosticOperation,
+                        model: modelName,
+                        outputTokens: outputTokens
+                    )
+
+                case .none:
+                    if Task.isCancelled {
+                        SwamaDiagnostics.cancelGeneration(
+                            diagnosticOperation,
+                            model: modelName,
+                            outputTokens: 0
+                        )
+                    }
+                    else {
+                        SwamaDiagnostics.failGeneration(diagnosticOperation, model: modelName)
+                    }
+                }
+            }
+
+            var output = ""
+            var promptTokens = 0
+            var capturedCompletionInfo: GenerateCompletionInfo?
+            var toolCalls: [MLXLMCommon.ToolCall] = []
+            var didRecordFirstToken = false
+
+            let rawOutputStorage = RawOutputBuffer()
+            let hasMediaInput = userInput.hasMediaContent
+            let configuredContextLimit = await ContextLimitConfig.shared.currentLimit()
+            let effectiveContextLimit = hasMediaInput
+                ? min(configuredContextLimit, InferenceSafetyLimits.multimodalContextLimit)
+                : configuredContextLimit
+
+            if hasMediaInput, effectiveContextLimit < configuredContextLimit {
+                modelRunnerLogger.info(
+                    "Multimodal request context limit clamped from \(configuredContextLimit) to \(effectiveContextLimit)"
+                )
+            }
+
+            var effectiveParameters = parameters
+            if effectiveParameters.maxKVSize == nil {
+                effectiveParameters.maxKVSize = effectiveContextLimit
+            }
+            let generationParameters = effectiveParameters
+
+            var effectiveInput = userInput
+            if case let .chat(messages) = userInput.prompt {
+                let trimmedMessages = try await trimChatMessagesInternal(
+                    chatMessages: messages,
+                    tools: userInput.tools,
+                    limit: effectiveContextLimit,
+                    container: container,
+                    processing: userInput.processing,
+                    additionalContext: userInput.additionalContext
+                )
+                effectiveInput = MLXLMCommon.UserInput(
+                    chat: trimmedMessages,
+                    processing: userInput.processing,
+                    tools: userInput.tools,
+                    additionalContext: userInput.additionalContext
+                )
+            }
+
+            let lmInput = try await container.prepare(input: effectiveInput)
+
+            promptTokens = tokenLength(lmInput.text.tokens)
+            guard promptTokens <= effectiveContextLimit else {
+                throw ContextLimitError.exceededAfterTrimming(
+                    limit: effectiveContextLimit,
+                    promptTokens: promptTokens
+                )
+            }
+
+            let maxKVSize = generationParameters.maxKVSize ?? effectiveContextLimit
+            let kvConfig = PromptCacheKVConfig(parameters: generationParameters, maxKVSize: maxKVSize)
+            let fullTokens = promptCacheTokenArray(lmInput.text.tokens)
+
+            let cacheDecision = resolvePromptCacheReuse(
+                enabled: PromptCacheConfig.isEnabled,
+                hasMediaInput: hasMediaInput,
+                modelName: modelName,
+                newTokens: fullTokens,
+                kvConfig: kvConfig,
+                store: promptCacheStore
+            )
+
+            // `resolvePromptCacheReuse` cannot see `generationParameters` at all, so it has no way
+            // to know whether a `.reuse` it just returned would actually need
+            // `FullHistoryLogitProcessor` wrapped around a processor that also wants a quantized
+            // KV cache -- the one combination no `TokenIterator` initializer can honour correctly
+            // (see `PromptCacheIteratorStrategy.bypass`). Override that specific case to an
+            // equivalent `.miss` here, once, so both the switch below and the log line after it
+            // agree on the same effective decision without duplicating this check.
+            let effectiveCacheDecision: PromptCacheResolution =
+                if case let .reuse(_, _, _, epoch) = cacheDecision,
+                promptCacheIteratorStrategy(
+                    needsFullHistoryWrapper: true,
+                    hasPenaltyProcessor: generationParameters.processor() != nil,
+                    kvBits: generationParameters.kvBits
+                ) == .bypass {
+                    .miss(reason: .kvQuantizationUnsupported, epoch: epoch)
+                }
+                else {
+                    cacheDecision
+                }
+
+            // Captured up front (before generation starts) on every path that will ever write a
+            // slot back -- `nil` only for `.disabled`/`.multimodal`, which never touch the store
+            // at all. `resolvePromptCacheReuse` already captured this from `checkout` (reuse,
+            // and the checked-out-but-rejected miss reasons) or `currentEpoch` (`.noSlot`); see
+            // `PromptCacheEpoch`'s doc comment for why it has to be this early.
+            let cacheEpoch: PromptCacheEpoch? =
+                switch effectiveCacheDecision {
+                case let .reuse(_, _, _, epoch):
+                    epoch
+                case let .miss(_, epoch):
+                    epoch
+                }
+
+            let run: PromptCacheGenerationRun = try await container.perform { context in
+                switch effectiveCacheDecision {
+                case .miss(.disabled, _),
+                     .miss(.kvQuantizationUnsupported, _),
+                     .miss(.multimodal, _):
+                    // Cache untouched (feature off, or bypassed for multimodal content -- image
+                    // embeddings aren't in the token sequence a KV cache indexes by), or a cache
+                    // hit we've deliberately declined to reuse because its full-history wrapper
+                    // would silently drop the caller's KV-quantization settings
+                    // (.kvQuantizationUnsupported). In every one of these cases, any slot
+                    // `resolvePromptCacheReuse` already checked out is simply never checked back
+                    // in below (`run.cache` is `nil` here), exactly like every other
+                    // rejected-but-checked-out miss reason.
+                    let stream = try generate(
+                        input: lmInput,
+                        parameters: generationParameters,
+                        context: context
+                    )
+                    return PromptCacheGenerationRun(stream: stream, task: nil, cache: nil, prefillMs: nil)
+
+                case let .reuse(matchedLength, reusedCache, _, _):
+                    // Cache hit: feed only the unmatched suffix, but prime the penalty
+                    // processors with the FULL history (not just the suffix), or their windowed
+                    // state would silently diverge from the uncached baseline.
+                    let suffixInput = LMInput(tokens: MLXArray(Array(fullTokens[matchedLength...])))
+                    return try buildPromptCacheGenerationRun(
+                        iterInput: suffixInput,
+                        cache: reusedCache,
+                        fullHistory: lmInput.text.tokens,
+                        context: context,
+                        generationParameters: generationParameters
+                    )
+
+                case .miss:
+                    // A cacheable miss (no prior slot, mismatch, rotated, or a KV config change):
+                    // full prefill on a fresh cache, captured so it can be stored for next turn.
+                    let freshCache = context.model.newCache(parameters: generationParameters)
+                    return try buildPromptCacheGenerationRun(
+                        iterInput: lmInput,
+                        cache: freshCache,
+                        fullHistory: nil,
+                        context: context,
+                        generationParameters: generationParameters
+                    )
+                }
+            }
+
+            logPromptCacheDecision(
+                decision: effectiveCacheDecision,
+                promptTokens: promptTokens,
+                prefillMs: run.prefillMs
+            )
+
+            var thrownError: Error?
+            for await generationEvent in run.stream {
+                if Task.isCancelled {
+                    break
+                }
+
+                do {
+                    switch generationEvent {
+                    case let .chunk(chunkString):
+                        if !didRecordFirstToken, !chunkString.isEmpty {
+                            SwamaDiagnostics.firstToken(diagnosticOperation, model: modelName)
+                            didRecordFirstToken = true
+                        }
+                        rawOutputStorage.append(chunkString)
+
+                        if let onToken {
+                            // Awaited (and fully written) before the next generation event is
+                            // processed, so writes land on the channel in generation order and are
+                            // guaranteed drained by the time this call returns; a failed write
+                            // throws here and stops generation.
+                            try await onToken(chunkString)
+                        }
+                        else {
+                            // Only accumulate if no onToken callback (for non-streaming)
+                            output += chunkString
+                        }
+
+                    case let .info(info):
+                        capturedCompletionInfo = info
+
+                    case let .toolCall(toolCall):
+                        if !didRecordFirstToken {
+                            SwamaDiagnostics.firstToken(diagnosticOperation, model: modelName)
+                            didRecordFirstToken = true
+                        }
+                        // Always accumulate tool calls for the return value
+                        toolCalls.append(toolCall)
+                        // Also send to callback if provided (for streaming)
+                        if let onToolCall {
+                            try await onToolCall(toolCall)
+                        }
+                    }
+                }
+                catch {
+                    thrownError = error
+                    break
+                }
+            }
+
+            // Whether the loop above finished normally, broke on cancellation, or broke on a
+            // thrown error, the background generation task may still be touching the cache for a
+            // few more ms (see `generateTask`'s doc comment). Await it before this function either
+            // stores the cache or returns/rethrows, exactly as ChatSession does -- this is also
+            // what makes it safe for the very next request on this model (ModelPool.run serializes
+            // by model name) to start touching the same cache/weights right after this returns.
+            if let task = run.task {
+                await task.value
+            }
+
+            // Only ever store on a clean, uncancelled, unthrown completion: on any abort the slot
+            // stays absent (it was already removed from the store by `checkout` inside
+            // `resolvePromptCacheReuse`, or was never created for a fresh miss), never
+            // half-written. `cacheEpoch` is non-nil whenever `run.cache` is (see the comment
+            // where it's captured above); binding it alongside the `run.cache` check rather than
+            // asserting that pairing means a future divergence skips the store instead of
+            // trapping.
+            if let cache = run.cache, let cacheEpoch, thrownError == nil, Task.isCancelled == false {
+                storePromptCacheIfReusable(
+                    cache: cache,
+                    fullTokens: fullTokens,
+                    promptTokenCount: promptTokens,
+                    kvConfig: kvConfig,
+                    modelName: modelName,
+                    epoch: cacheEpoch,
+                    store: promptCacheStore
+                )
+            }
+
+            if let thrownError {
+                throw thrownError
+            }
+
+            let rawOutput = rawOutputStorage.consume()
+            let resolvedOutput = output.isEmpty ? rawOutput : output
+
+            let result = ChatRunResult(
+                output: resolvedOutput,
+                analysis: nil,
+                promptTokens: promptTokens,
+                completionInfo: capturedCompletionInfo,
+                toolCalls: toolCalls,
+                rawText: rawOutput
+            )
+            let outputTokens = result.completionInfo?.generationTokenCount ?? 0
+            diagnosticOutcome = Task.isCancelled
+                ? .cancelled(outputTokens: outputTokens)
+                : .completed(inputTokens: result.promptTokens, outputTokens: outputTokens)
+            return result
+        }
+    }
+
+    // MARK: - Existing methods
+
+    // MARK: Private
+
+    private let container: ModelContainer
+    private let promptCacheStore: PromptCacheStore
+}
+
+// MARK: - GenerationDiagnosticOutcome
+
+private enum GenerationDiagnosticOutcome {
+    case completed(inputTokens: Int, outputTokens: Int)
+    case cancelled(outputTokens: Int)
+}
+
+// MARK: - RawOutputBuffer
+
+private final class RawOutputBuffer: @unchecked Sendable {
+    private var storage: String = ""
+
+    func append(_ chunk: String) {
+        storage.append(chunk)
+    }
+
+    func consume() -> String {
+        defer { storage.removeAll(keepingCapacity: false) }
+        return storage
+    }
+}
+
+private func trimChatMessagesInternal(
+    chatMessages: [MLXLMCommon.Chat.Message],
+    tools: [ToolSpec]?,
+    limit: Int,
+    container: ModelContainer,
+    processing: MLXLMCommon.UserInput.Processing,
+    additionalContext: [String: any Sendable]?
+) async throws -> [MLXLMCommon.Chat.Message] {
+    guard limit > 0 else {
+        return chatMessages
+    }
+    guard !chatMessages.isEmpty else {
+        return chatMessages
+    }
+
+    func isProtected(_ message: MLXLMCommon.Chat.Message) -> Bool {
+        if message.role == .system || message.role == .tool {
+            return true
+        }
+        return !message.images.isEmpty || !message.videos.isEmpty
+    }
+
+    func buildInput(with messages: [MLXLMCommon.Chat.Message]) -> MLXLMCommon.UserInput {
+        MLXLMCommon.UserInput(
+            chat: messages,
+            processing: processing,
+            tools: tools,
+            additionalContext: additionalContext
+        )
+    }
+
+    func hasMedia(_ messages: [MLXLMCommon.Chat.Message]) -> Bool {
+        messages.contains { !$0.images.isEmpty || !$0.videos.isEmpty }
+    }
+
+    func hasNonEmptyUserMessage(_ messages: [MLXLMCommon.Chat.Message]) -> Bool {
+        messages.contains {
+            $0.role == .user && !$0.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+    }
+
+    func countTokensForTrim(_ messages: [MLXLMCommon.Chat.Message]) async throws -> Int {
+        // For text-only chat, use model-accurate token counting via prepare(input:)
+        // to avoid template-estimation mismatch for multimodal-capable models.
+        if !hasMedia(messages) {
+            return try await tokenCount(for: buildInput(with: messages), container: container)
+        }
+
+        return try await estimateTokenCount(
+            messages: messages,
+            tools: tools,
+            additionalContext: additionalContext,
+            container: container
+        )
+    }
+
+    var workingMessages = chatMessages
+    var didTrimContent = false
+    var trimmableIndices = workingMessages.enumerated()
+        .filter { !isProtected($0.element) }
+        .map(\.offset)
+
+    var currentTokenCount = try await countTokensForTrim(workingMessages)
+    let initialTokenCount = currentTokenCount
+
+    var trimPointer = 0
+
+    while currentTokenCount > limit, trimPointer < trimmableIndices.count {
+        let index = trimmableIndices[trimPointer]
+        let originalContent = workingMessages[index].content
+
+        if originalContent.isEmpty {
+            trimPointer += 1
+            continue
+        }
+
+        let tokens = await container.encode(originalContent)
+        if tokens.isEmpty {
+            workingMessages[index].content = ""
+        }
+        else {
+            var bestContent: String?
+            var low = 0
+            var high = tokens.count
+
+            while low <= high {
+                let mid = (low + high) / 2
+                let prefix = Array(tokens.prefix(mid))
+                let decoded = await container.decode(tokens: prefix)
+                workingMessages[index].content = decoded
+
+                let count = try await countTokensForTrim(workingMessages)
+                if count <= limit {
+                    bestContent = decoded
+                    low = mid + 1
+                }
+                else {
+                    high = mid - 1
+                }
+            }
+
+            workingMessages[index].content = bestContent ?? ""
+        }
+
+        currentTokenCount = try await countTokensForTrim(workingMessages)
+        didTrimContent = true
+
+        if workingMessages[index].content.isEmpty {
+            workingMessages.remove(at: index)
+            trimmableIndices.remove(at: trimPointer)
+            trimmableIndices = trimmableIndices.map { $0 > index ? $0 - 1 : $0 }
+            continue
+        }
+
+        if currentTokenCount > limit {
+            trimPointer += 1
+        }
+    }
+
+    // Never collapse to an empty-user prompt. If trimming removed all user text,
+    // restore the latest non-empty user message from the original request.
+    if !hasNonEmptyUserMessage(workingMessages),
+       let fallbackUser = chatMessages.reversed().first(where: {
+           $0.role == .user && !$0.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+       })
+    {
+        workingMessages = [fallbackUser]
+        didTrimContent = true
+    }
+
+    let finalInput = buildInput(with: workingMessages)
+    let finalTokenCount = try await tokenCount(for: finalInput, container: container)
+
+    guard finalTokenCount <= limit else {
+        modelRunnerLogger.error(
+            "Context limit hit; prompt still \(finalTokenCount) tokens with limit \(limit)"
+        )
+        throw ContextLimitError.exceededAfterTrimming(limit: limit, promptTokens: finalTokenCount)
+    }
+
+    if didTrimContent, finalTokenCount < initialTokenCount {
+        modelRunnerLogger.info(
+            "Context trimmed to \(finalTokenCount) tokens (limit \(limit))"
+        )
+    }
+
+    return workingMessages
+}
+
+private func tokenCount(for input: MLXLMCommon.UserInput, container: ModelContainer) async throws -> Int {
+    let prepared = try await container.prepare(input: input)
+    return tokenLength(prepared.text.tokens)
+}
+
+private func estimateTokenCount(
+    messages: [MLXLMCommon.Chat.Message],
+    tools: [ToolSpec]?,
+    additionalContext: [String: any Sendable]?,
+    container: ModelContainer
+) async throws -> Int {
+    let rawMessages: [MLXLMCommon.Message] = messages.map { message in
+        [
+            "role": message.role.rawValue,
+            "content": message.content
+        ]
+    }
+
+    let templateTokens: [Int]
+    do {
+        templateTokens = try await container.perform { context in
+            try context.tokenizer.applyChatTemplate(
+                messages: rawMessages,
+                tools: tools,
+                additionalContext: additionalContext
+            )
+        }
+    }
+    catch {
+        let prompt = messages.map(\.content).joined(separator: "\n\n")
+        templateTokens = await container.encode(prompt)
+    }
+
+    let mediaItems = messages.reduce(into: 0) { count, message in
+        count += message.images.count
+        count += message.videos.count
+    }
+    let estimatedMediaTokens = mediaItems * 400
+
+    return templateTokens.count + estimatedMediaTokens
+}
+
+private extension MLXLMCommon.UserInput {
+    var hasMediaContent: Bool {
+        switch prompt {
+        case .text:
+            false
+        case let .chat(messages):
+            messages.contains { !$0.images.isEmpty || !$0.videos.isEmpty }
+        case let .messages(messages):
+            messages.contains { message in
+                message.keys.contains { key in
+                    let normalized = key.lowercased()
+                    return normalized.contains("image") || normalized.contains("video")
+                }
+            }
+        }
+    }
+}
+
+private func tokenLength(_ tokens: MLXArray) -> Int {
+    switch tokens.ndim {
+    case 0:
+        1
+    case 1:
+        tokens.count
+    default:
+        tokens.dim(-1)
+    }
+}
+
+// MARK: - PromptCacheGenerationRun
+
+/// One generation attempt's stream/task/cache, as built inside `container.perform` and consumed
+/// back in `runChat` after crossing the actor boundary.
+///
+/// `task` and `cache` are `nil` together on the two paths that never touch `PromptCacheStore` at
+/// all (`SWAMA_PROMPT_CACHE=0`, and multimodal requests, which bypass the cache entirely): those
+/// keep calling `generate(input:parameters:context:)` exactly as before this feature existed, so
+/// there is no task to await or cache to store. Whenever `cache` is non-nil, `task` is too --
+/// `runChat` awaits it before ever touching `cache`, exactly as `ChatSession` does.
+///
+/// `@unchecked Sendable`: `cache` (when present) is `[KVCache]`, a mutable, non-Sendable MLX
+/// type; safety comes from this value being built once inside `container.perform` and consumed
+/// exactly once back in `runChat`, never shared concurrently.
+private struct PromptCacheGenerationRun: @unchecked Sendable {
+    let stream: AsyncStream<Generation>
+    let task: Task<Void, Never>?
+    let cache: [KVCache]?
+    let prefillMs: Double?
+}
+
+// MARK: - FullHistoryLogitProcessor
+
+/// Wraps a `LogitProcessor` so `TokenIterator.prepare`'s call to `processor?.prompt(...)` --
+/// which only sees the tokens actually fed to this iterator, i.e. the cache-hit suffix -- is
+/// redirected to the full post-template token history instead. Repetition/presence/frequency
+/// penalties must see the same history the uncached path would give them (in particular
+/// `RepetitionContext`'s ring buffer keeps only the last `repetitionContextSize` tokens of
+/// whatever it's primed with), or their windowed state silently diverges from the cache-off
+/// baseline the moment a request crosses the suffix boundary.
+private struct FullHistoryLogitProcessor: LogitProcessor {
+    var inner: LogitProcessor
+    let fullHistory: MLXArray
+
+    mutating func prompt(_: MLXArray) {
+        inner.prompt(fullHistory)
+    }
+
+    func process(logits: MLXArray) -> MLXArray {
+        inner.process(logits: logits)
+    }
+
+    mutating func didSample(token: MLXArray) {
+        inner.didSample(token: token)
+    }
+}
+
+// MARK: - PromptCacheIteratorError
+
+/// Thrown when `buildPromptCacheGenerationRun` is reached in a state its
+/// `PromptCacheIteratorStrategy` says cannot happen -- `runChat` routes `.bypass` to the ordinary
+/// uncached path before ever calling it, and `.processorWrapper` is only ever returned when both
+/// a processor and a full history exist to wrap.
+///
+/// This is deliberately a thrown error rather than a `preconditionFailure`: swama is a long-lived
+/// server, and a future refactor that broke the invariant should fail this one request (the
+/// caller already surfaces a thrown error as a failed completion) rather than take the whole
+/// daemon down with every other in-flight request. Silently falling back to the parameters
+/// initializer is not an option -- that would drop the caller's KV-quantization settings, exactly
+/// what this fix exists to prevent.
+enum PromptCacheIteratorError: Error {
+    case unreachableStrategy(PromptCacheIteratorStrategy)
+}
+
+// MARK: - PromptCacheIteratorStrategy
+
+/// Which `TokenIterator` initializer `buildPromptCacheGenerationRun` should use for one
+/// generation attempt. Factored out as a pure function of three plain values (rather than
+/// asserted on a constructed `TokenIterator`, whose `kvBits`/`kvGroupSize`/`quantizedKVStart` are
+/// internal `let`s not visible from SwamaKit at all) so the initializer-selection decision itself
+/// is directly unit-testable, independent of MLX/model machinery.
+enum PromptCacheIteratorStrategy: Equatable {
+    /// `TokenIterator(input:model:cache:parameters:)` -- kvBits/kvGroupSize/quantizedKVStart are
+    /// honoured because this initializer reads them directly off `GenerateParameters`. Used
+    /// whenever no full-history wrapper is needed at all: every cacheable-miss path (`iterInput`
+    /// already *is* the full prompt) and any cache hit whose `GenerateParameters` yield no
+    /// penalty processor (there is nothing for `FullHistoryLogitProcessor` to wrap).
+    case parameters
+
+    /// `TokenIterator(input:model:cache:processor:sampler:prefillStepSize:maxTokens:)` with a
+    /// `FullHistoryLogitProcessor`-wrapped processor -- a cache hit with a penalty processor,
+    /// where the wrapper is required to re-prime penalty state with the full conversation
+    /// history rather than just the unmatched suffix. Safe only because this overload's
+    /// hardcoded `kvBits: nil` is indistinguishable from what an unset `kvBits` would have
+    /// produced via the other initializer: `maybeQuantizeKVCache` is already a no-op whenever
+    /// `kvBits == nil`, regardless of `kvGroupSize`/`quantizedKVStart` -- see `.bypass` for the
+    /// case where that is *not* true.
+    case processorWrapper
+
+    /// Neither initializer can correctly serve this request: a cache hit needs the full-history
+    /// wrapper (a penalty processor is configured) *and* the caller wants a quantized KV cache
+    /// (`kvBits != nil`), but the only initializer that accepts a custom processor hardcodes
+    /// `kvBits: nil` and cannot be told otherwise -- and the initializer that does honour
+    /// `kvBits` does not accept a custom processor. There is no combination of the two upstream
+    /// initializers that satisfies both requirements at once, so the caller must not build a
+    /// `TokenIterator` here at all: decline this cache hit and fall back to an ordinary,
+    /// uncached prefill for this one request instead (see
+    /// `PromptCacheMissReason.kvQuantizationUnsupported`).
+    case bypass
+}
+
+/// Pure decision function backing `PromptCacheIteratorStrategy`.
+///
+/// - Parameters:
+///   - needsFullHistoryWrapper: `true` on a cache hit (`iterInput` is only the unmatched
+///     suffix, so a penalty processor needs `FullHistoryLogitProcessor` to see the full
+///     history); `false` on a miss, where `iterInput` already is the full prompt.
+///   - hasPenaltyProcessor: whether `generationParameters.processor()` returned non-nil --
+///     i.e. whether there is anything to wrap in the first place.
+///   - kvBits: `generationParameters.kvBits`, forwarded as-is.
+func promptCacheIteratorStrategy(
+    needsFullHistoryWrapper: Bool,
+    hasPenaltyProcessor: Bool,
+    kvBits: Int?
+) -> PromptCacheIteratorStrategy {
+    guard needsFullHistoryWrapper, hasPenaltyProcessor else {
+        return .parameters
+    }
+
+    return kvBits == nil ? .processorWrapper : .bypass
+}
+
+/// Builds a `TokenIterator` (applying, on a cache hit with a penalty processor, the full-history
+/// wrapper -- see `PromptCacheIteratorStrategy`) and starts it via `generateTask`, capturing the
+/// `Task` so the caller can await it before ever touching `cache` again -- unlike
+/// `generate(input:cache:parameters:context:)`, which starts the same task but discards the
+/// handle.
+///
+/// - Parameter fullHistory: the full post-template token sequence to prime penalty
+///   processors with, when non-nil (a cache hit, where `iterInput` is only the unmatched
+///   suffix). `nil` on a miss, where `iterInput` already *is* the full prompt and needs no
+///   wrapper.
+private func buildPromptCacheGenerationRun(
+    iterInput: LMInput,
+    cache: [KVCache],
+    fullHistory: MLXArray?,
+    context: ModelContext,
+    generationParameters: GenerateParameters
+) throws -> PromptCacheGenerationRun {
+    let baseProcessor: LogitProcessor? = generationParameters.processor()
+    let strategy = promptCacheIteratorStrategy(
+        needsFullHistoryWrapper: fullHistory != nil,
+        hasPenaltyProcessor: baseProcessor != nil,
+        kvBits: generationParameters.kvBits
+    )
+
+    let prefillStart = Date()
+    let iterator: TokenIterator
+    switch strategy {
+    case .parameters:
+        iterator = try TokenIterator(
+            input: iterInput,
+            model: context.model,
+            cache: cache,
+            parameters: generationParameters
+        )
+
+    case .processorWrapper:
+        guard let baseProcessor, let fullHistory else {
+            throw PromptCacheIteratorError.unreachableStrategy(.processorWrapper)
+        }
+
+        let wrappedProcessor = FullHistoryLogitProcessor(inner: baseProcessor, fullHistory: fullHistory)
+        iterator = try TokenIterator(
+            input: iterInput,
+            model: context.model,
+            cache: cache,
+            processor: wrappedProcessor,
+            sampler: generationParameters.sampler(),
+            prefillStepSize: generationParameters.prefillStepSize,
+            maxTokens: generationParameters.maxTokens
+        )
+
+    case .bypass:
+        // Unreachable: `runChat` already rewrites a `.bypass` decision to
+        // `.miss(.kvQuantizationUnsupported, _)` before ever entering the branch that calls this
+        // function (see the `effectiveCacheDecision` override in `runChat`), so this function is
+        // only ever invoked for `.parameters`/`.processorWrapper`. Failing loudly rather than
+        // silently falling back to `.parameters` keeps this file's "assert, don't assume"
+        // register -- see `promptCacheLayerIsReusable`'s rotation guard -- without crashing a
+        // long-lived server (see `PromptCacheIteratorError`).
+        throw PromptCacheIteratorError.unreachableStrategy(.bypass)
+    }
+    let prefillMs = Date().timeIntervalSince(prefillStart) * 1000
+
+    let (stream, task) = generateTask(
+        promptTokenCount: iterInput.text.tokens.size,
+        modelConfiguration: context.configuration,
+        tokenizer: context.tokenizer,
+        iterator: iterator
+    )
+
+    return PromptCacheGenerationRun(stream: stream, task: task, cache: cache, prefillMs: prefillMs)
+}
+
+/// Converts a token `MLXArray` (as produced by `container.prepare(input:)`) to a plain `[Int]`
+/// for prefix matching and slot storage.
+private func promptCacheTokenArray(_ tokens: MLXArray) -> [Int] {
+    tokens.asType(.int32).asArray(Int32.self).map(Int.init)
+}
+
+/// Logs the per-request prompt-cache metrics required for diagnosability: a silently-zero-hit
+/// cache should never look identical to a working one in the logs.
+private func logPromptCacheDecision(
+    decision: PromptCacheResolution,
+    promptTokens: Int,
+    prefillMs: Double?
+) {
+    let cachedPrefix: Int
+    let reason: PromptCacheMissReason?
+    switch decision {
+    case let .reuse(matchedLength, _, reuseReason, _):
+        cachedPrefix = matchedLength
+        reason = reuseReason
+
+    case let .miss(missReason, _):
+        cachedPrefix = 0
+        reason = missReason
+    }
+    let prefilledSuffix = promptTokens - cachedPrefix
+    let prefillDescription = prefillMs.map { String(format: "%.1f", $0) } ?? "n/a"
+    let reasonDescription = reason?.rawValue ?? "none"
+
+    modelRunnerLogger.info(
+        "prompt_cache prompt_tokens=\(promptTokens) cached_prefix=\(cachedPrefix) prefilled_suffix=\(prefilledSuffix) prefill_ms=\(prefillDescription, privacy: .public) reason=\(reasonDescription, privacy: .public)"
+    )
+}
+
+/// After a generation completes cleanly, trims `cache` back down to exactly the prompt tokens
+/// (discarding the tokens generated during this turn -- see the plan's "what's in the cache
+/// after generation" note) and stores it for the next turn, unless rotation makes it unsafe to
+/// reuse, or `epoch` has been invalidated by a `drop(modelName:)`/`dropAll()` that ran while this
+/// generation was in flight (see `PromptCacheEpoch`), in which case the slot is simply not
+/// written and the miss is logged for diagnosability.
+private func storePromptCacheIfReusable(
+    cache: [KVCache],
+    fullTokens: [Int],
+    promptTokenCount: Int,
+    kvConfig: PromptCacheKVConfig,
+    modelName: String,
+    epoch: PromptCacheEpoch,
+    store: PromptCacheStore
+) {
+    guard promptCacheIsReusable(cache) else {
+        modelRunnerLogger.info(
+            "prompt_cache store skipped model=\(modelName, privacy: .public) reason=\(PromptCacheMissReason.rotated.rawValue, privacy: .public)"
+        )
+        return
+    }
+
+    for layer in cache {
+        layer.trim(layer.offset - promptTokenCount)
+    }
+
+    let stored = store.checkin(
+        modelName: modelName,
+        slot: PromptCacheSlot(tokens: fullTokens, cache: cache, kvConfig: kvConfig),
+        epoch: epoch
+    )
+    if stored == false {
+        modelRunnerLogger.info(
+            "prompt_cache store skipped model=\(modelName, privacy: .public) reason=\(PromptCacheMissReason.invalidated.rawValue, privacy: .public)"
+        )
+    }
+}

--- a/swama/Sources/SwamaRuntime/Model/PromptCacheStore.swift
+++ b/swama/Sources/SwamaRuntime/Model/PromptCacheStore.swift
@@ -1,0 +1,396 @@
+//
+//  PromptCacheStore.swift
+//  SwamaKit
+//
+//  In-memory, one-slot-per-model prompt/KV-cache used by `ModelRunner.runChat` to avoid
+//  re-prefilling the shared prefix of a multi-turn conversation. See
+//  claude/specs/prompt-cache/plan.md ("Design (v1)" and "Phase-1 amendments") for the design
+//  this implements.
+//
+
+import Foundation
+@preconcurrency import MLXLMCommon
+import Synchronization
+
+// MARK: - PromptCacheMissReason
+
+/// Why a request could not reuse cached KV state. Logged on every miss (including a *partial*
+/// reuse, which still counts as one for diagnostic purposes -- see `PromptCacheResolution`)
+/// so a silently-zero-hit cache is diagnosable rather than looking identical to a working one.
+package enum PromptCacheMissReason: String, Sendable {
+    /// `SWAMA_PROMPT_CACHE=0`.
+    case disabled
+
+    /// No slot exists for this model yet (first request, or the previous slot was dropped by
+    /// eviction/memory pressure/cancellation). Also covers a model swap, since slots are keyed
+    /// by model name.
+    case noSlot = "no_slot"
+
+    /// The request carries image/video content; multimodal requests bypass the cache entirely
+    /// (both restore and store), since image embeddings are not represented in the token
+    /// sequence a KV cache indexes by.
+    case multimodal
+
+    /// The new token sequence shares no prefix at all with the cached one (position 0 already
+    /// differs) -- typically a system-prompt change or an unrelated conversation.
+    case mismatchAtZero = "mismatch_at_0"
+
+    /// The new token sequence shares a non-empty prefix with the cached one, but not the whole
+    /// cached prefix -- typically a mid-history edit. The shared prefix is still reused (causal
+    /// attention means cache state at position i depends only on tokens[0..<i], so this remains
+    /// exact), this reason exists purely to flag that the reuse was partial.
+    case partialMismatch = "partial_mismatch"
+
+    /// The cached `KVCache` has rotated (a `RotatingKVCache` at or past `maxSize`) or is
+    /// otherwise not trimmable; its layout no longer corresponds to a simple prefix of the
+    /// original sequence, so it cannot be reused at all.
+    case rotated
+
+    /// The slot exists but was built with a different `PromptCacheKVConfig` than this request
+    /// wants -- `maxKVSize`, `kvBits`, `kvGroupSize`, or `quantizedKVStart` differs.
+    case kvConfigChanged = "kv_config_changed"
+
+    /// This request's `PromptCacheEpoch` (captured at `checkout`, or at `currentEpoch` on a
+    /// miss) no longer matched the store's current epoch by the time the request tried to
+    /// check its slot back in -- `drop(modelName:)` or `dropAll()` ran while this request's
+    /// generation was still in flight. The freshly-built or reused-and-trimmed cache this
+    /// request produced is discarded rather than resurrecting state the store had already
+    /// invalidated (see `PromptCacheEpoch`).
+    case invalidated
+
+    /// A cache hit whose reuse would need `FullHistoryLogitProcessor` (a penalty processor is
+    /// configured, so the wrapper must re-prime it with the full history) together with a
+    /// caller-requested quantized KV cache (`GenerateParameters.kvBits != nil`). The
+    /// `TokenIterator` overload that accepts a custom processor hardcodes
+    /// `kvBits: nil`/`kvGroupSize: 64`/`quantizedKVStart: 0` and cannot be told otherwise --
+    /// those are internal `let`s, set only by the sibling initializer that derives them from
+    /// `GenerateParameters`, which does not itself accept a custom processor. Rather than
+    /// silently drop the caller's quantization request, `ModelRunner.runChat` declines this
+    /// cache hit entirely and falls back to an ordinary, uncached, fully-quantization-correct
+    /// prefill for this one request. See `PromptCacheIteratorStrategy.bypass`.
+    case kvQuantizationUnsupported = "kv_quantization_unsupported"
+}
+
+// MARK: - PromptCacheEpoch
+
+/// A snapshot of `PromptCacheStore`'s invalidation counters, captured up front (at `checkout` on
+/// a reuse attempt, or at `currentEpoch` on a miss) and re-checked at `checkin`.
+///
+/// This closes the race described on `ModelPool.clearCache()`'s call to `PromptCacheStore
+/// .shared.dropAll()`: `ModelPool.run` suspends while an inference is in flight, so
+/// `clearCache()`/`remove(modelName:)` can run -- and mutate the store -- while a still-running
+/// `ModelRunner` already holds (or is about to build) a slot for the very model being cleared.
+/// Without this token, that runner's eventual `checkin` would silently resurrect a slot the store
+/// had already dropped, undoing the clear/remove and leaking the resurrected slot's KV memory
+/// forever. `checkin` only stores when the token presented still equals the store's current one;
+/// otherwise the slot the caller built is simply discarded.
+///
+/// This is a supplement to, not a replacement for, the checkout-is-destructive discipline
+/// documented on `PromptCacheStore` itself: checkout still atomically removes a slot so at most
+/// one caller ever owns it, and the epoch only guards the additional window where the store was
+/// mutated *while* that caller held the slot (or, on a miss, before it wrote a fresh one back).
+package struct PromptCacheEpoch: Equatable, Sendable {
+    fileprivate let global: UInt64
+    fileprivate let perModel: UInt64
+}
+
+// MARK: - PromptCacheResolution
+
+/// The outcome of trying to reuse a model's prompt cache for one request's token sequence.
+///
+/// `@unchecked Sendable`: carries `[KVCache]` (see `PromptCacheSlot`); this value is built once
+/// per request, handed across a single `container.perform` boundary, and not shared afterward.
+enum PromptCacheResolution: @unchecked Sendable {
+    /// Reuse the cache starting at `matchedLength` tokens in (already capped so the caller has
+    /// at least one suffix token to feed the `TokenIterator`, and already trimmed to that
+    /// offset). `reason` is `.partialMismatch` when the match was shorter than the entire
+    /// cached prefix, `nil` for a clean full-prefix hit (a plain append). `epoch` is the token
+    /// captured at the `checkout` that produced this slot -- carried by the caller all the way
+    /// through generation and presented back to `checkin`.
+    case reuse(matchedLength: Int, cache: [KVCache], reason: PromptCacheMissReason?, epoch: PromptCacheEpoch)
+
+    /// No reuse at all; the caller must prefill the full prompt. `epoch` is `nil` for
+    /// `.disabled`/`.multimodal`, which never touch the store at all (nothing will ever be
+    /// checked in for this request), and otherwise the token from `currentEpoch(modelName:)`
+    /// (`.noSlot`) or from the checkout that was attempted and rejected (`.kvConfigChanged`,
+    /// `.rotated`, `.mismatchAtZero`) -- in every case, captured before generation starts.
+    case miss(reason: PromptCacheMissReason, epoch: PromptCacheEpoch?)
+}
+
+// MARK: - PromptCacheKVConfig
+
+/// The KV-cache *layout* a slot's `KVCache` layers were built with -- everything that changes the
+/// shape or numeric representation of the cache tensors themselves, as opposed to the token
+/// content they represent. A mismatch on any field here means the stored `KVCache` layers are
+/// simply the wrong shape/type for this request's iterator to keep appending to, independent of
+/// whether the token prefix matches: `maxKVSize` selects `RotatingKVCache` vs `KVCacheSimple` (and
+/// its window size), while `kvBits`/`kvGroupSize`/`quantizedKVStart` select whether/when the
+/// cache gets transparently swapped for a `QuantizedKVCache` mid-generation (see
+/// `maybeQuantizeKVCache`). Compared as a whole struct in `resolvePromptCacheReuse` so a change to
+/// any one field -- not just `maxKVSize` -- correctly forces a `.kvConfigChanged` miss rather than
+/// reusing a cache whose layout no longer matches what this request's `GenerateParameters` asked
+/// for.
+package struct PromptCacheKVConfig: Equatable, Sendable {
+    package var maxKVSize: Int
+    package var kvBits: Int?
+    package var kvGroupSize: Int
+    package var quantizedKVStart: Int
+
+    package init(maxKVSize: Int, kvBits: Int? = nil, kvGroupSize: Int = 64, quantizedKVStart: Int = 0) {
+        self.maxKVSize = maxKVSize
+        self.kvBits = kvBits
+        self.kvGroupSize = kvGroupSize
+        self.quantizedKVStart = quantizedKVStart
+    }
+
+    /// Builds a config from `GenerateParameters`, with `maxKVSize` supplied separately since
+    /// `ModelRunner.runChat` computes the *effective* value (falling back to the context limit
+    /// when the caller left `parameters.maxKVSize` unset) rather than trusting
+    /// `parameters.maxKVSize` directly.
+    package init(parameters: GenerateParameters, maxKVSize: Int) {
+        self.init(
+            maxKVSize: maxKVSize,
+            kvBits: parameters.kvBits,
+            kvGroupSize: parameters.kvGroupSize,
+            quantizedKVStart: parameters.quantizedKVStart
+        )
+    }
+}
+
+// MARK: - PromptCacheSlot
+
+/// One model's cached prompt/KV state: the exact token sequence the cache represents, the live
+/// `KVCache` layers (one per model layer), and the `PromptCacheKVConfig` the cache was built with
+/// (a mismatch there means the stored layers are the wrong shape/layout, so the cache cannot be
+/// reused as-is even if the tokens match).
+///
+/// `@unchecked Sendable`: `KVCache` is a mutable, non-Sendable MLX type. Safety comes from
+/// `PromptCacheStore`'s checkout discipline, not from the type system -- a slot has exactly one
+/// owner at a time (see `PromptCacheStore`).
+package struct PromptCacheSlot: @unchecked Sendable {
+    package var tokens: [Int]
+    package var cache: [KVCache]
+    package var kvConfig: PromptCacheKVConfig
+
+    package init(tokens: [Int], cache: [KVCache], kvConfig: PromptCacheKVConfig) {
+        self.tokens = tokens
+        self.cache = cache
+        self.kvConfig = kvConfig
+    }
+}
+
+// MARK: - PromptCacheStore
+
+/// One prompt/KV-cache slot per model name, with checkout semantics: `checkout` atomically
+/// removes and returns a model's slot, so the caller has exclusive ownership of it until it
+/// explicitly `checkin`s it. This makes the cancellation-safe lifecycle free -- a caller that
+/// hits an error, is cancelled, or decides the resulting cache is unusable (rotated, etc.)
+/// simply never calls `checkin`, and the slot stays absent. There is no separate "invalidate"
+/// step and no way to leave a half-written slot behind: the slot the caller checked out is
+/// already gone from the store the moment `checkout` returns it.
+///
+/// Access is a simple mutex rather than an actor: `ModelPool.run` already serializes inference
+/// per model name, so contention is not expected, but the store itself makes no assumption
+/// about that -- `checkout`/`checkin`/`drop` are individually atomic regardless, and the epoch
+/// counters live under the same lock as the slots so "is this token still current" and "mutate
+/// the slots" can never observe each other torn.
+package final class PromptCacheStore: Sendable {
+    // MARK: Lifecycle
+
+    package init() {}
+
+    // MARK: Public
+
+    package static let shared: PromptCacheStore = .init()
+
+    /// Removes and returns the slot for `modelName`, if any, together with the `PromptCacheEpoch`
+    /// in force at that same instant -- see the checkout-semantics note on the type itself, and
+    /// `PromptCacheEpoch`'s doc comment for why the epoch has to be captured atomically with the
+    /// removal rather than read separately afterward.
+    package func checkout(modelName: String) -> (slot: PromptCacheSlot, epoch: PromptCacheEpoch)? {
+        let (slot, epoch) = checkoutOrCurrentEpoch(modelName: modelName)
+        guard let slot else {
+            return nil
+        }
+
+        return (slot, epoch)
+    }
+
+    /// Checks a slot out if there is one, and reports the `PromptCacheEpoch` in force either way
+    /// -- both under a single acquisition of the lock.
+    ///
+    /// The atomicity is the point. Reading the epoch in a second, separate call after a checkout
+    /// that found nothing would leave a window in which `dropAll()` lands between the two: the
+    /// caller would then capture the *post*-drop epoch, its later `checkin` would be accepted,
+    /// and the slot it built while holding a container that `clearCache()` has since evicted
+    /// would survive the clear -- which is the very resurrection `PromptCacheEpoch` exists to
+    /// prevent, just through a narrower window.
+    package func checkoutOrCurrentEpoch(modelName: String) -> (slot: PromptCacheSlot?, epoch: PromptCacheEpoch) {
+        state.withLock { state in
+            (state.slots.removeValue(forKey: modelName), state.currentEpoch(modelName: modelName))
+        }
+    }
+
+    /// The `PromptCacheEpoch` in force for `modelName` right now, without touching any slot --
+    /// for the miss path, where `checkout` found nothing to remove but a slot will still be
+    /// written back at the end of generation, so a token still has to be captured before that
+    /// generation starts.
+    package func currentEpoch(modelName: String) -> PromptCacheEpoch {
+        state.withLock { $0.currentEpoch(modelName: modelName) }
+    }
+
+    /// Non-destructive lookup of a model's slot, for diagnostics and tests -- does not affect
+    /// checkout state (unlike `checkout`, this does not remove the slot).
+    package func peek(modelName: String) -> PromptCacheSlot? {
+        state.withLock { $0.slots[modelName] }
+    }
+
+    /// Stores `slot` for `modelName`, checking it back in after clean completion, but only if
+    /// `epoch` still equals the store's current epoch for `modelName`. A mismatch means
+    /// `drop(modelName:)` or `dropAll()` ran while this slot's generation was in flight; the
+    /// slot is dropped on the floor instead (which also releases its KV arrays) rather than
+    /// resurrecting state the store had already invalidated. Returns whether the slot was
+    /// actually stored, so the caller can log a rejection for diagnosability.
+    @discardableResult
+    package func checkin(modelName: String, slot: PromptCacheSlot, epoch: PromptCacheEpoch) -> Bool {
+        state.withLock { state in
+            guard state.currentEpoch(modelName: modelName) == epoch else {
+                return false
+            }
+
+            state.slots[modelName] = slot
+            return true
+        }
+    }
+
+    /// Drops any slot for `modelName` and bumps that model's epoch -- used on model eviction and
+    /// under memory pressure, where the cache's underlying weights/buffers are going away
+    /// regardless of the slot's content, and available for explicit invalidation elsewhere. The
+    /// epoch bump happens unconditionally, even when no slot is currently present, so a
+    /// generation that is mid-flight for this model right now (and so already checked its slot
+    /// out, or never found one) is still correctly invalidated when it tries to check in later.
+    package func drop(modelName: String) {
+        state.withLock { state in
+            _ = state.slots.removeValue(forKey: modelName)
+            state.modelEpochs[modelName, default: 0] += 1
+        }
+    }
+
+    /// Drops every slot and bumps the global epoch -- used when the whole model cache is
+    /// cleared. Per-model epoch counters are left untouched (bumping the global epoch already
+    /// invalidates every model), and are never reset by this call either -- see `State
+    /// .modelEpochs`.
+    package func dropAll() {
+        state.withLock { state in
+            state.slots.removeAll()
+            state.globalEpoch += 1
+        }
+    }
+
+    // MARK: Private
+
+    /// Bundles the slots with the epoch counters that guard them so both live under one lock.
+    private struct State {
+        var slots: [String: PromptCacheSlot] = [:]
+
+        /// Per-model invalidation counters, bumped by `drop(modelName:)`. Deliberately **not**
+        /// cleared when a model's slot is removed (by `checkout`, `drop`, or eviction) -- a model
+        /// with no live slot right now must still correctly invalidate a write-back a past
+        /// generation for that model is about to attempt.
+        var modelEpochs: [String: UInt64] = [:]
+
+        /// Global invalidation counter, bumped by `dropAll()`.
+        var globalEpoch: UInt64 = 0
+
+        func currentEpoch(modelName: String) -> PromptCacheEpoch {
+            PromptCacheEpoch(global: globalEpoch, perModel: modelEpochs[modelName] ?? 0)
+        }
+    }
+
+    private let state: Mutex<State> = .init(State())
+}
+
+// MARK: - Pure helpers (free functions for direct unit testing via @testable import)
+
+/// Longest common prefix length of two token sequences.
+func promptCacheLongestCommonPrefix(_ a: [Int], _ b: [Int]) -> Int {
+    var index = 0
+    let limit = min(a.count, b.count)
+    while index < limit, a[index] == b[index] {
+        index += 1
+    }
+    return index
+}
+
+/// Whether a single cache layer can still be trimmed and treated as an exact prefix of the
+/// original sequence. `RotatingKVCache.isTrimmable` already encodes `offset < maxSize`, but the
+/// `maxSize` check is repeated explicitly here (rather than trusting `isTrimmable` alone) per
+/// the design's "assert, don't assume" rotation guard: the failure mode on getting this wrong is
+/// corrupt output, not extra latency.
+func promptCacheLayerIsReusable(_ layer: KVCache) -> Bool {
+    guard layer.isTrimmable else {
+        return false
+    }
+
+    if let maxSize = layer.maxSize {
+        return layer.offset < maxSize
+    }
+    return true
+}
+
+/// Whether every layer of a cache can still be trimmed and reused.
+func promptCacheIsReusable(_ cache: [KVCache]) -> Bool {
+    cache.isEmpty == false && cache.allSatisfy(promptCacheLayerIsReusable)
+}
+
+/// Resolves whether `newTokens` can reuse `store`'s slot for `modelName`, checking the slot out
+/// of the store in the process whenever one exists and is even considered (see the type docs on
+/// `PromptCacheStore` for why not checking a considered-but-rejected slot back in is sufficient
+/// to invalidate it).
+///
+/// `hasMediaInput` and `!enabled` short-circuit before any checkout, so a multimodal or
+/// cache-disabled request never disturbs a slot a later, ordinary request could still use.
+func resolvePromptCacheReuse(
+    enabled: Bool,
+    hasMediaInput: Bool,
+    modelName: String,
+    newTokens: [Int],
+    kvConfig: PromptCacheKVConfig,
+    store: PromptCacheStore
+) -> PromptCacheResolution {
+    guard enabled else {
+        return .miss(reason: .disabled, epoch: nil)
+    }
+    guard hasMediaInput == false else {
+        return .miss(reason: .multimodal, epoch: nil)
+    }
+
+    // Nothing may be checked out here, but a fresh cache will still be built and written back at
+    // the end of generation, so the token it will need is captured now -- in the same locked
+    // step as the checkout attempt, never as a separate read afterward.
+    let (checkedOutSlot, epoch) = store.checkoutOrCurrentEpoch(modelName: modelName)
+    guard let slot = checkedOutSlot else {
+        return .miss(reason: .noSlot, epoch: epoch)
+    }
+    guard slot.kvConfig == kvConfig else {
+        return .miss(reason: .kvConfigChanged, epoch: epoch)
+    }
+    guard promptCacheIsReusable(slot.cache) else {
+        return .miss(reason: .rotated, epoch: epoch)
+    }
+
+    let matched = promptCacheLongestCommonPrefix(slot.tokens, newTokens)
+    guard matched > 0 else {
+        return .miss(reason: .mismatchAtZero, epoch: epoch)
+    }
+
+    // The TokenIterator needs at least one prompt token to prime the pump, so a full-prefix
+    // match (matched == newTokens.count) still leaves the last token to be fed as the suffix.
+    let trimTarget = min(matched, max(newTokens.count - 1, 0))
+    for layer in slot.cache {
+        layer.trim(layer.offset - trimTarget)
+    }
+
+    let reason: PromptCacheMissReason? = matched < slot.tokens.count ? .partialMismatch : nil
+    return .reuse(matchedLength: trimTarget, cache: slot.cache, reason: reason, epoch: epoch)
+}

--- a/swama/Sources/SwamaRuntime/Model/StreamingDetokenizer.swift
+++ b/swama/Sources/SwamaRuntime/Model/StreamingDetokenizer.swift
@@ -1,0 +1,42 @@
+import Tokenizers
+
+package struct StreamingDetokenizer {
+    // MARK: Lifecycle
+
+    package init(tokenizer: Tokenizer) {
+        self.tokenizer = tokenizer
+    }
+
+    // MARK: Public
+
+    /// Appends a new token to the stream.
+    /// If a complete string chunk can be formed, it is returned.
+    /// Otherwise, nil is returned.
+    package mutating func append(token: Int) -> String? {
+        buffer.append(token)
+
+        let decoded = tokenizer.decode(tokens: buffer, skipSpecialTokens: false)
+
+        // Check if the decoded string has replacement characters (incomplete token)
+        if decoded.contains("\u{fffd}") {
+            return nil
+        }
+
+        // Buffer was successfully decoded → flush to tokens
+        tokens.append(contentsOf: buffer)
+        buffer.removeAll()
+
+        let fullDecoded = tokenizer.decode(tokens: tokens, skipSpecialTokens: true)
+        let delta = fullDecoded.dropFirst(lastDecoded.count)
+
+        lastDecoded = fullDecoded
+        return String(delta)
+    }
+
+    // MARK: Private
+
+    private let tokenizer: Tokenizer
+    private var tokens: [Int] = []
+    private var lastDecoded: String = ""
+    private var buffer: [Int] = []
+}

--- a/swama/Sources/SwamaRuntime/Model/TerminalUI/ProgressBar.swift
+++ b/swama/Sources/SwamaRuntime/Model/TerminalUI/ProgressBar.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+// MARK: - ProgressBar
+
+final class ProgressBar {
+    // MARK: Lifecycle
+
+    init(total: Int64, barWidth: Int = 30, initial: Int64 = 0) {
+        self.total = total
+        self.barWidth = barWidth
+        self.downloaded = initial
+        self.lastDownloaded = initial
+    }
+
+    // MARK: Internal
+
+    func update(bytes: Int64) {
+        downloaded += bytes
+        let now = Date()
+        let interval = now.timeIntervalSince(lastSpeedCheck)
+        if interval >= 0.5 {
+            let bytesDelta = downloaded - lastDownloaded
+            speed = interval > 0 ? Double(bytesDelta) / interval : 0
+            lastDownloaded = downloaded
+            lastSpeedCheck = now
+        }
+        if now.timeIntervalSince(lastPrint) >= 0.1 || (total > 0 && downloaded == total) {
+            lastPrint = now
+
+            // Handle case where total size is unknown (0)
+            guard total > 0 else {
+                let downloadedStr = formatBytes(downloaded)
+                let speedStr = formatSpeed(speed)
+                fputs("\rDownloading... \(downloadedStr) (\(speedStr))", stdout)
+                fflush(stdout)
+                return
+            }
+
+            let percent = Double(downloaded) / Double(total)
+            // Additional safety check for division result
+            guard percent.isFinite else {
+                return
+            }
+
+            let filled = Int(percent * Double(barWidth))
+            let bar =
+                if filled < barWidth {
+                    String(repeating: "=", count: filled) + ">" +
+                        String(repeating: " ", count: max(0, barWidth - filled - 1))
+                }
+                else {
+                    String(repeating: "=", count: barWidth)
+                }
+            let percentStr = String(format: "%3d%%", Int(percent * 100))
+            let speedStr = formatSpeed(speed)
+            // Use fputs to stdout for progress bar to behave like print
+            fputs("\r[\(bar)] \(percentStr) \(speedStr)", stdout)
+            fflush(stdout)
+        }
+    }
+
+    private func formatSpeed(_ speed: Double) -> String {
+        if speed > 1024 * 1024 {
+            String(format: "%.2f MB/s", speed / 1024 / 1024)
+        }
+        else if speed > 1024 {
+            String(format: "%.2f KB/s", speed / 1024)
+        }
+        else {
+            String(format: "%.0f B/s", speed)
+        }
+    }
+
+    private func formatBytes(_ bytes: Int64) -> String {
+        if bytes > 1024 * 1024 {
+            String(format: "%.2f MB", Double(bytes) / 1024 / 1024)
+        }
+        else if bytes > 1024 {
+            String(format: "%.2f KB", Double(bytes) / 1024)
+        }
+        else {
+            "\(bytes) B"
+        }
+    }
+
+    func finish() {
+        fputs("\n", stdout)
+        fflush(stdout)
+    }
+
+    // MARK: Private
+
+    private let total: Int64
+    private let barWidth: Int
+    private var downloaded: Int64
+    private var lastPrint: Date = .init(timeIntervalSince1970: 0)
+    private var lastDownloaded: Int64
+    private var lastSpeedCheck: Date = .init(timeIntervalSince1970: 0)
+    private var speed: Double = 0 // bytes/sec
+}

--- a/swama/Sources/SwamaRuntime/Model/TokenizerCache.swift
+++ b/swama/Sources/SwamaRuntime/Model/TokenizerCache.swift
@@ -1,0 +1,598 @@
+import CryptoKit
+import Foundation
+import MLXLMCommon
+
+// MARK: - TokenizerInputFingerprint
+
+/// Content identity for every local file the pinned tokenizer loader currently reads, plus the
+/// common split-vocabulary files that a future compatible loader may consult. File names,
+/// presence/absence, sizes, and bytes all participate except for `config.json`: the pinned loader
+/// uses only its parsed `model_type` to select a tokenizer fallback, so unrelated model-shape fields
+/// are deliberately excluded. The model name and directory path do not participate, allowing equal
+/// tokenizer inputs to be shared safely across model directories.
+struct TokenizerInputFingerprint: Equatable, Hashable, Sendable {
+    static let fileNames = [
+        "added_tokens.json",
+        "chat_template.jinja",
+        "chat_template.json",
+        "config.json",
+        "merges.txt",
+        "special_tokens_map.json",
+        "tokenizer.json",
+        "tokenizer_config.json",
+        "vocab.json"
+    ]
+
+    let digest: String
+    let byteCount: Int64
+
+    static func calculate(in directory: URL) throws -> Self {
+        var hasher = SHA256()
+        var byteCount: Int64 = 0
+
+        for fileName in fileNames {
+            hasher.update(data: Data(fileName.utf8))
+            hasher.update(data: Data([0]))
+            let file = directory.appendingPathComponent(fileName)
+            guard FileManager.default.fileExists(atPath: file.path) else {
+                hasher.update(data: Data([0]))
+                continue
+            }
+
+            let attributes = try FileManager.default.attributesOfItem(atPath: file.path)
+            guard attributes[.type] as? FileAttributeType == .typeRegular,
+                  let size = attributes[.size] as? NSNumber
+            else {
+                throw TokenizerFingerprintError.inputIsNotARegularFile(fileName)
+            }
+
+            hasher.update(data: Data([1]))
+            byteCount = try adding(byteCount, Int64(bitPattern: size.uint64Value))
+            if fileName == "config.json" {
+                let data = try Data(contentsOf: file)
+                guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                    throw TokenizerFingerprintError.invalidModelConfiguration
+                }
+
+                if let modelType = object["model_type"] as? String {
+                    hasher.update(data: Data([1]))
+                    hasher.update(data: Data(modelType.utf8))
+                }
+                else {
+                    hasher.update(data: Data([0]))
+                }
+                continue
+            }
+
+            var bigEndianSize = size.uint64Value.bigEndian
+            withUnsafeBytes(of: &bigEndianSize) { hasher.update(bufferPointer: $0) }
+
+            let handle = try FileHandle(forReadingFrom: file)
+            defer { try? handle.close() }
+            while let data = try handle.read(upToCount: 1024 * 1024), !data.isEmpty {
+                hasher.update(data: data)
+            }
+        }
+
+        return .init(
+            digest: hasher.finalize().map { String(format: "%02x", $0) }.joined(),
+            byteCount: byteCount
+        )
+    }
+
+    static func rejectionDigest(for directory: URL) -> String {
+        let payload = Data("tokenizer-rejected\0\(directory.standardizedFileURL.path)".utf8)
+        return SHA256.hash(data: payload).map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func adding(_ lhs: Int64, _ rhs: Int64) throws -> Int64 {
+        let (sum, overflow) = lhs.addingReportingOverflow(rhs)
+        guard !overflow, rhs >= 0 else {
+            throw TokenizerFingerprintError.inputSizeOverflow
+        }
+
+        return sum
+    }
+}
+
+// MARK: - TokenizerFingerprintError
+
+private enum TokenizerFingerprintError: Error {
+    case invalidModelConfiguration
+    case inputIsNotARegularFile(String)
+    case inputSizeOverflow
+}
+
+// MARK: - TokenizerCacheConfiguration
+
+struct TokenizerCacheConfiguration: Sendable {
+    static let live: Self = .init(
+        maximumEntries: 4,
+        maximumInputBytes: 64 * 1024 * 1024
+    )
+
+    let maximumEntries: Int
+    let maximumInputBytes: Int64
+}
+
+// MARK: - TokenizerCacheDiagnostics
+
+struct TokenizerCacheDiagnostics: Sendable {
+    static let live: Self = .init(
+        hit: { SwamaDiagnostics.hitTokenizerCache(fingerprint: $0) },
+        miss: { SwamaDiagnostics.missTokenizerCache(fingerprint: $0) },
+        evict: { SwamaDiagnostics.evictTokenizerCache(fingerprint: $0, reason: $1) },
+        reject: { SwamaDiagnostics.rejectTokenizerCache(fingerprint: $0, durationMilliseconds: $1) }
+    )
+
+    static let disabled: Self = .init(
+        hit: { _ in },
+        miss: { _ in },
+        evict: { _, _ in },
+        reject: { _, _ in }
+    )
+
+    let hit: @Sendable (String) -> Void
+    let miss: @Sendable (String) -> Void
+    let evict: @Sendable (String, String) -> Void
+    let reject: @Sendable (String, Double) -> Void
+}
+
+// MARK: - TokenizerCacheOwner
+
+struct TokenizerCacheOwner: Hashable, Sendable {
+    static let standalone: Self = .init()
+
+    init() {
+        id = .init()
+    }
+
+    private let id: UUID
+}
+
+// MARK: - TokenizerCache
+
+final class TokenizerCache: @unchecked Sendable {
+    static let shared: TokenizerCache = .init(configuration: .live, diagnostics: .live)
+
+    init(
+        configuration: TokenizerCacheConfiguration,
+        diagnostics: TokenizerCacheDiagnostics = .live
+    ) {
+        self.configuration = configuration
+        self.diagnostics = diagnostics
+    }
+
+    /// Loads through a content-addressed, process-local cache. A failed fingerprint or an
+    /// over-budget input fails open to the upstream loader without entering either the ready cache
+    /// or the coalescing table.
+    func load(
+        from directory: URL,
+        using upstream: any TokenizerLoader,
+        owner: TokenizerCacheOwner = .standalone
+    ) async throws -> any Tokenizer {
+        try Task.checkCancellation()
+        let startedAt = DispatchTime.now().uptimeNanoseconds
+        let fingerprint: TokenizerInputFingerprint
+        do {
+            fingerprint = try TokenizerInputFingerprint.calculate(in: directory)
+        }
+        catch {
+            diagnostics.reject(
+                TokenizerInputFingerprint.rejectionDigest(for: directory),
+                Self.elapsedMilliseconds(since: startedAt)
+            )
+            try Task.checkCancellation()
+            return try await upstream.load(from: directory)
+        }
+        try Task.checkCancellation()
+
+        guard configuration.maximumEntries > 0,
+              configuration.maximumInputBytes > 0,
+              fingerprint.byteCount <= configuration.maximumInputBytes
+        else {
+            diagnostics.reject(fingerprint.digest, Self.elapsedMilliseconds(since: startedAt))
+            try Task.checkCancellation()
+            return try await upstream.load(from: directory)
+        }
+
+        let (acquisition, newTask) = acquire(
+            fingerprint: fingerprint,
+            directory: directory,
+            upstream: upstream,
+            owner: owner
+        )
+        switch acquisition {
+        case let .ready(tokenizer):
+            diagnostics.hit(fingerprint.digest)
+            return tokenizer
+
+        case let .waiting(sequence, waiter):
+            if let newTask {
+                diagnostics.miss(fingerprint.digest)
+                observe(
+                    newTask,
+                    fingerprint: fingerprint,
+                    sequence: sequence,
+                    startedAt: startedAt
+                )
+            }
+            else {
+                diagnostics.hit(fingerprint.digest)
+            }
+
+            let completed = try await waiter.value {
+                self.cancelWaiter(
+                    fingerprint: fingerprint.digest,
+                    sequence: sequence,
+                    waiterID: waiter.id
+                )
+            }
+            try Task.checkCancellation()
+            let fingerprintAfterWaiting = try? TokenizerInputFingerprint.calculate(in: directory)
+            try Task.checkCancellation()
+            guard fingerprintAfterWaiting == fingerprint else {
+                diagnostics.reject(
+                    fingerprint.digest,
+                    Self.elapsedMilliseconds(since: startedAt)
+                )
+                throw TokenizerCacheError.inputsChangedDuringLoad
+            }
+
+            return completed.tokenizer
+        }
+    }
+
+    func purge(owner: TokenizerCacheOwner = .standalone) {
+        let (fingerprints, tasks, waiters) = lock.withLock {
+            () -> ([String], [Task<CompletedLoad, Error>], [Waiter]) in
+            var fingerprints: [String] = []
+            for fingerprint in Array(ready.keys) {
+                guard var entry = ready[fingerprint] else {
+                    continue
+                }
+
+                entry.owners.remove(owner)
+                if entry.owners.isEmpty {
+                    ready.removeValue(forKey: fingerprint)
+                    fingerprints.append(fingerprint)
+                }
+                else {
+                    ready[fingerprint] = entry
+                }
+            }
+
+            var tasks: [Task<CompletedLoad, Error>] = []
+            var removedWaiters: [Waiter] = []
+            for fingerprint in Array(pending.keys) {
+                guard var pendingLoad = pending[fingerprint] else {
+                    continue
+                }
+
+                let ownerWaiters = pendingLoad.waiters.values.filter { $0.owner == owner }
+                removedWaiters.append(contentsOf: ownerWaiters)
+                for waiter in ownerWaiters {
+                    pendingLoad.waiters.removeValue(forKey: waiter.id)
+                }
+                if pendingLoad.waiters.isEmpty {
+                    pending.removeValue(forKey: fingerprint)
+                    tasks.append(pendingLoad.task)
+                }
+                else {
+                    pending[fingerprint] = pendingLoad
+                }
+            }
+
+            return (fingerprints.sorted(), tasks, removedWaiters)
+        }
+        for fingerprint in fingerprints {
+            diagnostics.evict(fingerprint, "explicit")
+        }
+        for task in tasks {
+            task.cancel()
+        }
+        for waiter in waiters {
+            waiter.resolve(.failure(CancellationError()))
+        }
+    }
+
+    #if DEBUG
+        func entryCountForTesting() -> Int {
+            lock.withLock { ready.count }
+        }
+
+        func pendingCountForTesting() -> Int {
+            lock.withLock { pending.count }
+        }
+
+        func waiterCountForTesting() -> Int {
+            lock.withLock { pending.values.reduce(0) { $0 + $1.waiters.count } }
+        }
+    #endif
+
+    private enum Acquisition {
+        case ready(any Tokenizer)
+        case waiting(sequence: UInt64, waiter: Waiter)
+    }
+
+    private struct ReadyEntry: Sendable {
+        let tokenizer: any Tokenizer
+        var lastAccess: UInt64
+        var owners: Set<TokenizerCacheOwner>
+    }
+
+    private struct CompletedLoad: Sendable {
+        let tokenizer: any Tokenizer
+        let fingerprintAfterLoad: TokenizerInputFingerprint?
+    }
+
+    private struct PendingLoad: Sendable {
+        let sequence: UInt64
+        let task: Task<CompletedLoad, Error>
+        var waiters: [UUID: Waiter]
+    }
+
+    private let configuration: TokenizerCacheConfiguration
+    private let diagnostics: TokenizerCacheDiagnostics
+    private let lock: NSLock = .init()
+    private var ready: [String: ReadyEntry] = [:]
+    private var pending: [String: PendingLoad] = [:]
+    private var accessSequence: UInt64 = 0
+    private var loadSequence: UInt64 = 0
+
+    private func acquire(
+        fingerprint: TokenizerInputFingerprint,
+        directory: URL,
+        upstream: any TokenizerLoader,
+        owner: TokenizerCacheOwner
+    ) -> (Acquisition, Task<CompletedLoad, Error>?) {
+        lock.withLock {
+            if var entry = ready[fingerprint.digest] {
+                accessSequence &+= 1
+                entry.lastAccess = accessSequence
+                entry.owners.insert(owner)
+                ready[fingerprint.digest] = entry
+                return (.ready(entry.tokenizer), nil)
+            }
+
+            let waiter = Waiter(owner: owner)
+            if var pendingLoad = pending[fingerprint.digest] {
+                pendingLoad.waiters[waiter.id] = waiter
+                pending[fingerprint.digest] = pendingLoad
+                return (.waiting(sequence: pendingLoad.sequence, waiter: waiter), nil)
+            }
+
+            loadSequence &+= 1
+            let sequence = loadSequence
+            let task = Task.detached { () throws -> CompletedLoad in
+                let tokenizer = try await upstream.load(from: directory)
+                let fingerprintAfterLoad = try? TokenizerInputFingerprint.calculate(in: directory)
+                return .init(tokenizer: tokenizer, fingerprintAfterLoad: fingerprintAfterLoad)
+            }
+            pending[fingerprint.digest] = .init(
+                sequence: sequence,
+                task: task,
+                waiters: [waiter.id: waiter]
+            )
+            return (.waiting(sequence: sequence, waiter: waiter), task)
+        }
+    }
+
+    private func observe(
+        _ task: Task<CompletedLoad, Error>,
+        fingerprint: TokenizerInputFingerprint,
+        sequence: UInt64,
+        startedAt: UInt64
+    ) {
+        Task.detached { [self] in
+            let result = await task.result
+            complete(
+                result,
+                fingerprint: fingerprint,
+                sequence: sequence,
+                startedAt: startedAt
+            )
+        }
+    }
+
+    private func complete(
+        _ result: Result<CompletedLoad, Error>,
+        fingerprint: TokenizerInputFingerprint,
+        sequence: UInt64,
+        startedAt: UInt64
+    ) {
+        var finalResult = result
+        var waiters: [Waiter] = []
+        var evictedFingerprints: [String] = []
+        var rejected = false
+
+        lock.lock()
+        guard let pendingLoad = pending[fingerprint.digest], pendingLoad.sequence == sequence else {
+            lock.unlock()
+            return
+        }
+
+        pending.removeValue(forKey: fingerprint.digest)
+        waiters = Array(pendingLoad.waiters.values)
+
+        if case let .success(completed) = result {
+            if completed.fingerprintAfterLoad == fingerprint {
+                accessSequence &+= 1
+                ready[fingerprint.digest] = .init(
+                    tokenizer: completed.tokenizer,
+                    lastAccess: accessSequence,
+                    owners: Set(waiters.map(\.owner))
+                )
+                evictedFingerprints = evictToBudgetLocked()
+            }
+            else {
+                rejected = true
+                finalResult = .failure(TokenizerCacheError.inputsChangedDuringLoad)
+            }
+        }
+        lock.unlock()
+
+        if rejected {
+            diagnostics.reject(
+                fingerprint.digest,
+                Self.elapsedMilliseconds(since: startedAt)
+            )
+        }
+        for evictedFingerprint in evictedFingerprints {
+            diagnostics.evict(evictedFingerprint, "budget")
+        }
+        for waiter in waiters {
+            waiter.resolve(finalResult)
+        }
+    }
+
+    private func cancelWaiter(
+        fingerprint: String,
+        sequence: UInt64,
+        waiterID: UUID
+    ) {
+        var taskToCancel: Task<CompletedLoad, Error>?
+        lock.withLock {
+            guard var pendingLoad = pending[fingerprint], pendingLoad.sequence == sequence else {
+                return
+            }
+
+            pendingLoad.waiters.removeValue(forKey: waiterID)
+            if pendingLoad.waiters.isEmpty {
+                pending.removeValue(forKey: fingerprint)
+                taskToCancel = pendingLoad.task
+            }
+            else {
+                pending[fingerprint] = pendingLoad
+            }
+        }
+        taskToCancel?.cancel()
+    }
+
+    private func evictToBudgetLocked() -> [String] {
+        var fingerprints: [String] = []
+        while ready.count > configuration.maximumEntries,
+              let victim = ready.min(by: { lhs, rhs in
+                  if lhs.value.lastAccess == rhs.value.lastAccess {
+                      lhs.key < rhs.key
+                  }
+                  else {
+                      lhs.value.lastAccess < rhs.value.lastAccess
+                  }
+              })
+        {
+            ready.removeValue(forKey: victim.key)
+            fingerprints.append(victim.key)
+        }
+        return fingerprints
+    }
+
+    private static func elapsedMilliseconds(since startedAt: UInt64) -> Double {
+        Double(DispatchTime.now().uptimeNanoseconds - startedAt) / 1_000_000
+    }
+
+    private final class Waiter: @unchecked Sendable {
+        init(owner: TokenizerCacheOwner) {
+            self.owner = owner
+        }
+
+        let id: UUID = .init()
+        let owner: TokenizerCacheOwner
+
+        func value(onCancel: @escaping @Sendable () -> Void) async throws -> CompletedLoad {
+            do {
+                try Task.checkCancellation()
+                return try await withTaskCancellationHandler {
+                    try await withCheckedThrowingContinuation { continuation in
+                        let immediate = lock.withLock { () -> Result<CompletedLoad, Error>? in
+                            if let result {
+                                return result
+                            }
+                            if cancelled {
+                                return .failure(CancellationError())
+                            }
+                            self.continuation = continuation
+                            return nil
+                        }
+                        if let immediate {
+                            continuation.resume(with: immediate)
+                        }
+                    }
+                } onCancel: {
+                    if self.cancel() {
+                        onCancel()
+                    }
+                }
+            }
+            catch is CancellationError {
+                if cancel() {
+                    onCancel()
+                }
+                throw CancellationError()
+            }
+        }
+
+        func resolve(_ result: Result<CompletedLoad, Error>) {
+            let continuation = lock.withLock { () -> CheckedContinuation<CompletedLoad, Error>? in
+                guard self.result == nil, !cancelled else {
+                    return nil
+                }
+
+                self.result = result
+                let continuation = self.continuation
+                self.continuation = nil
+                return continuation
+            }
+            continuation?.resume(with: result)
+        }
+
+        private func cancel() -> Bool {
+            let (didCancel, continuation) = lock.withLock {
+                () -> (Bool, CheckedContinuation<CompletedLoad, Error>?) in
+                guard result == nil, !cancelled else {
+                    return (false, nil)
+                }
+
+                cancelled = true
+                let continuation = self.continuation
+                self.continuation = nil
+                return (true, continuation)
+            }
+            continuation?.resume(throwing: CancellationError())
+            return didCancel
+        }
+
+        private let lock: NSLock = .init()
+        private var continuation: CheckedContinuation<CompletedLoad, Error>?
+        private var result: Result<CompletedLoad, Error>?
+        private var cancelled = false
+    }
+}
+
+// MARK: - TokenizerCacheError
+
+enum TokenizerCacheError: Error {
+    case inputsChangedDuringLoad
+}
+
+// MARK: - CachedTokenizerLoader
+
+struct CachedTokenizerLoader: TokenizerLoader {
+    init(
+        upstream: any TokenizerLoader,
+        cache: TokenizerCache = .shared,
+        owner: TokenizerCacheOwner = .standalone
+    ) {
+        self.upstream = upstream
+        self.cache = cache
+        self.owner = owner
+    }
+
+    func load(from directory: URL) async throws -> any Tokenizer {
+        try await cache.load(from: directory, using: upstream, owner: owner)
+    }
+
+    private let upstream: any TokenizerLoader
+    private let cache: TokenizerCache
+    private let owner: TokenizerCacheOwner
+}

--- a/swama/Tests/SwamaRuntimeTests/ConfigurationTests.swift
+++ b/swama/Tests/SwamaRuntimeTests/ConfigurationTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+@testable import SwamaRuntime
+import Testing
+
+@MainActor @Suite(.serialized)
+final class ConfigurationTests {
+    @Test func fileManagerOperations() {
+        // Test basic file manager operations that the app uses
+        let fileManager = FileManager.default
+        let homeDirectory = fileManager.homeDirectoryForCurrentUser
+
+        #expect(homeDirectory.isFileURL)
+        #expect(fileManager.fileExists(atPath: homeDirectory.path))
+    }
+
+    @Test func uRLExtensions() {
+        // Test URL extensions and operations used in the app
+        let testURL = URL(fileURLWithPath: "/tmp/test")
+        #expect(testURL.path == "/tmp/test")
+        #expect(testURL.isFileURL)
+
+        let documentsURL = testURL.appendingPathComponent("documents")
+        #expect(documentsURL.lastPathComponent == "documents")
+    }
+
+    @Test func metadataSourceCases() {
+        // Test all MetadataSource enum cases
+        let metaFile = MetadataSource.metaFile
+        let directoryScan = MetadataSource.directoryScan
+
+        #expect(metaFile != directoryScan)
+
+        // Test that we can use them in functions
+        func getSourceName(_ source: MetadataSource) -> String {
+            switch source {
+            case .metaFile:
+                "meta_file"
+            case .directoryScan:
+                "directory_scan"
+            }
+        }
+
+        #expect(getSourceName(metaFile) == "meta_file")
+        #expect(getSourceName(directoryScan) == "directory_scan")
+    }
+
+    @Test func foundationIntegration() {
+        // Test Foundation framework integration
+        let testData = "Hello, World!".data(using: .utf8)
+        #expect(testData != nil)
+
+        if let data = testData {
+            let string = String(data: data, encoding: .utf8)
+            #expect(string == "Hello, World!")
+        }
+    }
+}

--- a/swama/Tests/SwamaRuntimeTests/ModelManagerTests.swift
+++ b/swama/Tests/SwamaRuntimeTests/ModelManagerTests.swift
@@ -70,4 +70,32 @@ final class ModelManagerTests {
         // Note: We can't test the actual content since it depends on the file system
         // In a real test environment, you might want to mock the file system
     }
+
+    @Test func runtimeListingSkipsTheCanonicalAudioSubtree() throws {
+        let root = FileManager.default
+            .temporaryDirectory
+            .appendingPathComponent("swama-runtime-model-list-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let languageModel = root.appendingPathComponent("org/language-model", isDirectory: true)
+        let audioModel = root.appendingPathComponent("mlx-audio/org_audio-model", isDirectory: true)
+        try FileManager.default.createDirectory(at: languageModel, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: audioModel, withIntermediateDirectories: true)
+        try metadata(id: "org/language-model").write(
+            to: languageModel.appendingPathComponent(".swama-meta.json")
+        )
+        try metadata(id: "org/audio-model").write(
+            to: audioModel.appendingPathComponent(".swama-meta.json")
+        )
+
+        #expect(ModelManager.scanModelsDirectory(at: root).map(\.id) == ["org/language-model"])
+    }
+
+    private func metadata(id: String) throws -> Data {
+        try JSONSerialization.data(withJSONObject: [
+            "id": id,
+            "created": 1_703_980_800,
+            "size_in_bytes": 1024
+        ])
+    }
 }

--- a/swama/Tests/SwamaRuntimeTests/ModelManagerTests.swift
+++ b/swama/Tests/SwamaRuntimeTests/ModelManagerTests.swift
@@ -1,0 +1,73 @@
+import Foundation
+@testable import SwamaRuntime
+import Testing
+
+@MainActor @Suite(.serialized)
+final class ModelManagerTests {
+    @Test func modelInfoInitialization() {
+        // Test ModelInfo initialization with all parameters
+        let modelInfo = ModelInfo(
+            id: "test/model",
+            created: 1_703_980_800, // 2023-12-31
+            sizeInBytes: 1024 * 1024 * 1024, // 1GB
+            source: .metaFile,
+            rawMetadata: ["version": "1.0", "type": "llm"]
+        )
+
+        #expect(modelInfo.id == "test/model")
+        #expect(modelInfo.created == 1_703_980_800)
+        #expect(modelInfo.sizeInBytes == (1024 * 1024 * 1024))
+        #expect(modelInfo.source == .metaFile)
+        #expect(modelInfo.rawMetadata != nil)
+        #expect(modelInfo.rawMetadata?["version"] as? String == "1.0")
+    }
+
+    @Test func modelInfoInitializationWithoutMetadata() {
+        // Test ModelInfo initialization without metadata
+        let modelInfo = ModelInfo(
+            id: "test/model2",
+            created: 1_703_980_800,
+            sizeInBytes: 512 * 1024 * 1024, // 512MB
+            source: .directoryScan
+        )
+
+        #expect(modelInfo.id == "test/model2")
+        #expect(modelInfo.created == 1_703_980_800)
+        #expect(modelInfo.sizeInBytes == (512 * 1024 * 1024))
+        #expect(modelInfo.source == .directoryScan)
+        #expect(modelInfo.rawMetadata == nil)
+    }
+
+    @Test func modelInfoWithRawMetadata() {
+        // Test ModelInfo with rawMetadata
+        let testMetadata: [String: Any] = ["hidden_size": 768, "vocab_size": 50000, "model_type": "BPE"]
+
+        let modelInfo = ModelInfo(
+            id: "test/model-with-metadata",
+            created: 1_703_980_800,
+            sizeInBytes: 1024 * 1024 * 1024, // 1GB
+            source: .metaFile,
+            rawMetadata: testMetadata
+        )
+
+        #expect(modelInfo.id == "test/model-with-metadata")
+        #expect(modelInfo.rawMetadata != nil)
+        #expect(modelInfo.rawMetadata?["hidden_size"] as? Int == 768)
+        #expect(modelInfo.rawMetadata?["model_type"] as? String == "BPE")
+    }
+
+    @Test func metadataSourceEquality() {
+        // Test MetadataSource enum equality
+        #expect(MetadataSource.metaFile == MetadataSource.metaFile)
+        #expect(MetadataSource.directoryScan == MetadataSource.directoryScan)
+        #expect(MetadataSource.metaFile != MetadataSource.directoryScan)
+    }
+
+    @Test func modelsListReturnsArray() {
+        // Test that models() returns an array (even if empty)
+        let models = ModelManager.models()
+        #expect(models.count >= 0) // Should always return a valid array, even if empty
+        // Note: We can't test the actual content since it depends on the file system
+        // In a real test environment, you might want to mock the file system
+    }
+}

--- a/swama/Tests/SwamaRuntimeTests/ModelPoolCancellationTests.swift
+++ b/swama/Tests/SwamaRuntimeTests/ModelPoolCancellationTests.swift
@@ -1,0 +1,84 @@
+//
+//  ModelPoolCancellationTests.swift
+//  SwamaRuntimeTests
+//
+//  Focused test file (rather than an extension of `CompletionsHandlerTests`) because these
+//  tests exercise `ModelPool` directly rather than anything HTTP/`CompletionsHandler`-shaped,
+//  and don't need `CompletionsHandlerTests`'s `@MainActor @Suite(.serialized)` shape.
+//
+
+import Foundation
+@testable import SwamaRuntime
+import Testing
+
+// MARK: - ModelPoolCancellationTests
+
+/// Regression coverage for the queued-cancellation hole in `ModelPool.run`: the wait loop used
+/// to discard `CancellationError` via `try?`, and nothing checked cancellation before a slot
+/// was reserved and `getContainer` was called. A caller whose `Task` was already cancelled
+/// therefore still reserved a slot and reached `getContainer`, surfacing
+/// `ModelPoolError.modelNotFoundLocally` for a missing model instead of `CancellationError`.
+/// The fix adds `try Task.checkCancellation()` immediately after the wait loop and before slot
+/// reservation.
+///
+/// Both tests below use a model name guaranteed not to exist locally, so `getContainer` always
+/// reaches the cheap, MLX-free `ModelPoolError.modelNotFoundLocally` path rather than
+/// attempting a real model load -- `ModelPool` has no locally-cached model to work with in this
+/// test environment. `ModelPool()` construction itself no longer touches MLX either: the cache
+/// limit configuration that used to run eagerly in `init()` (and abort `swift test`, which has
+/// no `mlx.metallib` colocated with the test binary) is now deferred until a model is actually
+/// about to load, so it's never reached by either test below.
+@Suite("ModelPool queued-cancellation hole")
+struct ModelPoolCancellationTests {
+    /// Test A (the regression test): a caller whose `Task` is already cancelled calls
+    /// `pool.run(modelName:)` for a nonexistent model and must get `CancellationError` --
+    /// proving `Task.checkCancellation()` runs before slot reservation. Under the old code
+    /// this returned `ModelPoolError.modelNotFoundLocally` instead, because cancellation was
+    /// never checked.
+    @Test func runThrowsCancellationErrorForAlreadyCancelledCaller() async throws {
+        let pool = ModelPool()
+        let modelName = "swama-test-definitely-nonexistent-model-\(UUID().uuidString)"
+
+        let task = Task<Result<String, Error>, Never> {
+            do {
+                let value = try await pool.run(modelName: modelName) { _ in "unused" }
+                return .success(value)
+            }
+            catch {
+                return .failure(error)
+            }
+        }
+        task.cancel()
+
+        switch await task.value {
+        case .success:
+            Issue.record("expected run(modelName:) to fail for a cancelled caller, not succeed")
+
+        case let .failure(error):
+            #expect(error is CancellationError, "expected CancellationError, got \(error)")
+        }
+    }
+
+    /// Test B (control): a caller whose `Task` is *not* cancelled, calling `run(modelName:)`
+    /// with the same kind of nonexistent model name, must still get
+    /// `ModelPoolError.modelNotFoundLocally` -- proving the new cancellation gate doesn't
+    /// break the normal (non-cancelled) path.
+    @Test func runThrowsModelNotFoundForNonCancelledCallerWithMissingModel() async throws {
+        let pool = ModelPool()
+        let modelName = "swama-test-definitely-nonexistent-model-\(UUID().uuidString)"
+
+        do {
+            _ = try await pool.run(modelName: modelName) { _ in "unused" }
+            Issue.record("expected run(modelName:) to fail for a nonexistent model, not succeed")
+        }
+        catch let error as ModelPoolError {
+            guard case .modelNotFoundLocally = error else {
+                Issue.record("expected .modelNotFoundLocally, got \(error)")
+                return
+            }
+        }
+        catch {
+            Issue.record("expected ModelPoolError.modelNotFoundLocally, got \(error)")
+        }
+    }
+}

--- a/swama/Tests/SwamaRuntimeTests/ModelPoolInFlightTeardownTests.swift
+++ b/swama/Tests/SwamaRuntimeTests/ModelPoolInFlightTeardownTests.swift
@@ -1,0 +1,746 @@
+import Foundation
+import MLX
+import MLXEmbedders
+@preconcurrency import MLXLMCommon
+import MLXNN
+@testable import SwamaRuntime
+import Testing
+
+// MARK: - ModelPoolInFlightTeardownTests
+
+@Suite("ModelPool in-flight load teardown", .serialized)
+struct ModelPoolInFlightTeardownTests {
+    @Test
+    func concurrentEmbeddingWaitersShareOneLoadAndBothSucceed() async throws {
+        let modelName = "coalesced-embedding-waiters"
+        let loader = ControlledLoader(
+            first: makeLifetimeEmbeddingRunner(),
+            next: makeLifetimeEmbeddingRunner()
+        )
+        let witness = CleanupWitness(nil)
+        let pool = makePool(witness: witness, embeddingLoader: loader)
+
+        let firstRequest = Task<Result<String, Error>, Never> {
+            do {
+                return try await .success(pool.runEmbeddingWithConcurrencyControl(modelName: modelName) { _ in
+                    "first"
+                })
+            }
+            catch {
+                return .failure(error)
+            }
+        }
+        await loader.waitUntilFirstLoadEntered()
+
+        let secondRequest = Task<Result<String, Error>, Never> {
+            do {
+                return try await .success(pool.runEmbeddingWithConcurrencyControl(modelName: modelName) { _ in
+                    "second"
+                })
+            }
+            catch {
+                return .failure(error)
+            }
+        }
+        await waitUntilRunningInferenceCount(2, pool: pool)
+        #expect(await loader.numberOfLoads == 1)
+
+        await loader.releaseFirstLoad()
+        for (result, expected) in await [(firstRequest.value, "first"), (secondRequest.value, "second")] {
+            switch result {
+            case let .success(value):
+                #expect(value == expected)
+            case let .failure(error):
+                Issue.record("coalesced embedding waiter unexpectedly failed: \(error)")
+            }
+        }
+        #expect(await pool.isCachedForTesting(.embedding, modelName: modelName))
+        #expect(witness.cleanupReleaseStates.isEmpty)
+    }
+
+    @Test
+    func currentLoadedEmbeddingDiscardedBehindExistingCacheCleansUpAfterRelease() async throws {
+        let modelName = "embedding-cache-won-before-load"
+        var loaded: EmbeddingRunner? = makeLifetimeEmbeddingRunner()
+        let loader = try ControlledLoader(
+            first: #require(loaded),
+            next: makeLifetimeEmbeddingRunner()
+        )
+        let witness = CleanupWitness(loaded)
+        loaded = nil
+        let pool = makePool(witness: witness, embeddingLoader: loader)
+        let cached = makeLifetimeEmbeddingRunner()
+
+        let request = Task<Result<Bool, Error>, Never> {
+            do {
+                return try await .success(pool.runEmbeddingWithConcurrencyControl(modelName: modelName) { runner in
+                    runner === cached
+                })
+            }
+            catch {
+                return .failure(error)
+            }
+        }
+
+        await loader.waitUntilFirstLoadEntered()
+        await pool.setEmbeddingRunner(cached, for: modelName)
+        await loader.releaseFirstLoad()
+
+        switch await request.value {
+        case let .success(receivedExistingRunner):
+            #expect(receivedExistingRunner)
+        case let .failure(error):
+            Issue.record("current load should use the existing cache value: \(error)")
+        }
+        #expect(witness.cleanupReleaseStates == [true])
+        #expect(await pool.isCachedForTesting(.embedding, modelName: modelName))
+    }
+
+    @Test
+    func newerEmbeddingLoadSurvivesOlderGenerationFinishingLate() async throws {
+        let modelName = "overlapping-embedding-generations"
+        var first: EmbeddingRunner? = makeLifetimeEmbeddingRunner()
+        let loader = try ControlledLoader(
+            first: #require(first),
+            next: makeLifetimeEmbeddingRunner(),
+            blockSecond: true
+        )
+        let witness = CleanupWitness(first)
+        first = nil
+        let pool = makePool(witness: witness, embeddingLoader: loader)
+
+        let staleRequest = Task<Result<String, Error>, Never> {
+            do {
+                return try await .success(pool.runEmbeddingWithConcurrencyControl(modelName: modelName) { _ in
+                    "stale"
+                })
+            }
+            catch {
+                return .failure(error)
+            }
+        }
+        await loader.waitUntilFirstLoadEntered()
+        await pool.clearCache()
+
+        let freshRequest = Task<Result<String, Error>, Never> {
+            do {
+                return try await .success(pool.runEmbeddingWithConcurrencyControl(modelName: modelName) { _ in
+                    "fresh"
+                })
+            }
+            catch {
+                return .failure(error)
+            }
+        }
+        await loader.waitUntilSecondLoadEntered()
+
+        await loader.releaseFirstLoad()
+        switch await staleRequest.value {
+        case .success:
+            Issue.record("the older embedding generation unexpectedly reached its operation")
+        case let .failure(error):
+            #expect(error is CancellationError)
+        }
+        #expect(await pool.hasPendingLoadForTesting(.embedding, modelName: modelName))
+
+        await loader.releaseSecondLoad()
+        switch await freshRequest.value {
+        case let .success(value):
+            #expect(value == "fresh")
+        case let .failure(error):
+            Issue.record("newer embedding generation unexpectedly failed: \(error)")
+        }
+        #expect(await pool.isCachedForTesting(.embedding, modelName: modelName))
+        #expect(await !(pool.hasPendingLoadForTesting(.embedding, modelName: modelName)))
+        #expect(witness.cleanupReleaseStates == [false, true])
+    }
+
+    @Test
+    func pendingLoadWithSameNameDoesNotLetEvictionInterruptALiveOperation() async throws {
+        let modelName = "shared-modality-key"
+        let languageLoader = ControlledLoader(
+            first: makeLifetimeTestContainer(),
+            next: makeLifetimeTestContainer()
+        )
+        await languageLoader.releaseFirstLoad()
+        let embeddingLoader = ControlledLoader(
+            first: makeLifetimeEmbeddingRunner(),
+            next: makeLifetimeEmbeddingRunner()
+        )
+        let witness = CleanupWitness(nil)
+        let pool = makePool(
+            witness: witness,
+            languageLoader: languageLoader,
+            embeddingLoader: embeddingLoader
+        )
+        let operationBarrier = OperationBarrier()
+
+        let languageRequest = Task<Result<String, Error>, Never> {
+            do {
+                return try await .success(pool.run(modelName: modelName) { _ in
+                    await operationBarrier.enterAndWait()
+                    return "language"
+                })
+            }
+            catch {
+                return .failure(error)
+            }
+        }
+        await operationBarrier.waitUntilEntered()
+
+        let embeddingRequest = Task<Result<String, Error>, Never> {
+            do {
+                return try await .success(pool.runEmbeddingWithConcurrencyControl(modelName: modelName) { _ in
+                    "embedding"
+                })
+            }
+            catch {
+                return .failure(error)
+            }
+        }
+        await embeddingLoader.waitUntilFirstLoadEntered()
+
+        await pool.evictModelForTesting(modelName: modelName)
+        #expect(await pool.isCachedForTesting(.language, modelName: modelName))
+        #expect(await pool.hasPendingLoadForTesting(.embedding, modelName: modelName))
+        #expect(witness.cleanupReleaseStates.isEmpty)
+
+        await embeddingLoader.releaseFirstLoad()
+        switch await embeddingRequest.value {
+        case let .success(value):
+            #expect(value == "embedding")
+        case let .failure(error):
+            Issue.record("pending embedding load unexpectedly failed: \(error)")
+        }
+
+        await operationBarrier.release()
+        switch await languageRequest.value {
+        case let .success(value):
+            #expect(value == "language")
+        case let .failure(error):
+            Issue.record("active language operation unexpectedly failed: \(error)")
+        }
+    }
+
+    @Test
+    func periodicEvictionStillSkipsALiveInferenceOperation() async throws {
+        let modelName = "active-language-operation"
+        let loader = ControlledLoader(
+            first: makeLifetimeTestContainer(),
+            next: makeLifetimeTestContainer()
+        )
+        await loader.releaseFirstLoad()
+        let witness = CleanupWitness(nil)
+        let pool = makePool(witness: witness, languageLoader: loader)
+        let operationBarrier = OperationBarrier()
+
+        let request = Task<Result<String, Error>, Never> {
+            do {
+                return try await .success(pool.run(modelName: modelName) { _ in
+                    await operationBarrier.enterAndWait()
+                    return "finished"
+                })
+            }
+            catch {
+                return .failure(error)
+            }
+        }
+
+        await operationBarrier.waitUntilEntered()
+        #expect(await pool.isCachedForTesting(.language, modelName: modelName))
+        await pool.evictModelForTesting(modelName: modelName)
+        #expect(await pool.isCachedForTesting(.language, modelName: modelName))
+        #expect(witness.cleanupReleaseStates.isEmpty)
+
+        await operationBarrier.release()
+        switch await request.value {
+        case let .success(value):
+            #expect(value == "finished")
+        case let .failure(error):
+            Issue.record("active operation unexpectedly failed: \(error)")
+        }
+    }
+
+    @Test
+    func cancelledLoadFailureStillRunsCleanupAfterItsPartialOwnerReleases() async throws {
+        let modelName = "in-flight-failing-language"
+        var partialOwner: PartialLoadOwner? = PartialLoadOwner()
+        let loader = try FailingControlledLoader(partialOwner: #require(partialOwner))
+        let witness = CleanupWitness(partialOwner)
+        partialOwner = nil
+        let pool = ModelPool(
+            memoryHooks: .init(
+                activeMemory: { 0 },
+                clearCache: { witness.recordCleanup() }
+            ),
+            loadOverrides: .init(
+                modelExistsLocally: { _ in true },
+                determineIsVLM: { _ in false },
+                loadLanguage: { _, _ in try await loader.load() },
+                loadEmbedding: { _ in fatalError("unexpected embedding load") }
+            )
+        )
+
+        let request = Task<Result<String, Error>, Never> {
+            do {
+                return try await .success(pool.run(modelName: modelName) { _ in "unexpected" })
+            }
+            catch {
+                return .failure(error)
+            }
+        }
+
+        await loader.waitUntilEntered()
+        await pool.clearCache()
+        #expect(await loader.isBlocked)
+        await loader.releaseAndFail()
+
+        switch await request.value {
+        case .success:
+            Issue.record("an invalidated failed load must not reach its operation")
+        case let .failure(error):
+            #expect(error is CancellationError)
+        }
+        #expect(witness.cleanupReleaseStates == [false, true])
+    }
+
+    @Test(arguments: TeardownPath.allCases)
+    func languageLoadCannotResurrectAfterTeardown(_ path: TeardownPath) async throws {
+        let modelName = "in-flight-language-\(path)"
+        var first: MLXLMCommon.ModelContainer? = makeLifetimeTestContainer()
+        let loader = try ControlledLoader(
+            first: #require(first),
+            next: makeLifetimeTestContainer()
+        )
+        let witness = CleanupWitness(first)
+        first = nil
+        let pool = makePool(witness: witness, languageLoader: loader)
+        let operationCount = LockedCounter()
+
+        let request = Task<Result<String, Error>, Never> {
+            do {
+                return try await .success(pool.run(modelName: modelName) { _ in
+                    operationCount.increment()
+                    return "stale"
+                })
+            }
+            catch {
+                return .failure(error)
+            }
+        }
+
+        await loader.waitUntilFirstLoadEntered()
+        #expect(await pool.hasPendingLoadForTesting(.language, modelName: modelName))
+        #expect(await pool.hasMatchingLoadingOperationForTesting(modelName: modelName))
+        await apply(path, to: pool, modelName: modelName)
+        #expect(await loader.isFirstLoadBlocked)
+        await loader.releaseFirstLoad()
+
+        await assertStaleLoadWasDiscarded(
+            request,
+            pool: pool,
+            kind: .language,
+            modelName: modelName,
+            operationCount: operationCount,
+            witness: witness
+        )
+
+        let fresh = try await pool.run(modelName: modelName) { _ in "fresh" }
+        #expect(fresh == "fresh")
+        #expect(await pool.isCachedForTesting(.language, modelName: modelName))
+    }
+
+    @Test(arguments: TeardownPath.allCases)
+    func embeddingLoadCannotResurrectAfterTeardown(_ path: TeardownPath) async throws {
+        let modelName = "in-flight-embedding-\(path)"
+        var first: EmbeddingRunner? = makeLifetimeEmbeddingRunner()
+        let loader = try ControlledLoader(
+            first: #require(first),
+            next: makeLifetimeEmbeddingRunner()
+        )
+        let witness = CleanupWitness(first)
+        first = nil
+        let pool = makePool(witness: witness, embeddingLoader: loader)
+        let operationCount = LockedCounter()
+
+        let request = Task<Result<String, Error>, Never> {
+            do {
+                return try await .success(pool.runEmbeddingWithConcurrencyControl(modelName: modelName) { _ in
+                    operationCount.increment()
+                    return "stale"
+                })
+            }
+            catch {
+                return .failure(error)
+            }
+        }
+
+        await loader.waitUntilFirstLoadEntered()
+        #expect(await pool.hasPendingLoadForTesting(.embedding, modelName: modelName))
+        #expect(await !(pool.hasMatchingLoadingOperationForTesting(modelName: modelName)))
+        await apply(path, to: pool, modelName: modelName)
+        #expect(await loader.isFirstLoadBlocked)
+        await loader.releaseFirstLoad()
+
+        await assertStaleLoadWasDiscarded(
+            request,
+            pool: pool,
+            kind: .embedding,
+            modelName: modelName,
+            operationCount: operationCount,
+            witness: witness
+        )
+
+        let fresh = try await pool.runEmbeddingWithConcurrencyControl(modelName: modelName) { _ in "fresh" }
+        #expect(fresh == "fresh")
+        #expect(await pool.isCachedForTesting(.embedding, modelName: modelName))
+    }
+
+    private func makePool(
+        witness: CleanupWitness,
+        languageLoader: ControlledLoader<MLXLMCommon.ModelContainer>? = nil,
+        embeddingLoader: ControlledLoader<EmbeddingRunner>? = nil
+    ) -> ModelPool {
+        ModelPool(
+            memoryHooks: .init(
+                activeMemory: { 0 },
+                clearCache: { witness.recordCleanup() }
+            ),
+            loadOverrides: .init(
+                modelExistsLocally: { _ in true },
+                determineIsVLM: { _ in false },
+                loadLanguage: { _, _ in
+                    guard let languageLoader else {
+                        fatalError("unexpected language load")
+                    }
+
+                    return await languageLoader.load()
+                },
+                loadEmbedding: { _ in
+                    guard let embeddingLoader else {
+                        fatalError("unexpected embedding load")
+                    }
+
+                    return await embeddingLoader.load()
+                }
+            )
+        )
+    }
+
+    private func apply(_ path: TeardownPath, to pool: ModelPool, modelName: String) async {
+        switch path {
+        case .clear:
+            await pool.clearCache()
+        case .remove:
+            await pool.remove(modelName: modelName)
+        case .periodicEviction:
+            await pool.evictModelForTesting(modelName: modelName)
+        }
+    }
+
+    private func assertStaleLoadWasDiscarded(
+        _ request: Task<Result<String, Error>, Never>,
+        pool: ModelPool,
+        kind: ModelPoolModelKind,
+        modelName: String,
+        operationCount: LockedCounter,
+        witness: CleanupWitness
+    ) async {
+        switch await request.value {
+        case .success:
+            Issue.record("a load invalidated by teardown must not reach its operation")
+        case let .failure(error):
+            #expect(error is CancellationError, "expected CancellationError, got \(error)")
+        }
+
+        #expect(operationCount.value == 0)
+        #expect(await !(pool.isCachedForTesting(kind, modelName: modelName)))
+        #expect(await !(pool.hasPendingLoadForTesting(kind, modelName: modelName)))
+        #expect(witness.cleanupReleaseStates == [false, true])
+    }
+
+    private func waitUntilRunningInferenceCount(_ expected: Int, pool: ModelPool) async {
+        for _ in 0 ..< 1000 {
+            if await pool.runningInferenceCountForTesting() == expected {
+                return
+            }
+            await Task.yield()
+        }
+        Issue.record("timed out waiting for \(expected) running inference slots")
+    }
+}
+
+// MARK: - TeardownPath
+
+enum TeardownPath: String, CaseIterable, CustomStringConvertible, Sendable {
+    case clear
+    case remove
+    case periodicEviction
+
+    var description: String { rawValue }
+}
+
+// MARK: - ControlledLoader
+
+private actor ControlledLoader<Value: AnyObject & Sendable> {
+    init(first: Value, next: Value, blockSecond: Bool = false) {
+        values = [first, next]
+        self.blockSecond = blockSecond
+    }
+
+    func load() async -> Value {
+        loadCount += 1
+        precondition(!values.isEmpty, "test loader exhausted")
+        let value = values.removeFirst()
+        if loadCount == 1 {
+            firstLoadEntered = true
+            enteredWaiters.forEach { $0.resume() }
+            enteredWaiters.removeAll()
+
+            if !firstLoadReleased {
+                await withCheckedContinuation { continuation in
+                    releaseWaiter = continuation
+                }
+            }
+        }
+        else if loadCount == 2, blockSecond {
+            secondLoadEntered = true
+            secondEnteredWaiters.forEach { $0.resume() }
+            secondEnteredWaiters.removeAll()
+
+            if !secondLoadReleased {
+                await withCheckedContinuation { continuation in
+                    secondReleaseWaiter = continuation
+                }
+            }
+        }
+
+        return value
+    }
+
+    func waitUntilFirstLoadEntered() async {
+        guard !firstLoadEntered else {
+            return
+        }
+
+        await withCheckedContinuation { continuation in
+            enteredWaiters.append(continuation)
+        }
+    }
+
+    func releaseFirstLoad() {
+        firstLoadReleased = true
+        releaseWaiter?.resume()
+        releaseWaiter = nil
+    }
+
+    func waitUntilSecondLoadEntered() async {
+        guard !secondLoadEntered else {
+            return
+        }
+
+        await withCheckedContinuation { continuation in
+            secondEnteredWaiters.append(continuation)
+        }
+    }
+
+    func releaseSecondLoad() {
+        secondLoadReleased = true
+        secondReleaseWaiter?.resume()
+        secondReleaseWaiter = nil
+    }
+
+    var isFirstLoadBlocked: Bool {
+        firstLoadEntered && !firstLoadReleased
+    }
+
+    var numberOfLoads: Int { loadCount }
+
+    private var values: [Value]
+    private let blockSecond: Bool
+    private var loadCount = 0
+    private var firstLoadEntered = false
+    private var firstLoadReleased = false
+    private var enteredWaiters: [CheckedContinuation<Void, Never>] = []
+    private var releaseWaiter: CheckedContinuation<Void, Never>?
+    private var secondLoadEntered = false
+    private var secondLoadReleased = false
+    private var secondEnteredWaiters: [CheckedContinuation<Void, Never>] = []
+    private var secondReleaseWaiter: CheckedContinuation<Void, Never>?
+}
+
+// MARK: - FailingControlledLoader
+
+private actor FailingControlledLoader {
+    init(partialOwner: PartialLoadOwner) {
+        self.partialOwner = partialOwner
+    }
+
+    func load() async throws -> MLXLMCommon.ModelContainer {
+        entered = true
+        enteredWaiters.forEach { $0.resume() }
+        enteredWaiters.removeAll()
+
+        if !released {
+            await withCheckedContinuation { continuation in
+                releaseWaiter = continuation
+            }
+        }
+
+        partialOwner = nil
+        throw SyntheticLoadError()
+    }
+
+    func waitUntilEntered() async {
+        guard !entered else {
+            return
+        }
+
+        await withCheckedContinuation { continuation in
+            enteredWaiters.append(continuation)
+        }
+    }
+
+    func releaseAndFail() {
+        released = true
+        releaseWaiter?.resume()
+        releaseWaiter = nil
+    }
+
+    var isBlocked: Bool { entered && !released }
+
+    private var partialOwner: PartialLoadOwner?
+    private var entered = false
+    private var released = false
+    private var enteredWaiters: [CheckedContinuation<Void, Never>] = []
+    private var releaseWaiter: CheckedContinuation<Void, Never>?
+}
+
+// MARK: - OperationBarrier
+
+private actor OperationBarrier {
+    func enterAndWait() async {
+        entered = true
+        enteredWaiters.forEach { $0.resume() }
+        enteredWaiters.removeAll()
+        guard !released else {
+            return
+        }
+
+        await withCheckedContinuation { continuation in
+            releaseWaiter = continuation
+        }
+    }
+
+    func waitUntilEntered() async {
+        guard !entered else {
+            return
+        }
+
+        await withCheckedContinuation { continuation in
+            enteredWaiters.append(continuation)
+        }
+    }
+
+    func release() {
+        released = true
+        releaseWaiter?.resume()
+        releaseWaiter = nil
+    }
+
+    private var entered = false
+    private var released = false
+    private var enteredWaiters: [CheckedContinuation<Void, Never>] = []
+    private var releaseWaiter: CheckedContinuation<Void, Never>?
+}
+
+// MARK: - SyntheticLoadError
+
+private struct SyntheticLoadError: Error {}
+
+// MARK: - PartialLoadOwner
+
+private final class PartialLoadOwner: @unchecked Sendable {}
+
+// MARK: - CleanupWitness
+
+private final class CleanupWitness: @unchecked Sendable {
+    init(_ object: AnyObject?) {
+        trackedObject = object
+    }
+
+    func recordCleanup() {
+        lock.withLock {
+            cleanupStates.append(trackedObject == nil)
+        }
+    }
+
+    var cleanupReleaseStates: [Bool] {
+        lock.withLock { cleanupStates }
+    }
+
+    private let lock: NSLock = .init()
+    private weak var trackedObject: AnyObject?
+    private var cleanupStates: [Bool] = []
+}
+
+// MARK: - LockedCounter
+
+private final class LockedCounter: @unchecked Sendable {
+    func increment() {
+        lock.withLock { count += 1 }
+    }
+
+    var value: Int {
+        lock.withLock { count }
+    }
+
+    private let lock: NSLock = .init()
+    private var count = 0
+}
+
+// MARK: - Minimal embedding value
+
+private func makeLifetimeEmbeddingRunner() -> EmbeddingRunner {
+    let context = EmbedderModelContext(
+        configuration: .init(id: "in-flight-embedding-test"),
+        model: LifetimeEmbeddingModel(),
+        tokenizer: LifetimeTokenizer(),
+        pooling: Pooling(strategy: .none)
+    )
+    return EmbeddingRunner(container: EmbedderModelContainer(context: context))
+}
+
+// MARK: - LifetimeEmbeddingModel
+
+private final class LifetimeEmbeddingModel: Module, EmbeddingModel {
+    let vocabularySize = 8
+    let maxPositionEmbeddings: Int? = nil
+
+    func callAsFunction(
+        _: MLXArray,
+        positionIds _: MLXArray?,
+        tokenTypeIds _: MLXArray?,
+        attentionMask _: MLXArray?
+    ) -> EmbeddingModelOutput {
+        fatalError("lifetime-only model must not run inference")
+    }
+}
+
+// MARK: - LifetimeTokenizer
+
+private struct LifetimeTokenizer: MLXLMCommon.Tokenizer {
+    var bosToken: String? { nil }
+    var eosToken: String? { nil }
+    var unknownToken: String? { nil }
+
+    func encode(text _: String, addSpecialTokens _: Bool) -> [Int] { [] }
+    func decode(tokenIds _: [Int], skipSpecialTokens _: Bool) -> String { "" }
+    func convertTokenToId(_: String) -> Int? { nil }
+    func convertIdToToken(_: Int) -> String? { nil }
+    func applyChatTemplate(
+        messages _: [[String: any Sendable]],
+        tools _: [[String: any Sendable]]?,
+        additionalContext _: [String: any Sendable]?
+    ) throws -> [Int] { [] }
+}

--- a/swama/Tests/SwamaRuntimeTests/ModelTypeDetectorTests.swift
+++ b/swama/Tests/SwamaRuntimeTests/ModelTypeDetectorTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+@testable import SwamaRuntime
+import Testing
+
+@Suite("Model Type Detection")
+struct ModelTypeDetectorTests {
+    @Test func detectVLMByOmniName() {
+        #expect(ModelTypeDetector.isVLMModelName("mlx-community/Qwen3.5-Omni-7B-4bit"))
+    }
+
+    @Test func detectVLMByConfigWithoutVLSuffix() {
+        let config: [String: Any] = [
+            "architectures": ["Qwen3_5ForConditionalGeneration"],
+            "model_type": "qwen3_5",
+            "image_token_id": 248_056,
+            "vision_config": [
+                "hidden_size": 1152
+            ]
+        ]
+
+        #expect(ModelTypeDetector.isVLMModelConfig(config))
+    }
+
+    @Test func doNotDetectTextOnlyConfigAsVLM() {
+        let config: [String: Any] = [
+            "architectures": ["Qwen2ForCausalLM"],
+            "model_type": "qwen2",
+            "hidden_size": 4096
+        ]
+
+        #expect(!ModelTypeDetector.isVLMModelConfig(config))
+    }
+
+    @Test func resolveQwen35Aliases() {
+        #expect(ModelAliasResolver.resolve(name: "qwen3.5") == "mlx-community/Qwen3.5-35B-A3B-4bit")
+        #expect(ModelAliasResolver.resolve(name: "qwen3.5-0.8b") == "mlx-community/Qwen3.5-0.8B-4bit")
+        #expect(ModelAliasResolver.resolve(name: "qwen3.5-2b") == "mlx-community/Qwen3.5-2B-4bit")
+        #expect(ModelAliasResolver.resolve(name: "qwen3.5-4b") == "mlx-community/Qwen3.5-4B-4bit")
+        #expect(ModelAliasResolver.resolve(name: "qwen3.5-9b") == "mlx-community/Qwen3.5-9B-4bit")
+        #expect(ModelAliasResolver.resolve(name: "qwen3.5-27b") == "mlx-community/Qwen3.5-27B-4bit")
+        #expect(ModelAliasResolver.resolve(name: "qwen3.5-35b-a3b") == "mlx-community/Qwen3.5-35B-A3B-4bit")
+        #expect(ModelAliasResolver.resolve(name: "qwen3.5-122b-a10b") == "mlx-community/Qwen3.5-122B-A10B-4bit")
+        #expect(ModelAliasResolver.resolve(name: "qwen3.5-397b-a17b") == "mlx-community/Qwen3.5-397B-A17B-4bit")
+    }
+}

--- a/swama/Tests/SwamaRuntimeTests/PromptCacheTests.swift
+++ b/swama/Tests/SwamaRuntimeTests/PromptCacheTests.swift
@@ -1,0 +1,1364 @@
+//
+//  PromptCacheTests.swift
+//  SwamaRuntimeTests
+//
+//  Coverage for the prompt/KV-cache feature (claude/specs/prompt-cache/). Two complementary
+//  styles are used throughout:
+//
+//  - Whitebox: `resolvePromptCacheReuse` is called directly against a hand-built
+//    `PromptCacheStore` slot, using real `KVCacheSimple`/`RotatingKVCache` instances fed via
+//    their real `update(keys:values:)`. This pins down matched-length and miss-reason
+//    classification precisely and deterministically.
+//  - Blackbox: a small deterministic `LanguageModel` (`WordEchoModel`) is wired into a real
+//    `ModelContainer`/`ModelRunner`, so `TokenIterator`, `LLMModel.prepare`'s chunked prefill,
+//    and the full `runChat` generation path are genuinely exercised end to end, with no model
+//    downloads. The model's logits are a deterministic function of the token history it reads
+//    back from the cache it's handed (via `KVCache.update`'s return value, which always covers
+//    the full history up to the current offset) -- so if the cache/suffix stitching in
+//    `ModelRunner.runChat` is wrong, cached and uncached runs of the same conversation diverge.
+//
+//  Every blackbox test compares a "cached" run (one `ModelRunner`/`PromptCacheStore` reused
+//  across turns) against an "uncached" baseline (a fresh `PromptCacheStore` per turn, so every
+//  turn is a `no_slot` miss) built from the *same* container -- any mismatch means the cache
+//  path computed something different from a full, correct prefill.
+
+import Foundation
+import MLX
+import MLXLLM
+@preconcurrency import MLXLMCommon
+import MLXNN
+@testable import SwamaRuntime
+import Testing
+
+// MARK: - WordVocabTokenizer
+
+/// A tiny, fully deterministic tokenizer. Content tokens are written as "w<N>" words (e.g.
+/// "w3 w1 w7"); `encode` parses them directly to `N % contentVocabSize`, so tests can construct
+/// exact token sequences without going through real BPE. `decode` is the exact inverse (each id
+/// maps back to "w<N> "), so text a model generates can be re-encoded losslessly if fed back in
+/// as a later turn's context -- as a real client resending conversation history would.
+struct WordVocabTokenizer: MLXLMCommon.Tokenizer {
+    static let systemToken = 16
+    static let userToken = 17
+    static let assistantToken = 18
+    static let sepToken = 19
+
+    let contentVocabSize: Int
+
+    var bosToken: String? {
+        nil
+    }
+
+    var eosToken: String? {
+        nil
+    }
+
+    var unknownToken: String? {
+        nil
+    }
+
+    func encode(text: String, addSpecialTokens _: Bool) -> [Int] {
+        text.split(separator: " ").compactMap { piece -> Int? in
+            guard piece.hasPrefix("w"), let value = Int(piece.dropFirst()) else {
+                return nil
+            }
+
+            return ((value % contentVocabSize) + contentVocabSize) % contentVocabSize
+        }
+    }
+
+    func decode(tokenIds: [Int], skipSpecialTokens _: Bool) -> String {
+        tokenIds.map { id in
+            switch id {
+            case 0 ..< contentVocabSize:
+                "w\(id) "
+            case Self.systemToken:
+                "<sys> "
+            case Self.userToken:
+                "<user> "
+            case Self.assistantToken:
+                "<asst> "
+            case Self.sepToken:
+                "<sep> "
+            default:
+                "<unk\(id)> "
+            }
+        }
+        .joined()
+    }
+
+    func convertTokenToId(_ token: String) -> Int? {
+        if token.hasPrefix("w"), let value = Int(token.dropFirst()) {
+            return value
+        }
+        switch token {
+        case "<sys>":
+            return Self.systemToken
+        case "<user>":
+            return Self.userToken
+        case "<asst>":
+            return Self.assistantToken
+        case "<sep>":
+            return Self.sepToken
+        default:
+            return nil
+        }
+    }
+
+    func convertIdToToken(_ id: Int) -> String? {
+        decode(tokenIds: [id], skipSpecialTokens: false).trimmingCharacters(in: .whitespaces)
+    }
+
+    func applyChatTemplate(
+        messages: [[String: any Sendable]],
+        tools _: [[String: any Sendable]]?,
+        additionalContext _: [String: any Sendable]?
+    ) throws -> [Int] {
+        var tokens = [Int]()
+        for message in messages {
+            let role = message["role"] as? String ?? "user"
+            switch role {
+            case "system":
+                tokens.append(Self.systemToken)
+            case "assistant":
+                tokens.append(Self.assistantToken)
+            default:
+                tokens.append(Self.userToken)
+            }
+            if let content = message["content"] as? String {
+                tokens.append(contentsOf: encode(text: content, addSpecialTokens: false))
+            }
+            tokens.append(Self.sepToken)
+        }
+        return tokens
+    }
+}
+
+// MARK: - WordVocabUserInputProcessor
+
+/// Mirrors `LLMModelFactory`'s real (but non-public) `LLMUserInputProcessor`: render the chat
+/// messages with `DefaultMessageGenerator`, then run them through the tokenizer's chat template.
+struct WordVocabUserInputProcessor: UserInputProcessor {
+    let tokenizer: WordVocabTokenizer
+    private let messageGenerator = MLXLMCommon.DefaultMessageGenerator()
+
+    func prepare(input: MLXLMCommon.UserInput) throws -> LMInput {
+        let messages = messageGenerator.generate(from: input)
+        let tokens = try tokenizer.applyChatTemplate(
+            messages: messages, tools: input.tools, additionalContext: input.additionalContext
+        )
+        return LMInput(tokens: MLXArray(tokens))
+    }
+}
+
+// MARK: - WordEchoModel
+
+/// A deterministic `LanguageModel`: its "prediction" for the next token is the content token
+/// `period` positions back in the *full* history, read back from the cache's own
+/// `update(keys:values:)` return value (which always covers everything up to the new offset --
+/// exactly like a real attention cache). This creates a period-`period` repeating pattern that
+/// repetition penalties have real, visible leverage over, making equivalence a meaningful
+/// check rather than a trivial one: the wrong window (e.g. suffix-only instead of full history)
+/// changes which token wins.
+final class WordEchoModel: MLXNN.Module, LLMModel, KVCacheDimensionProvider {
+    let kvHeads: [Int]
+    private let outputVocabSize: Int
+    private let contentVocabSize: Int
+    private let period: Int
+    private let predictedLogit: Float
+    private let alternativeLogit: Float
+
+    var loraLayers: [MLXNN.Module] {
+        []
+    }
+
+    init(
+        numLayers: Int,
+        outputVocabSize: Int,
+        contentVocabSize: Int,
+        period: Int = 2,
+        predictedLogit: Float = 10,
+        alternativeLogit: Float = 8
+    ) {
+        self.kvHeads = Array(repeating: 1, count: numLayers)
+        self.outputVocabSize = outputVocabSize
+        self.contentVocabSize = contentVocabSize
+        self.period = period
+        self.predictedLogit = predictedLogit
+        self.alternativeLogit = alternativeLogit
+        super.init()
+    }
+
+    func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+        let sequenceLength = inputs.dim(1)
+        let keysIn = inputs.asType(.float32).reshaped([1, 1, sequenceLength, 1])
+
+        var history = [Float]()
+        if let cache, cache.isEmpty == false {
+            for (index, layer) in cache.enumerated() {
+                let (k, _) = layer.update(keys: keysIn, values: keysIn)
+                if index == 0 {
+                    history = k.reshaped([-1]).asArray(Float32.self)
+                }
+            }
+        }
+        else {
+            history = keysIn.reshaped([-1]).asArray(Float32.self)
+        }
+
+        let historyTokens = history.map { Int($0.rounded()) }
+        let predicted = Self.predictNextToken(
+            history: historyTokens, period: period, contentVocabSize: contentVocabSize
+        )
+        let alternative = (predicted + 1) % contentVocabSize
+
+        var row = [Float](repeating: 0, count: outputVocabSize)
+        row[predicted] = predictedLogit
+        row[alternative] = max(row[alternative], alternativeLogit)
+
+        let flat = Array(repeating: row, count: sequenceLength).flatMap(\.self)
+        return MLXArray(flat, [1, sequenceLength, outputVocabSize])
+    }
+
+    static func predictNextToken(history: [Int], period: Int, contentVocabSize: Int) -> Int {
+        guard history.count >= period else {
+            return 0
+        }
+
+        let candidate = history[history.count - period]
+        return ((candidate % contentVocabSize) + contentVocabSize) % contentVocabSize
+    }
+}
+
+// MARK: - Test fixtures
+
+/// Space-separated "w<N>" content words, matching `WordVocabTokenizer.encode`.
+private func words(_ ids: [Int]) -> String {
+    ids.map { "w\($0)" }.joined(separator: " ")
+}
+
+/// Builds a fresh, isolated (never-before-used) model container: a unique model name (so
+/// `PromptCacheStore.shared` could never leak between tests even if used), a small deterministic
+/// vocabulary, and `WordEchoModel` as the `LanguageModel`.
+func makeTestContainer(
+    numLayers: Int = 2,
+    contentVocabSize: Int = 16,
+    period: Int = 2
+) -> (container: MLXLMCommon.ModelContainer, tokenizer: WordVocabTokenizer) {
+    let tokenizer = WordVocabTokenizer(contentVocabSize: contentVocabSize)
+    let model = WordEchoModel(
+        numLayers: numLayers,
+        outputVocabSize: contentVocabSize + 4,
+        contentVocabSize: contentVocabSize,
+        period: period
+    )
+    let configuration = MLXLMCommon.ModelConfiguration(id: "prompt-cache-test-\(UUID().uuidString)")
+    let context = MLXLMCommon.ModelContext(
+        configuration: configuration,
+        model: model,
+        processor: WordVocabUserInputProcessor(tokenizer: tokenizer),
+        tokenizer: tokenizer
+    )
+    return (MLXLMCommon.ModelContainer(context: context), tokenizer)
+}
+
+func makeLifetimeTestContainer() -> MLXLMCommon.ModelContainer {
+    makeTestContainer().container
+}
+
+/// Feeds `tokens` through fresh `KVCacheSimple` layers in one `update` call each, as a stand-in
+/// for "a slot stored after some earlier, already-completed turn". Unbounded (no rotation), so
+/// suitable for prefix-matching tests that aren't about rotation.
+private func makeSimpleCacheFedWithTokens(_ tokens: [Int], layerCount: Int) -> [KVCache] {
+    let cache: [KVCache] = (0 ..< layerCount).map { _ in KVCacheSimple() }
+    guard tokens.isEmpty == false else {
+        return cache
+    }
+
+    let keys = MLXArray(tokens.map(Float.init), [1, 1, tokens.count, 1])
+    for layer in cache {
+        _ = layer.update(keys: keys, values: keys)
+    }
+    return cache
+}
+
+/// Feeds `tokens` through fresh `RotatingKVCache` layers **one token at a time**, matching real
+/// autoregressive decode (`updateInPlace`) rather than a bulk multi-token prefill
+/// (`updateConcat`, which has its own, unrelated temporary-growth trimming). With
+/// `tokens.count > maxKVSize` this reliably drives the cache past rotation
+/// (`offset >= maxKVSize`, `isTrimmable == false`).
+private func makeRotatedCache(tokens: [Int], layerCount: Int, maxKVSize: Int, keep: Int = 4) -> [KVCache] {
+    let cache: [KVCache] = (0 ..< layerCount).map { _ in RotatingKVCache(maxSize: maxKVSize, keep: keep) }
+    for token in tokens {
+        let keys = MLXArray([Float(token)], [1, 1, 1, 1])
+        for layer in cache {
+            _ = layer.update(keys: keys, values: keys)
+        }
+    }
+    return cache
+}
+
+/// Runs an uncached baseline: a brand-new `PromptCacheStore` per call means every turn is a
+/// `no_slot` miss, so this is equivalent to the feature not existing, while still sharing the
+/// exact same container/model as whatever cached run it's compared against.
+private func runUncached(
+    container: MLXLMCommon.ModelContainer,
+    messages: [MLXLMCommon.Chat.Message],
+    parameters: GenerateParameters
+) async throws -> ModelRunner.ChatRunResult {
+    let runner = ModelRunner(container: container, promptCacheStore: PromptCacheStore())
+    return try await runner.runChat(
+        userInput: MLXLMCommon.UserInput(chat: messages), parameters: parameters
+    )
+}
+
+// MARK: - PromptCacheReuseClassificationTests
+
+@Suite("Prompt cache: reuse classification")
+struct PromptCacheReuseClassificationTests {
+    @Test func hitOnAppendMatchesEntirePreviousPrompt() {
+        let store = PromptCacheStore()
+        let modelName = "model-append"
+        let previousTokens = [16, 1, 2, 19, 17, 3, 4, 19]
+        let cache = makeSimpleCacheFedWithTokens(previousTokens, layerCount: 2)
+        store.checkin(
+            modelName: modelName,
+            slot: PromptCacheSlot(tokens: previousTokens, cache: cache, kvConfig: PromptCacheKVConfig(maxKVSize: 4096)),
+            epoch: store.currentEpoch(modelName: modelName)
+        )
+
+        let newTokens = previousTokens + [18, 5, 6, 19, 17, 7, 8, 19]
+        let decision = resolvePromptCacheReuse(
+            enabled: true, hasMediaInput: false, modelName: modelName,
+            newTokens: newTokens, kvConfig: PromptCacheKVConfig(maxKVSize: 4096), store: store
+        )
+
+        guard case let .reuse(matchedLength, reusedCache, reason, _) = decision else {
+            Issue.record("expected .reuse, got \(decision)")
+            return
+        }
+
+        #expect(matchedLength == previousTokens.count)
+        #expect(reason == nil)
+        #expect(reusedCache[0].offset == previousTokens.count)
+        #expect(store.checkout(modelName: modelName) == nil, "slot must be consumed by checkout")
+    }
+
+    @Test func partialMismatchOnMidHistoryEditStillReusesTheSharedPrefix() {
+        let store = PromptCacheStore()
+        let modelName = "model-edit"
+        let priorTokens = [16, 1, 19, 17, 2, 19, 18, 3, 19]
+        let cache = makeSimpleCacheFedWithTokens(priorTokens, layerCount: 2)
+        store.checkin(
+            modelName: modelName,
+            slot: PromptCacheSlot(tokens: priorTokens, cache: cache, kvConfig: PromptCacheKVConfig(maxKVSize: 4096)),
+            epoch: store.currentEpoch(modelName: modelName)
+        )
+
+        var editedTokens = priorTokens
+        editedTokens[4] = 99 // edit deep inside the already-cached "user" content
+        editedTokens.append(contentsOf: [17, 5, 19])
+
+        let decision = resolvePromptCacheReuse(
+            enabled: true, hasMediaInput: false, modelName: modelName,
+            newTokens: editedTokens, kvConfig: PromptCacheKVConfig(maxKVSize: 4096), store: store
+        )
+
+        guard case let .reuse(matchedLength, _, reason, _) = decision else {
+            Issue.record("expected .reuse (partial), got \(decision)")
+            return
+        }
+
+        #expect(matchedLength == 4)
+        #expect(reason == .partialMismatch)
+    }
+
+    @Test func mismatchAtZeroWhenNothingInCommon() {
+        let store = PromptCacheStore()
+        let modelName = "model-system-change"
+        let priorTokens = [16, 1, 19, 17, 2, 19]
+        let cache = makeSimpleCacheFedWithTokens(priorTokens, layerCount: 2)
+        store.checkin(
+            modelName: modelName,
+            slot: PromptCacheSlot(tokens: priorTokens, cache: cache, kvConfig: PromptCacheKVConfig(maxKVSize: 4096)),
+            epoch: store.currentEpoch(modelName: modelName)
+        )
+
+        // No system message this time: the sequence starts with the user-role token instead of
+        // the system-role token, so position 0 itself differs.
+        let newTokens = [17, 5, 19]
+        let decision = resolvePromptCacheReuse(
+            enabled: true, hasMediaInput: false, modelName: modelName,
+            newTokens: newTokens, kvConfig: PromptCacheKVConfig(maxKVSize: 4096), store: store
+        )
+
+        guard case let .miss(reason, _) = decision else {
+            Issue.record("expected .miss, got \(decision)")
+            return
+        }
+
+        #expect(reason == .mismatchAtZero)
+    }
+
+    @Test func fullPrefixMatchCapsAtNMinusOneForTheIterator() {
+        let store = PromptCacheStore()
+        let modelName = "model-resend"
+        let previousTokens = [16, 1, 19, 17, 2, 3, 19]
+        let cache = makeSimpleCacheFedWithTokens(previousTokens, layerCount: 2)
+        store.checkin(
+            modelName: modelName,
+            slot: PromptCacheSlot(tokens: previousTokens, cache: cache, kvConfig: PromptCacheKVConfig(maxKVSize: 4096)),
+            epoch: store.currentEpoch(modelName: modelName)
+        )
+
+        // The exact same prompt, resent verbatim.
+        let decision = resolvePromptCacheReuse(
+            enabled: true, hasMediaInput: false, modelName: modelName,
+            newTokens: previousTokens, kvConfig: PromptCacheKVConfig(maxKVSize: 4096), store: store
+        )
+
+        guard case let .reuse(matchedLength, reusedCache, reason, _) = decision else {
+            Issue.record("expected .reuse, got \(decision)")
+            return
+        }
+
+        #expect(matchedLength == previousTokens.count - 1)
+        #expect(reason == nil)
+        #expect(reusedCache[0].offset == previousTokens.count - 1)
+    }
+
+    @Test func rotatedCacheRefusesReuseRegardlessOfMatchingPrefix() {
+        let store = PromptCacheStore()
+        let modelName = "model-rotated"
+        let maxKVSize = 6
+        let priorTokens = Array(1 ... 10) // fed one at a time, exceeds maxKVSize -> rotates
+        let cache = makeRotatedCache(tokens: priorTokens, layerCount: 2, maxKVSize: maxKVSize)
+        #expect(promptCacheIsReusable(cache) == false, "setup sanity: cache should have rotated")
+
+        store.checkin(
+            modelName: modelName,
+            slot: PromptCacheSlot(
+                tokens: priorTokens,
+                cache: cache,
+                kvConfig: PromptCacheKVConfig(maxKVSize: maxKVSize)
+            ),
+            epoch: store.currentEpoch(modelName: modelName)
+        )
+
+        let newTokens = priorTokens + [11, 12] // would share a full prefix if reuse were attempted
+        let decision = resolvePromptCacheReuse(
+            enabled: true, hasMediaInput: false, modelName: modelName,
+            newTokens: newTokens, kvConfig: PromptCacheKVConfig(maxKVSize: maxKVSize), store: store
+        )
+
+        guard case let .miss(reason, _) = decision else {
+            Issue.record("expected .miss, got \(decision)")
+            return
+        }
+
+        #expect(reason == .rotated)
+        #expect(store.checkout(modelName: modelName) == nil, "rotated slot must be dropped, not reused")
+    }
+
+    @Test func kvConfigChangeIsAMiss() {
+        let store = PromptCacheStore()
+        let modelName = "model-kv-change"
+        let priorTokens = [16, 1, 19, 17, 2, 19]
+        let cache = makeSimpleCacheFedWithTokens(priorTokens, layerCount: 1)
+        store.checkin(
+            modelName: modelName,
+            slot: PromptCacheSlot(tokens: priorTokens, cache: cache, kvConfig: PromptCacheKVConfig(maxKVSize: 2048)),
+            epoch: store.currentEpoch(modelName: modelName)
+        )
+
+        let decision = resolvePromptCacheReuse(
+            enabled: true, hasMediaInput: false, modelName: modelName,
+            newTokens: priorTokens + [18, 3, 19], kvConfig: PromptCacheKVConfig(maxKVSize: 4096), store: store
+        )
+
+        guard case let .miss(reason, _) = decision else {
+            Issue.record("expected .miss, got \(decision)")
+            return
+        }
+
+        #expect(reason == .kvConfigChanged)
+    }
+
+    // MARK: KV-config fingerprint (kvBits / kvGroupSize / quantizedKVStart)
+
+    /// Unlike their siblings above, the tests in this section build slots from a bare, never-fed
+    /// `KVCacheSimple()` instead of `makeSimpleCacheFedWithTokens`. `resolvePromptCacheReuse`'s
+    /// `PromptCacheKVConfig` comparison runs *before* anything touches `KVCache.update(keys:
+    /// values:)` (the real MLX tensor op that needs a Metal runtime this environment lacks -- see
+    /// the harness's hazard note), so a never-fed cache classifies identically for these purposes
+    /// while keeping these specific tests runnable without one.
+    @Test func kvBitsChangeIsAMiss() {
+        let store = PromptCacheStore()
+        let modelName = "model-kvbits-change"
+        let priorTokens = [16, 1, 19, 17, 2, 19]
+        store.checkin(
+            modelName: modelName,
+            slot: PromptCacheSlot(
+                tokens: priorTokens, cache: [KVCacheSimple()],
+                kvConfig: PromptCacheKVConfig(maxKVSize: 4096, kvBits: 8, kvGroupSize: 64, quantizedKVStart: 0)
+            ),
+            epoch: store.currentEpoch(modelName: modelName)
+        )
+
+        let decision = resolvePromptCacheReuse(
+            enabled: true, hasMediaInput: false, modelName: modelName,
+            newTokens: priorTokens + [18, 3, 19],
+            kvConfig: PromptCacheKVConfig(maxKVSize: 4096, kvBits: 4, kvGroupSize: 64, quantizedKVStart: 0),
+            store: store
+        )
+
+        guard case let .miss(reason, _) = decision else {
+            Issue.record("expected .miss, got \(decision)")
+            return
+        }
+
+        #expect(reason == .kvConfigChanged)
+    }
+
+    @Test func kvGroupSizeChangeIsAMiss() {
+        let store = PromptCacheStore()
+        let modelName = "model-kvgroupsize-change"
+        let priorTokens = [16, 1, 19, 17, 2, 19]
+        store.checkin(
+            modelName: modelName,
+            slot: PromptCacheSlot(
+                tokens: priorTokens, cache: [KVCacheSimple()],
+                kvConfig: PromptCacheKVConfig(maxKVSize: 4096, kvBits: 8, kvGroupSize: 64, quantizedKVStart: 0)
+            ),
+            epoch: store.currentEpoch(modelName: modelName)
+        )
+
+        // kvBits held fixed at 8 on both sides so kvGroupSize is the only field under test.
+        let decision = resolvePromptCacheReuse(
+            enabled: true, hasMediaInput: false, modelName: modelName,
+            newTokens: priorTokens + [18, 3, 19],
+            kvConfig: PromptCacheKVConfig(maxKVSize: 4096, kvBits: 8, kvGroupSize: 32, quantizedKVStart: 0),
+            store: store
+        )
+
+        guard case let .miss(reason, _) = decision else {
+            Issue.record("expected .miss, got \(decision)")
+            return
+        }
+
+        #expect(reason == .kvConfigChanged)
+    }
+
+    @Test func quantizedKVStartChangeIsAMiss() {
+        let store = PromptCacheStore()
+        let modelName = "model-quantizedkvstart-change"
+        let priorTokens = [16, 1, 19, 17, 2, 19]
+        store.checkin(
+            modelName: modelName,
+            slot: PromptCacheSlot(
+                tokens: priorTokens, cache: [KVCacheSimple()],
+                kvConfig: PromptCacheKVConfig(maxKVSize: 4096, kvBits: 8, kvGroupSize: 64, quantizedKVStart: 0)
+            ),
+            epoch: store.currentEpoch(modelName: modelName)
+        )
+
+        // kvBits/kvGroupSize held fixed on both sides so quantizedKVStart is the only field under
+        // test.
+        let decision = resolvePromptCacheReuse(
+            enabled: true, hasMediaInput: false, modelName: modelName,
+            newTokens: priorTokens + [18, 3, 19],
+            kvConfig: PromptCacheKVConfig(maxKVSize: 4096, kvBits: 8, kvGroupSize: 64, quantizedKVStart: 8),
+            store: store
+        )
+
+        guard case let .miss(reason, _) = decision else {
+            Issue.record("expected .miss, got \(decision)")
+            return
+        }
+
+        #expect(reason == .kvConfigChanged)
+    }
+
+    @Test func identicalKVConfigIncludingQuantizationSettingsStillHits() {
+        let store = PromptCacheStore()
+        let modelName = "model-kvconfig-match"
+        let priorTokens = [16, 1, 19, 17, 2, 19]
+        let config = PromptCacheKVConfig(maxKVSize: 4096, kvBits: 8, kvGroupSize: 32, quantizedKVStart: 4)
+        store.checkin(
+            modelName: modelName,
+            slot: PromptCacheSlot(tokens: priorTokens, cache: [KVCacheSimple()], kvConfig: config),
+            epoch: store.currentEpoch(modelName: modelName)
+        )
+
+        let decision = resolvePromptCacheReuse(
+            enabled: true, hasMediaInput: false, modelName: modelName,
+            newTokens: priorTokens + [18, 3, 19], kvConfig: config, store: store
+        )
+
+        guard case .reuse = decision else {
+            Issue.record("expected .reuse, got \(decision)")
+            return
+        }
+    }
+
+    @Test func noSlotWhenModelHasNeverBeenSeen() {
+        let store = PromptCacheStore()
+        let decision = resolvePromptCacheReuse(
+            enabled: true, hasMediaInput: false, modelName: "never-seen",
+            newTokens: [1, 2, 3], kvConfig: PromptCacheKVConfig(maxKVSize: 4096), store: store
+        )
+        guard case let .miss(reason, _) = decision else {
+            Issue.record("expected .miss, got \(decision)")
+            return
+        }
+
+        #expect(reason == .noSlot)
+    }
+
+    @Test func disabledNeverTouchesTheStore() {
+        let store = PromptCacheStore()
+        let modelName = "model-disabled"
+        store.checkin(
+            modelName: modelName,
+            slot: PromptCacheSlot(
+                tokens: [1, 2], cache: makeSimpleCacheFedWithTokens([1, 2], layerCount: 1),
+                kvConfig: PromptCacheKVConfig(maxKVSize: 100)
+            ),
+            epoch: store.currentEpoch(modelName: modelName)
+        )
+
+        let decision = resolvePromptCacheReuse(
+            enabled: false, hasMediaInput: false, modelName: modelName,
+            newTokens: [1, 2, 3], kvConfig: PromptCacheKVConfig(maxKVSize: 100), store: store
+        )
+        guard case let .miss(reason, _) = decision else {
+            Issue.record("expected .miss, got \(decision)")
+            return
+        }
+
+        #expect(reason == .disabled)
+        #expect(store.peek(modelName: modelName) != nil, "disabled must not disturb an existing slot")
+    }
+
+    @Test func multimodalNeverTouchesTheStore() {
+        let store = PromptCacheStore()
+        let modelName = "model-multimodal"
+        store.checkin(
+            modelName: modelName,
+            slot: PromptCacheSlot(
+                tokens: [1, 2], cache: makeSimpleCacheFedWithTokens([1, 2], layerCount: 1),
+                kvConfig: PromptCacheKVConfig(maxKVSize: 100)
+            ),
+            epoch: store.currentEpoch(modelName: modelName)
+        )
+
+        let decision = resolvePromptCacheReuse(
+            enabled: true, hasMediaInput: true, modelName: modelName,
+            newTokens: [1, 2, 3], kvConfig: PromptCacheKVConfig(maxKVSize: 100), store: store
+        )
+        guard case let .miss(reason, _) = decision else {
+            Issue.record("expected .miss, got \(decision)")
+            return
+        }
+
+        #expect(reason == .multimodal)
+        #expect(store.peek(modelName: modelName) != nil, "multimodal must not disturb an existing slot")
+    }
+}
+
+// MARK: - PromptCacheStoreTests
+
+@Suite("Prompt cache: store lifecycle")
+struct PromptCacheStoreTests {
+    @Test func dropRemovesOneSlotAndDropAllClearsEverything() {
+        let store = PromptCacheStore()
+        store.checkin(
+            modelName: "a",
+            slot: PromptCacheSlot(
+                tokens: [1, 2, 3],
+                cache: [KVCacheSimple()],
+                kvConfig: PromptCacheKVConfig(maxKVSize: 100)
+            ),
+            epoch: store.currentEpoch(modelName: "a")
+        )
+        store.checkin(
+            modelName: "b",
+            slot: PromptCacheSlot(
+                tokens: [4, 5],
+                cache: [KVCacheSimple()],
+                kvConfig: PromptCacheKVConfig(maxKVSize: 100)
+            ),
+            epoch: store.currentEpoch(modelName: "b")
+        )
+
+        store.drop(modelName: "a")
+        #expect(store.peek(modelName: "a") == nil)
+        #expect(store.peek(modelName: "b") != nil)
+
+        store.dropAll()
+        #expect(store.peek(modelName: "b") == nil)
+    }
+
+    @Test func checkoutIsDestructiveButPeekIsNot() {
+        let store = PromptCacheStore()
+        store.checkin(
+            modelName: "m",
+            slot: PromptCacheSlot(
+                tokens: [1, 2],
+                cache: [KVCacheSimple()],
+                kvConfig: PromptCacheKVConfig(maxKVSize: 100)
+            ),
+            epoch: store.currentEpoch(modelName: "m")
+        )
+
+        #expect(store.peek(modelName: "m") != nil)
+        #expect(store.peek(modelName: "m") != nil, "peek must not remove the slot")
+        #expect(store.checkout(modelName: "m") != nil)
+        #expect(store.peek(modelName: "m") == nil, "checkout must remove the slot")
+    }
+
+    @Test func dropBumpsThatModelsEpochEvenWithNoLiveSlotAndLeavesOtherModelsAlone() {
+        let store = PromptCacheStore()
+        let epochBefore = store.currentEpoch(modelName: "never-had-a-slot")
+
+        // `drop` must invalidate a future write-back for this model even though no slot exists
+        // to remove right now -- see `PromptCacheStore.modelEpochs`'s "never cleared" note.
+        store.drop(modelName: "never-had-a-slot")
+        let epochAfter = store.currentEpoch(modelName: "never-had-a-slot")
+        #expect(epochAfter != epochBefore, "drop must bump the per-model epoch even with no live slot")
+
+        let untouchedBefore = store.currentEpoch(modelName: "untouched")
+        store.drop(modelName: "never-had-a-slot")
+        let untouchedAfter = store.currentEpoch(modelName: "untouched")
+        #expect(untouchedAfter == untouchedBefore, "dropping one model must not bump another model's epoch")
+    }
+
+    @Test func dropAllBumpsTheGlobalEpochForEveryModelIncludingOnesNeverSeen() {
+        let store = PromptCacheStore()
+        let neverSeenBefore = store.currentEpoch(modelName: "never-seen")
+        let seededBefore = store.currentEpoch(modelName: "seeded")
+
+        store.dropAll()
+
+        #expect(
+            store.currentEpoch(modelName: "never-seen") != neverSeenBefore,
+            "dropAll must invalidate even a model with no slot and no prior per-model drop"
+        )
+        #expect(store.currentEpoch(modelName: "seeded") != seededBefore)
+    }
+}
+
+// MARK: - PromptCacheEpochInvalidationTests
+
+/// Covers the callout on `ModelPool.clearCache()`'s `PromptCacheStore.shared.dropAll()` call:
+/// `ModelPool.run` suspends while an inference is in flight, so `clearCache()`/`remove(modelName:)`
+/// can mutate the store while a still-running `ModelRunner` already holds (or is about to build) a
+/// slot for the model being cleared, and its eventual `checkin` must not resurrect what was just
+/// invalidated. `ModelPool` itself is never constructed here (see the harness's hazard note) --
+/// every test drives `PromptCacheStore` directly, exactly as `ModelPool.clearCache()`/
+/// `remove(modelName:)` do via their own `dropAll()`/`drop(modelName:)` calls.
+@Suite("Prompt cache: epoch invalidation")
+struct PromptCacheEpochInvalidationTests {
+    @Test func checkinIsRejectedAfterDropAllEvenWithTheTokenCapturedAtCheckout() {
+        let store = PromptCacheStore()
+        let modelName = "model-dropall-race"
+        let slot = PromptCacheSlot(
+            tokens: [1, 2, 3],
+            cache: [KVCacheSimple()],
+            kvConfig: PromptCacheKVConfig(maxKVSize: 100)
+        )
+        store.checkin(modelName: modelName, slot: slot, epoch: store.currentEpoch(modelName: modelName))
+
+        guard let (checkedOutSlot, epoch) = store.checkout(modelName: modelName) else {
+            Issue.record("expected a slot to check out")
+            return
+        }
+
+        // Simulates `ModelPool.run` being suspended awaiting an in-flight inference's operation
+        // while `clearCache()` runs on the actor and calls `dropAll()`.
+        store.dropAll()
+
+        let accepted = store.checkin(modelName: modelName, slot: checkedOutSlot, epoch: epoch)
+        #expect(accepted == false, "checkin must be rejected once the global epoch has moved on")
+        #expect(store.peek(modelName: modelName) == nil, "a stale check-in must not resurrect a slot")
+    }
+
+    @Test func checkinIsRejectedAfterDropOfThatModelButNotAfterDroppingAnotherModel() {
+        let store = PromptCacheStore()
+        let droppedModel = "model-dropped"
+        let otherModel = "model-untouched"
+        let droppedSlot = PromptCacheSlot(
+            tokens: [1, 2],
+            cache: [KVCacheSimple()],
+            kvConfig: PromptCacheKVConfig(maxKVSize: 100)
+        )
+        let otherSlot = PromptCacheSlot(
+            tokens: [3, 4],
+            cache: [KVCacheSimple()],
+            kvConfig: PromptCacheKVConfig(maxKVSize: 100)
+        )
+        store.checkin(modelName: droppedModel, slot: droppedSlot, epoch: store.currentEpoch(modelName: droppedModel))
+        store.checkin(modelName: otherModel, slot: otherSlot, epoch: store.currentEpoch(modelName: otherModel))
+
+        guard let (checkedOutDropped, droppedEpoch) = store.checkout(modelName: droppedModel) else {
+            Issue.record("expected \(droppedModel)'s slot to check out")
+            return
+        }
+        guard let (checkedOutOther, otherEpoch) = store.checkout(modelName: otherModel) else {
+            Issue.record("expected \(otherModel)'s slot to check out")
+            return
+        }
+
+        // Simulates `ModelPool.remove(modelName:)` racing with just `droppedModel`'s in-flight
+        // inference -- `otherModel`'s concurrently in-flight inference must be unaffected.
+        store.drop(modelName: droppedModel)
+
+        let droppedAccepted = store.checkin(modelName: droppedModel, slot: checkedOutDropped, epoch: droppedEpoch)
+        #expect(droppedAccepted == false, "checkin for the dropped model must be rejected")
+        #expect(store.peek(modelName: droppedModel) == nil)
+
+        // Control: an unrelated model's checkin must still succeed -- proves the rejection above
+        // is targeted at `droppedModel`'s epoch, not some global side effect of calling `drop`.
+        let otherAccepted = store.checkin(modelName: otherModel, slot: checkedOutOther, epoch: otherEpoch)
+        #expect(otherAccepted, "checkin for an untouched model must still succeed")
+        #expect(store.peek(modelName: otherModel) != nil)
+    }
+
+    @Test func currentEpochCapturedOnTheMissPathIsInvalidatedByADropAllBeforeCheckin() {
+        let store = PromptCacheStore()
+        let modelName = "model-never-seen-yet"
+
+        // Mirrors `resolvePromptCacheReuse`'s `.noSlot` branch: no slot exists yet, so the caller
+        // captures `currentEpoch` up front, intending to write a freshly-built cache back at the
+        // end of generation.
+        let epoch = store.currentEpoch(modelName: modelName)
+
+        store.dropAll()
+
+        let freshSlot = PromptCacheSlot(
+            tokens: [1, 2, 3],
+            cache: [KVCacheSimple()],
+            kvConfig: PromptCacheKVConfig(maxKVSize: 100)
+        )
+        let accepted = store.checkin(modelName: modelName, slot: freshSlot, epoch: epoch)
+        #expect(accepted == false, "a global epoch bump before checkin must reject even a miss-path write-back")
+        #expect(store.peek(modelName: modelName) == nil)
+    }
+
+    @Test func ordinaryCheckoutCheckinRoundTripWithNoInterveningDropStillStores() {
+        // Guards against the epoch check rejecting everything -- that failure mode would look
+        // like a passing suite sitting on top of a cache that never actually stores anything.
+        let store = PromptCacheStore()
+        let modelName = "model-clean-path"
+        let slot = PromptCacheSlot(
+            tokens: [1, 2],
+            cache: [KVCacheSimple()],
+            kvConfig: PromptCacheKVConfig(maxKVSize: 100)
+        )
+        store.checkin(modelName: modelName, slot: slot, epoch: store.currentEpoch(modelName: modelName))
+
+        guard let (checkedOut, epoch) = store.checkout(modelName: modelName) else {
+            Issue.record("expected a slot to check out")
+            return
+        }
+
+        let accepted = store.checkin(modelName: modelName, slot: checkedOut, epoch: epoch)
+        #expect(accepted, "an ordinary checkout/checkin round trip with no intervening drop must still store")
+        #expect(store.peek(modelName: modelName) != nil)
+    }
+}
+
+// MARK: - PromptCacheIteratorStrategyTests
+
+/// `promptCacheIteratorStrategy` is a pure function over three plain values (no `KVCache`,
+/// `MLXArray`, or `TokenIterator` involved), so these tests exercise the initializer-selection
+/// decision directly rather than trying to assert on a constructed `TokenIterator` (whose
+/// `kvBits`/`kvGroupSize`/`quantizedKVStart` are internal `let`s SwamaKit cannot read back out).
+/// Also useful in this sandbox specifically: unlike almost everything else in this file, none of
+/// these tests can ever hit the missing-metallib crash, since nothing here touches MLX.
+@Suite("Prompt cache: iterator strategy")
+struct PromptCacheIteratorStrategyTests {
+    @Test func missPathAlwaysUsesParametersRegardlessOfProcessorOrKVBits() {
+        // needsFullHistoryWrapper: false covers every cacheable-miss path -- `iterInput` already
+        // is the full prompt there, so there is never anything to wrap, independent of whether a
+        // penalty processor or KV quantization is configured.
+        #expect(
+            promptCacheIteratorStrategy(needsFullHistoryWrapper: false, hasPenaltyProcessor: false, kvBits: nil)
+                == .parameters
+        )
+        #expect(
+            promptCacheIteratorStrategy(needsFullHistoryWrapper: false, hasPenaltyProcessor: true, kvBits: nil)
+                == .parameters
+        )
+        #expect(
+            promptCacheIteratorStrategy(needsFullHistoryWrapper: false, hasPenaltyProcessor: true, kvBits: 4)
+                == .parameters
+        )
+    }
+
+    @Test func cacheHitWithNoPenaltyProcessorUsesParameters() {
+        // A cache hit with nothing to wrap: no reason to give up the `parameters:` initializer's
+        // full KV-config fidelity just because this is a suffix-only prefill.
+        #expect(
+            promptCacheIteratorStrategy(needsFullHistoryWrapper: true, hasPenaltyProcessor: false, kvBits: nil)
+                == .parameters
+        )
+        #expect(
+            promptCacheIteratorStrategy(needsFullHistoryWrapper: true, hasPenaltyProcessor: false, kvBits: 8)
+                == .parameters
+        )
+    }
+
+    @Test func cacheHitWithPenaltyProcessorAndNoKVQuantizationUsesProcessorWrapper() {
+        #expect(
+            promptCacheIteratorStrategy(needsFullHistoryWrapper: true, hasPenaltyProcessor: true, kvBits: nil)
+                == .processorWrapper
+        )
+    }
+
+    @Test func cacheHitWithPenaltyProcessorAndKVQuantizationBypasses() {
+        // The one combination neither upstream initializer can serve correctly: a full-history
+        // wrapper is needed (drops to the processor:sampler: overload) but the caller also wants
+        // KV quantization (which that overload's hardcoded kvBits: nil would silently disable).
+        #expect(
+            promptCacheIteratorStrategy(needsFullHistoryWrapper: true, hasPenaltyProcessor: true, kvBits: 8)
+                == .bypass
+        )
+        #expect(
+            promptCacheIteratorStrategy(needsFullHistoryWrapper: true, hasPenaltyProcessor: true, kvBits: 0)
+                == .bypass,
+            "kvBits: 0 is still non-nil -- a caller asking for 0-bit quantization must not be treated as unset"
+        )
+    }
+}
+
+// MARK: - PromptCacheEndToEndTests
+
+@Suite("Prompt cache: end to end")
+struct PromptCacheEndToEndTests {
+    @Test func multiTurnEquivalenceWithRepetitionPenalty() async throws {
+        let (container, _) = makeTestContainer(period: 5)
+        // Small per-turn generations keep each turn's *suffix* (previous reply + new user
+        // message -- the only tokens a cache-hit turn actually prefills) short, while
+        // `repetitionContextSize` is set far larger than any single suffix but
+        // comfortably within the full conversation length. That makes this a real regression
+        // check rather than a vacuous one: a processor primed with only the suffix (the bug this
+        // wrapper exists to prevent) sees a materially smaller window than one primed with the
+        // full history, which changes which tokens get penalized enough to change the argmax --
+        // confirmed by deliberately breaking `FullHistoryLogitProcessor.prompt` locally and
+        // re-running this test, which fails as expected.
+        let parameters = GenerateParameters(
+            maxTokens: 3, maxKVSize: 4096, temperature: 0,
+            repetitionPenalty: 1.3, repetitionContextSize: 40
+        )
+
+        let userTurns = [[1, 2], [3, 4], [5, 6], [7, 8], [9, 10]] // >= 3 turns
+
+        let cachedRunner = ModelRunner(container: container, promptCacheStore: PromptCacheStore())
+        var cachedMessages: [MLXLMCommon.Chat.Message] = [.system(words([0]))]
+        var cachedOutputs = [String]()
+        for turnWords in userTurns {
+            cachedMessages.append(.user(words(turnWords)))
+            let result = try await cachedRunner.runChat(
+                userInput: .init(chat: cachedMessages), parameters: parameters
+            )
+            cachedOutputs.append(result.output)
+            cachedMessages.append(.assistant(result.output))
+        }
+
+        var uncachedMessages: [MLXLMCommon.Chat.Message] = [.system(words([0]))]
+        var uncachedOutputs = [String]()
+        for turnWords in userTurns {
+            uncachedMessages.append(.user(words(turnWords)))
+            let result = try await runUncached(
+                container: container, messages: uncachedMessages, parameters: parameters
+            )
+            uncachedOutputs.append(result.output)
+            uncachedMessages.append(.assistant(result.output))
+        }
+
+        #expect(cachedOutputs.count == userTurns.count)
+        #expect(cachedOutputs.allSatisfy { $0.isEmpty == false })
+        #expect(cachedOutputs == uncachedOutputs, "cached and uncached generation must be tokenwise identical")
+    }
+
+    @Test func cacheHitAfterAppendingOneMessageReusesTheWholePreviousPrompt() async throws {
+        let (container, _) = makeTestContainer()
+        let modelName = await container.configuration.name
+        let parameters = GenerateParameters(maxTokens: 6, maxKVSize: 4096, temperature: 0)
+        let store = PromptCacheStore()
+        let runner = ModelRunner(container: container, promptCacheStore: store)
+
+        var messages: [MLXLMCommon.Chat.Message] = [.system(words([0])), .user(words([1, 2]))]
+        let turn1 = try await runner.runChat(userInput: .init(chat: messages), parameters: parameters)
+
+        let slotAfterTurn1 = try #require(
+            store.peek(modelName: modelName),
+            "expected a slot to be stored after a clean turn"
+        )
+
+        let turn1PromptTokenCount = slotAfterTurn1.tokens.count
+
+        messages.append(.assistant(turn1.output))
+        messages.append(.user(words([3, 4])))
+        let turn2 = try await runner.runChat(userInput: .init(chat: messages), parameters: parameters)
+
+        let baseline = try await runUncached(container: container, messages: messages, parameters: parameters)
+        #expect(turn2.output == baseline.output)
+
+        let slotAfterTurn2 = try #require(store.peek(modelName: modelName), "expected a slot to be stored after turn 2")
+
+        // The stored slot always holds exactly the prompt tokens for the last clean turn (no
+        // generated tokens); turn 2's prompt is turn 1's prompt plus the appended messages, so
+        // its stored length must be strictly greater than turn 1's.
+        #expect(slotAfterTurn2.tokens.count > turn1PromptTokenCount)
+        #expect(Array(slotAfterTurn2.tokens.prefix(turn1PromptTokenCount)) == slotAfterTurn1.tokens)
+    }
+
+    @Test func missOnMidHistoryEditStillProducesCorrectOutput() async throws {
+        let (container, _) = makeTestContainer()
+        let parameters = GenerateParameters(maxTokens: 5, maxKVSize: 4096, temperature: 0)
+        let store = PromptCacheStore()
+        let runner = ModelRunner(container: container, promptCacheStore: store)
+
+        _ = try await runner.runChat(
+            userInput: .init(chat: [.system(words([0])), .user(words([1, 2]))]), parameters: parameters
+        )
+
+        // Same system message (shared prefix), but the user content changed -- a mid-history
+        // edit relative to what's cached.
+        let editedMessages: [MLXLMCommon.Chat.Message] = [.system(words([0])), .user(words([9, 9, 9]))]
+        let edited = try await runner.runChat(userInput: .init(chat: editedMessages), parameters: parameters)
+        let baseline = try await runUncached(container: container, messages: editedMessages, parameters: parameters)
+
+        #expect(edited.output == baseline.output)
+    }
+
+    @Test func missOnSystemPromptChangeStillProducesCorrectOutput() async throws {
+        let (container, _) = makeTestContainer()
+        let parameters = GenerateParameters(maxTokens: 5, maxKVSize: 4096, temperature: 0)
+        let store = PromptCacheStore()
+        let runner = ModelRunner(container: container, promptCacheStore: store)
+
+        _ = try await runner.runChat(
+            userInput: .init(chat: [.system(words([0])), .user(words([1]))]), parameters: parameters
+        )
+
+        // No system message this time -- the sequence starts with a different role token, a
+        // mismatch at position 0.
+        let newMessages: [MLXLMCommon.Chat.Message] = [.user(words([2]))]
+        let missResult = try await runner.runChat(userInput: .init(chat: newMessages), parameters: parameters)
+        let baseline = try await runUncached(container: container, messages: newMessages, parameters: parameters)
+
+        #expect(missResult.output == baseline.output)
+    }
+
+    @Test func fullPrefixMatchTrimsToNMinusOneAndStillProducesCorrectOutput() async throws {
+        let (container, _) = makeTestContainer()
+        let parameters = GenerateParameters(maxTokens: 5, maxKVSize: 4096, temperature: 0)
+        let store = PromptCacheStore()
+        let runner = ModelRunner(container: container, promptCacheStore: store)
+
+        let messages: [MLXLMCommon.Chat.Message] = [.system(words([0])), .user(words([1, 2, 3]))]
+        let turn1 = try await runner.runChat(userInput: .init(chat: messages), parameters: parameters)
+
+        // Resend the exact same prompt verbatim: matched length == the entire cached prefix ==
+        // the entire new prompt, which the iterator-needs->=1-token cap must trim to N-1.
+        let turn2 = try await runner.runChat(userInput: .init(chat: messages), parameters: parameters)
+
+        let baseline = try await runUncached(container: container, messages: messages, parameters: parameters)
+        #expect(turn1.output == baseline.output)
+        #expect(turn2.output == baseline.output)
+    }
+
+    @Test func rotationFallbackProducesCorrectOutput() async throws {
+        let (container, tokenizer) = makeTestContainer()
+        let modelName = await container.configuration.name
+        let maxKVSize = 8
+        let store = PromptCacheStore()
+
+        let priorMessages: [MLXLMCommon.Chat.Message] = [.system(words([0])), .user(words([1, 2, 3, 4, 5]))]
+        let priorRawMessages = priorMessages.map { ["role": $0.role.rawValue, "content": $0.content] }
+        let priorTokens = try tokenizer.applyChatTemplate(
+            messages: priorRawMessages, tools: nil, additionalContext: nil
+        )
+
+        // Simulate "a slot was stored earlier and has since rotated past maxKVSize" directly,
+        // the same way `PromptCacheReuseClassificationTests.rotatedCacheRefusesReuseRegardlessOfMatchingPrefix`
+        // does, but wired into a real end-to-end run this time.
+        let cache = makeRotatedCache(tokens: priorTokens, layerCount: 2, maxKVSize: maxKVSize)
+        #expect(promptCacheIsReusable(cache) == false, "setup sanity: cache should have rotated")
+        store.checkin(
+            modelName: modelName,
+            slot: PromptCacheSlot(
+                tokens: priorTokens,
+                cache: cache,
+                kvConfig: PromptCacheKVConfig(maxKVSize: maxKVSize)
+            ),
+            epoch: store.currentEpoch(modelName: modelName)
+        )
+
+        let runner = ModelRunner(container: container, promptCacheStore: store)
+        var messages = priorMessages
+        messages.append(.user(words([6, 7])))
+        let parameters = GenerateParameters(maxTokens: 5, maxKVSize: maxKVSize, temperature: 0)
+
+        let result = try await runner.runChat(userInput: .init(chat: messages), parameters: parameters)
+        let baseline = try await runUncached(container: container, messages: messages, parameters: parameters)
+
+        #expect(result.output == baseline.output)
+    }
+
+    /// Covers the callout on `ModelRunner.swift`'s `buildPromptCacheGenerationRun`: a cache hit
+    /// whose `GenerateParameters` configure both a penalty processor (forcing the
+    /// `FullHistoryLogitProcessor` wrapper) *and* KV quantization (`kvBits != nil`) must not
+    /// silently reuse the slot through the wrapper's hardcoded `kvBits: nil` -- see
+    /// `PromptCacheIteratorStrategy.bypass`.
+    ///
+    /// Unlike this suite's other tests, this one cannot be distinguished from the pre-fix
+    /// behavior by a compile error: it only calls upstream's own, pre-existing
+    /// `GenerateParameters(kvBits:)`, not any new SwamaKit symbol. The only way to observe the
+    /// difference is behaviorally -- turn 2 must decline the cache hit `resolvePromptCacheReuse`
+    /// found and store nothing back, where the pre-fix code would have silently reused it via the
+    /// processor:sampler: overload (dropping kvBits) and stored the result. That requires
+    /// actually running this test, which this sandbox cannot do for any test that reaches a real
+    /// MLXArray tensor op (see the harness's hazard note) -- turn 1's prefill alone is already
+    /// enough to trigger `maybeQuantizeKVCache`'s real quantization math once `kvBits` is
+    /// non-nil, on top of the pre-existing missing-metallib limitation every other blackbox test
+    /// in this file already has.
+    @Test func kvBitsWithPenaltyProcessorOnCacheHitBypassesReuseAndProducesCorrectOutput() async throws {
+        let (container, _) = makeTestContainer(period: 5)
+        let modelName = await container.configuration.name
+        let store = PromptCacheStore()
+        let runner = ModelRunner(container: container, promptCacheStore: store)
+        let parameters = GenerateParameters(
+            maxTokens: 4, maxKVSize: 4096, kvBits: 8, temperature: 0,
+            repetitionPenalty: 1.3, repetitionContextSize: 40
+        )
+
+        var messages: [MLXLMCommon.Chat.Message] = [.system(words([0])), .user(words([1, 2]))]
+        let turn1 = try await runner.runChat(userInput: .init(chat: messages), parameters: parameters)
+        #expect(store.peek(modelName: modelName) != nil, "setup sanity: turn 1 must have primed a slot")
+
+        messages.append(.assistant(turn1.output))
+        messages.append(.user(words([3, 4, 5])))
+
+        // Turn 2 shares turn 1's exact kvConfig and appends onto its token sequence, so
+        // `resolvePromptCacheReuse` would ordinarily report `.reuse` here -- the bypass must
+        // intercept that decision before any `TokenIterator` gets built for it.
+        let turn2 = try await runner.runChat(userInput: .init(chat: messages), parameters: parameters)
+        let baseline = try await runUncached(container: container, messages: messages, parameters: parameters)
+
+        #expect(turn2.output == baseline.output)
+        #expect(
+            store.peek(modelName: modelName) == nil,
+            """
+            a bypassed cache hit must neither resurrect the slot resolvePromptCacheReuse already \
+            checked out nor store a new one -- run.cache is nil on the .kvQuantizationUnsupported path
+            """
+        )
+    }
+
+    @Test func cancelMidGenerationThenNextRequestIsCleanAndCorrect() async throws {
+        let (container, _) = makeTestContainer()
+        let modelName = await container.configuration.name
+        let store = PromptCacheStore()
+        let runner = ModelRunner(container: container, promptCacheStore: store)
+        let parameters = GenerateParameters(maxTokens: 40, maxKVSize: 4096, temperature: 0)
+
+        // Rebuilt at each call site (rather than shared via one `let`) so the non-Sendable
+        // `[Chat.Message]` value doesn't get flagged as sent into the cancellable Task below
+        // while still "in use" by the follow-up calls afterward -- each call site owns its own
+        // independent value.
+        func buildMessages() -> [MLXLMCommon.Chat.Message] {
+            [.system(words([0])), .user(words([1, 2, 3]))]
+        }
+
+        let chunkCount = Counter()
+        // Run on its own Task (as production does via `runCancellingOnClose`) and cancel *that*
+        // task from within the callback -- deterministic, no scheduling race -- rather than
+        // cancelling whatever task happens to be running this test function itself, which would
+        // also derail the "clean next request" assertions below.
+        let cancellableTask = Task<ModelRunner.ChatRunResult, Error> {
+            try await runner.runChat(
+                userInput: .init(chat: buildMessages()),
+                parameters: parameters,
+                onToken: { _ in
+                    chunkCount.increment()
+                    if chunkCount.value == 3 {
+                        withUnsafeCurrentTask { $0?.cancel() }
+                    }
+                }
+            )
+        }
+        // runChat does not throw on cancellation; it returns whatever was accumulated so far.
+        _ = try await cancellableTask.value
+
+        #expect(store.peek(modelName: modelName) == nil, "an aborted generation must never be stored")
+
+        // The next request on the same model must be a clean run with correct output -- never
+        // corrupted state from the cancelled generation.
+        let followUp = try await runner.runChat(userInput: .init(chat: buildMessages()), parameters: parameters)
+        let baseline = try await runUncached(container: container, messages: buildMessages(), parameters: parameters)
+        #expect(followUp.output == baseline.output)
+    }
+
+    @Test func dropAllMidGenerationDoesNotResurrectAStaleSlotAndNextRequestIsCorrect() async throws {
+        let (container, _) = makeTestContainer()
+        let modelName = await container.configuration.name
+        let store = PromptCacheStore()
+        let runner = ModelRunner(container: container, promptCacheStore: store)
+        let parameters = GenerateParameters(maxTokens: 40, maxKVSize: 4096, temperature: 0)
+
+        // Prime a slot with a first, ordinary turn so turn 2 below is a genuine cache *hit*
+        // (checkout, not just `currentEpoch` on a miss) -- the exact shape of the callout: an
+        // in-flight inference that has already checked a slot out for reuse.
+        var messages: [MLXLMCommon.Chat.Message] = [.system(words([0])), .user(words([1, 2]))]
+        let turn1 = try await runner.runChat(userInput: .init(chat: messages), parameters: parameters)
+        #expect(store.peek(modelName: modelName) != nil, "setup sanity: turn 1 must have primed a slot")
+
+        messages.append(.assistant(turn1.output))
+        messages.append(.user(words([3, 4, 5])))
+
+        let chunkCount = Counter()
+        let turn2 = try await runner.runChat(
+            userInput: .init(chat: messages),
+            parameters: parameters,
+            onToken: { _ in
+                chunkCount.increment()
+                if chunkCount.value == 3 {
+                    // Simulates `ModelPool.run` suspended awaiting turn 2's still-in-flight
+                    // operation while `clearCache()` runs on the actor and calls `dropAll()` --
+                    // the callout this fix addresses.
+                    store.dropAll()
+                }
+            }
+        )
+
+        #expect(turn2.output.isEmpty == false)
+        #expect(
+            store.peek(modelName: modelName) == nil,
+            "turn 2's check-in must not resurrect a slot dropAll() already cleared"
+        )
+
+        // The next request must still be a clean, correct run -- never stale/corrupted state
+        // left over from the invalidated (but still-completed) turn 2.
+        let turn3 = try await runner.runChat(userInput: .init(chat: messages), parameters: parameters)
+        let baseline = try await runUncached(container: container, messages: messages, parameters: parameters)
+        #expect(turn3.output == baseline.output)
+    }
+
+    @Test func dropModelNameMidGenerationDoesNotResurrectAStaleSlotAndNextRequestIsCorrect() async throws {
+        let (container, _) = makeTestContainer()
+        let modelName = await container.configuration.name
+        let store = PromptCacheStore()
+        let runner = ModelRunner(container: container, promptCacheStore: store)
+        let parameters = GenerateParameters(maxTokens: 40, maxKVSize: 4096, temperature: 0)
+
+        var messages: [MLXLMCommon.Chat.Message] = [.system(words([0])), .user(words([1, 2]))]
+        let turn1 = try await runner.runChat(userInput: .init(chat: messages), parameters: parameters)
+        #expect(store.peek(modelName: modelName) != nil, "setup sanity: turn 1 must have primed a slot")
+
+        messages.append(.assistant(turn1.output))
+        messages.append(.user(words([3, 4, 5])))
+
+        let chunkCount = Counter()
+        let turn2 = try await runner.runChat(
+            userInput: .init(chat: messages),
+            parameters: parameters,
+            onToken: { _ in
+                chunkCount.increment()
+                if chunkCount.value == 3 {
+                    // Sibling of the `dropAll` test above, but for the targeted
+                    // `ModelPool.remove(modelName:)` path via `drop(modelName:)`.
+                    store.drop(modelName: modelName)
+                }
+            }
+        )
+
+        #expect(turn2.output.isEmpty == false)
+        #expect(
+            store.peek(modelName: modelName) == nil,
+            "turn 2's check-in must not resurrect a slot drop(modelName:) already cleared"
+        )
+
+        let turn3 = try await runner.runChat(userInput: .init(chat: messages), parameters: parameters)
+        let baseline = try await runUncached(container: container, messages: messages, parameters: parameters)
+        #expect(turn3.output == baseline.output)
+    }
+
+    @Test func abortViaThrownErrorDuringStreamingNeverStoresAPartialSlot() async throws {
+        struct SimulatedDisconnect: Error {}
+
+        let (container, _) = makeTestContainer()
+        let modelName = await container.configuration.name
+        let store = PromptCacheStore()
+        let runner = ModelRunner(container: container, promptCacheStore: store)
+        let parameters = GenerateParameters(maxTokens: 40, maxKVSize: 4096, temperature: 0)
+        let messages: [MLXLMCommon.Chat.Message] = [.system(words([0])), .user(words([1, 2, 3]))]
+
+        let chunkCount = Counter()
+        do {
+            _ = try await runner.runChat(
+                userInput: .init(chat: messages),
+                parameters: parameters,
+                onToken: { _ in
+                    chunkCount.increment()
+                    if chunkCount.value == 3 {
+                        throw SimulatedDisconnect()
+                    }
+                }
+            )
+            Issue.record("expected runChat to rethrow the onToken failure")
+        }
+        catch is SimulatedDisconnect {
+            // expected
+        }
+
+        #expect(store.peek(modelName: modelName) == nil, "an aborted generation must never be stored")
+
+        let followUp = try await runner.runChat(userInput: .init(chat: messages), parameters: parameters)
+        let baseline = try await runUncached(container: container, messages: messages, parameters: parameters)
+        #expect(followUp.output == baseline.output)
+    }
+
+    @Test func storesOnCleanCompletionOnly() async throws {
+        let (container, _) = makeTestContainer()
+        let modelName = await container.configuration.name
+        let store = PromptCacheStore()
+        let runner = ModelRunner(container: container, promptCacheStore: store)
+        let parameters = GenerateParameters(maxTokens: 4, maxKVSize: 4096, temperature: 0)
+
+        #expect(store.peek(modelName: modelName) == nil)
+
+        let messages: [MLXLMCommon.Chat.Message] = [.system(words([0])), .user(words([1]))]
+        let result = try await runner.runChat(userInput: .init(chat: messages), parameters: parameters)
+
+        let slot = try #require(store.peek(modelName: modelName), "expected a slot after a clean completion")
+
+        #expect(slot.tokens.isEmpty == false)
+        #expect(slot.kvConfig.maxKVSize == 4096)
+        // Precise store-side trim check: the cache must be trimmed back to *exactly* the
+        // request's prompt token count (discarding this turn's generated tokens), matching
+        // `ChatRunResult.promptTokens` -- not off by one in either direction. `next()` feeds
+        // exactly one token into the cache per yielded token, and none are fed beyond the last
+        // one yielded, so after `result.completionInfo!.generationTokenCount` tokens were
+        // generated, `offset == promptTokens + generationTokenCount`; trimming by
+        // `generationTokenCount` must land exactly back on `promptTokens`.
+        #expect(slot.tokens.count == result.promptTokens)
+        #expect(slot.cache[0].offset == result.promptTokens)
+        #expect(slot.cache.allSatisfy { $0.offset == result.promptTokens })
+    }
+}
+
+// MARK: - Counter
+
+/// A plain, unsynchronized mutable box for test callbacks that are invoked serially (as
+/// `runChat`'s `onToken` documents itself to be) but whose closure type is `@Sendable`.
+private final class Counter: @unchecked Sendable {
+    private(set) var value = 0
+
+    func increment() {
+        value += 1
+    }
+}

--- a/swama/Tests/SwamaRuntimeTests/RuntimeLineageTests.swift
+++ b/swama/Tests/SwamaRuntimeTests/RuntimeLineageTests.swift
@@ -132,7 +132,7 @@ private let lineage: [LineageEntry] = [
     .init(
         path: "Model/ModelManager.swift",
         legacySHA256: "24b73c4993bba9f271e6ac6b991fd409a7bf13b2c619a509b0a31f3245594870",
-        runtimeSHA256: "257d7ed38bd7e7664988b98560c6af9d2ff605d502c0b25a07dc02f01c887b9f",
+        runtimeSHA256: "69352f2209b50329093c8cfc35b1d26ccdb6095f21df3c379f769286be08ac0d",
         derivedSymbols: ["enum ModelManager"]
     ),
     .init(

--- a/swama/Tests/SwamaRuntimeTests/RuntimeLineageTests.swift
+++ b/swama/Tests/SwamaRuntimeTests/RuntimeLineageTests.swift
@@ -1,0 +1,188 @@
+import CryptoKit
+import Foundation
+import Testing
+
+// MARK: - RuntimeLineageTests
+
+@Suite("SwamaRuntime source lineage")
+struct RuntimeLineageTests {
+    @Test func derivedSourcesStayPinnedToTheirReviewedLegacyInputs() throws {
+        let package = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+
+        for entry in lineage {
+            let legacy = package.appendingPathComponent("Sources/SwamaKit/\(entry.path)")
+            let runtime = package.appendingPathComponent("Sources/SwamaRuntime/\(entry.path)")
+            let legacyData = try Data(contentsOf: legacy)
+            let runtimeData = try Data(contentsOf: runtime)
+
+            #expect(sha256(legacyData) == entry.legacySHA256, "legacy drift: \(entry.path)")
+            #expect(sha256(runtimeData) == entry.runtimeSHA256, "runtime drift: \(entry.path)")
+
+            let legacySource = try #require(String(data: legacyData, encoding: .utf8))
+            let runtimeSource = try #require(String(data: runtimeData, encoding: .utf8))
+            for symbol in entry.derivedSymbols {
+                #expect(legacySource.contains(symbol), "missing legacy lineage symbol \(symbol)")
+                #expect(runtimeSource.contains(symbol), "missing runtime lineage symbol \(symbol)")
+            }
+        }
+    }
+
+    private func sha256(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+// MARK: - LineageEntry
+
+private struct LineageEntry: Sendable {
+    let path: String
+    let legacySHA256: String
+    let runtimeSHA256: String
+    let derivedSymbols: [String]
+}
+
+private let lineage: [LineageEntry] = [
+    .init(
+        path: "Config/ContextLimitConfig.swift",
+        legacySHA256: "a3aff18e3af7605a2eb94a4766fcba7d86ded48d984d7139796b4479e6281e8c",
+        runtimeSHA256: "d5eb46d9faf58f7a05cafb139b50d08c3c0e209eedcfafafc239c8630bb888ad",
+        derivedSymbols: ["actor ContextLimitConfig"]
+    ),
+    .init(
+        path: "Config/ContextLimitError.swift",
+        legacySHA256: "903666bb82e065860f8574f1c7a27d905b9bb2570581b0d6952cf11622ae4076",
+        runtimeSHA256: "0ab13b15d9a48fb723a9a8b9f8ee48df23521027398c2e8431f56ad266004fae",
+        derivedSymbols: ["enum ContextLimitError"]
+    ),
+    .init(
+        path: "Config/PromptCacheConfig.swift",
+        legacySHA256: "e4164039769c52647c21ea0b7d5b587c420ce58f25364cd191850d8e898e25d7",
+        runtimeSHA256: "53bae5a8074f438b11dd853c64b88423cca50cc66a0209e686d4fa2bc2c1ed86",
+        derivedSymbols: ["enum PromptCacheConfig"]
+    ),
+    .init(
+        path: "Diagnostics/DiagnosticTokenizerLoader.swift",
+        legacySHA256: "23a050f962578acefbd59711b158058b6e65e30203909359264e07734f40da91",
+        runtimeSHA256: "23a050f962578acefbd59711b158058b6e65e30203909359264e07734f40da91",
+        derivedSymbols: ["struct DiagnosticTokenizerLoader", "final class ModelLoadPhaseRecorder"]
+    ),
+    .init(
+        path: "Diagnostics/SwamaDiagnostics.swift",
+        legacySHA256: "7f6063b0c875121dff03a438e428a9469829c7162d314456fd4d57d4c76eb400",
+        runtimeSHA256: "16892d9ec137cce43056f9ec8ece0068e91007fc1e892ad65cbeae7a7744351d",
+        derivedSymbols: ["enum SwamaDiagnostics"]
+    ),
+    .init(
+        path: "Model/Downloaders/BaseDownloader.swift",
+        legacySHA256: "75a964d4e88a6e34840eb7736cd4617920566db5f08ac4eb0ad4e46faf0fef37",
+        runtimeSHA256: "b87dfda04a55c009af50321581f8b9116b7a3acce19cbc021a163b9438042e43",
+        derivedSymbols: ["class BaseDownloader"]
+    ),
+    .init(
+        path: "Model/Downloaders/HuggingFaceDownloader.swift",
+        legacySHA256: "85f077352f3fbbf88d8557e681499c654eb275c2388dd143fed188c33b0b06b8",
+        runtimeSHA256: "d89246fc125561a4136d6885cd414133c61ace3634ef4668229f0940060df84b",
+        derivedSymbols: ["class HuggingFaceDownloader"]
+    ),
+    .init(
+        path: "Model/Downloaders/IDownloader.swift",
+        legacySHA256: "dc8393e06054fbf71821f484444b621e4b1f0333bb2fe65f57d1ede44dcd4141",
+        runtimeSHA256: "c886af25b4bbd0600f9fb2630a01d55692ab44d801577c9c68f68357f2c5166c",
+        derivedSymbols: ["protocol IDownloader"]
+    ),
+    .init(
+        path: "Model/Downloaders/ModelScopeDownloader.swift",
+        legacySHA256: "424298731366a6b828ecff84d26422cb94cdf835e85a5e3cf9bb24398833c02d",
+        runtimeSHA256: "bb52dae91598cf66cb845bb23f3e4163006cc0075dcb5590441939ee48d93c17",
+        derivedSymbols: ["class ModelScopeDownloader"]
+    ),
+    .init(
+        path: "Model/EmbeddingRunner.swift",
+        legacySHA256: "e98feba0f798afa436a14a61b82534030228412a1ee89ce542046b3d35101202",
+        runtimeSHA256: "09344ae5ae0974fb6e229619dcd9856fb4c4eda08c72f2ed899f81fe781a5358",
+        derivedSymbols: ["actor EmbeddingRunner", "func generateEmbeddings", "struct EmbeddingUsage"]
+    ),
+    .init(
+        path: "Model/LocalOnlyModelDownloader.swift",
+        legacySHA256: "43e770126412872e274cdafaba7541de0c75ae832ada0764db09f96641416ccb",
+        runtimeSHA256: "43e770126412872e274cdafaba7541de0c75ae832ada0764db09f96641416ccb",
+        derivedSymbols: ["struct LocalOnlyModelDownloader"]
+    ),
+    .init(
+        path: "Model/ModelAliases.swift",
+        legacySHA256: "bf30d5e039dbb2e6333c59b73b0dc15374c1c56adc88f2ff8d862e71632062d3",
+        runtimeSHA256: "24ce5a5eb690c712cf2dd468b03b808ce8bcc61219714f1fd1cc03e9c4e13180",
+        derivedSymbols: ["enum ModelAliasResolver", "static func resolve"]
+    ),
+    .init(
+        path: "Model/ModelCreator.swift",
+        legacySHA256: "5a1887f4d13f8a230c72241a4fe9e232170ded5beb1e71226db9a8cf05f7d77e",
+        runtimeSHA256: "d58301027704d95b6ca86666f469da866e1a6f202fea13128a062beb5093c919",
+        derivedSymbols: ["enum ModelCreator"]
+    ),
+    .init(
+        path: "Model/ModelDownloader.swift",
+        legacySHA256: "2c9d70bf028ea98e445518b62cd7306791a1d1833640fbf6c4ae6b13bbda6bd3",
+        runtimeSHA256: "38bf2a46c78a2988b3d8638159ec90ec8f68920e0cc6b4a45e5d932bf869da50",
+        derivedSymbols: ["enum ModelDownloader", "static func downloadModel", "static func fetchModel"]
+    ),
+    .init(
+        path: "Model/ModelManager.swift",
+        legacySHA256: "24b73c4993bba9f271e6ac6b991fd409a7bf13b2c619a509b0a31f3245594870",
+        runtimeSHA256: "257d7ed38bd7e7664988b98560c6af9d2ff605d502c0b25a07dc02f01c887b9f",
+        derivedSymbols: ["enum ModelManager"]
+    ),
+    .init(
+        path: "Model/ModelPaths.swift",
+        legacySHA256: "6a9d06eccae50a263918f02d20db2c080c283bc1a39091b43aced760dd61b970",
+        runtimeSHA256: "9192dc4701507b081acbfe962f6638ea192e5cfdd212186e079cc9acc16f96ab",
+        derivedSymbols: ["enum ModelPaths", "static func getModelDirectory", "static func removeModel"]
+    ),
+    .init(
+        path: "Model/ModelPool.swift",
+        legacySHA256: "9efe64ad25e30dc1f747eaf91c8d3dcf6c944a1ec938a4573bbd3e74b7d79f13",
+        runtimeSHA256: "bd8ff6ddb014cc9bf2e7fef2dc30ef44e9386bca7679c117c513964c30db59ef",
+        derivedSymbols: [
+            "actor ModelPool",
+            "func run<",
+            "func runEmbeddingWithConcurrencyControl",
+            "func clearCache",
+            "func remove",
+            "func finishLoad",
+            "func evictModel"
+        ]
+    ),
+    .init(
+        path: "Model/ModelRunner.swift",
+        legacySHA256: "c5715822d87ff73f9ca54f8577d1f9873a45088b098575b464a1a4660903ef3e",
+        runtimeSHA256: "7b1feb15e90047e8963c045a757f85d6728e2c0967d54c7bb71e600ee116f34a",
+        derivedSymbols: ["actor ModelRunner", "struct ChatRunResult", "func runChat"]
+    ),
+    .init(
+        path: "Model/PromptCacheStore.swift",
+        legacySHA256: "016497d685e246fd42b6ca3d5ad1333a6d235175722085e03badcd99174f14af",
+        runtimeSHA256: "ac9d2c8e868375c8bc98e3d2fd8334de7433a7d5ac8e64264cb6f91eef33f444",
+        derivedSymbols: ["class PromptCacheStore", "func checkout", "func checkin"]
+    ),
+    .init(
+        path: "Model/StreamingDetokenizer.swift",
+        legacySHA256: "03ab47960c87c34da70d6fc2fab9c88d2e3b6726af86c15473f8472079e29b9d",
+        runtimeSHA256: "b0fb921ebd73475808a30aafc9a4a21f1b89fb3cce6580b2fb740b4a94fc0fdf",
+        derivedSymbols: ["struct StreamingDetokenizer"]
+    ),
+    .init(
+        path: "Model/TerminalUI/ProgressBar.swift",
+        legacySHA256: "d3698593bdac3abfb6ee6f7a1b0970d69f46baf3aa369c60e9ba119f49ae7354",
+        runtimeSHA256: "d3698593bdac3abfb6ee6f7a1b0970d69f46baf3aa369c60e9ba119f49ae7354",
+        derivedSymbols: ["class ProgressBar"]
+    ),
+    .init(
+        path: "Model/TokenizerCache.swift",
+        legacySHA256: "e7743b4db4b67f5e70463e14d63356e36f12b2566cf7d7cac69db5558763cafc",
+        runtimeSHA256: "e7743b4db4b67f5e70463e14d63356e36f12b2566cf7d7cac69db5558763cafc",
+        derivedSymbols: ["final class TokenizerCache", "func load", "func purge"]
+    ),
+]

--- a/swama/Tests/SwamaRuntimeTests/RuntimeParityTests.swift
+++ b/swama/Tests/SwamaRuntimeTests/RuntimeParityTests.swift
@@ -1,0 +1,93 @@
+import MLX
+@testable import MLXEmbedders
+import MLXLMCommon
+import MLXNN
+@testable import SwamaKit
+@testable import SwamaRuntime
+import Testing
+
+// MARK: - RuntimeParityTests
+
+@Suite("Legacy and package runtime parity", .serialized)
+struct RuntimeParityTests {
+    @Test func deterministicChatTextToolAndUsageStayEquivalent() async throws {
+        let legacyContainer = makeTestContainer(period: 3).container
+        let runtimeContainer = makeTestContainer(period: 3).container
+        let parameters = GenerateParameters(
+            maxTokens: 8,
+            maxKVSize: 4096,
+            temperature: 0,
+            repetitionPenalty: 1.2,
+            repetitionContextSize: 32
+        )
+        let input = UserInput(chat: [
+            .system("w0"),
+            .user("w1 w2 w3")
+        ])
+
+        let legacy = SwamaKit.ModelRunner(
+            container: legacyContainer,
+            promptCacheStore: SwamaKit.PromptCacheStore()
+        )
+        let runtime = SwamaRuntime.ModelRunner(
+            container: runtimeContainer,
+            promptCacheStore: SwamaRuntime.PromptCacheStore()
+        )
+
+        let legacyResult = try await legacy.runChat(userInput: input, parameters: parameters)
+        let runtimeResult = try await runtime.runChat(userInput: input, parameters: parameters)
+
+        #expect(runtimeResult.output == legacyResult.output)
+        #expect(runtimeResult.rawText == legacyResult.rawText)
+        #expect(runtimeResult.analysis == legacyResult.analysis)
+        #expect(runtimeResult.promptTokens == legacyResult.promptTokens)
+        #expect(runtimeResult.toolCalls == legacyResult.toolCalls)
+    }
+
+    @Test func deterministicEmbeddingAndUsageStayEquivalent() async throws {
+        let tokenizer = WordVocabTokenizer(contentVocabSize: 16)
+        let legacyContainer = EmbedderModelContainer(context: .init(
+            configuration: .init(id: "runtime-parity-legacy"),
+            model: FixedEmbeddingModel(),
+            tokenizer: tokenizer,
+            pooling: Pooling(strategy: .mean)
+        ))
+        let runtimeContainer = EmbedderModelContainer(context: .init(
+            configuration: .init(id: "runtime-parity-runtime"),
+            model: FixedEmbeddingModel(),
+            tokenizer: tokenizer,
+            pooling: Pooling(strategy: .mean)
+        ))
+        let inputs = ["w1 w2", "w3"]
+
+        let legacy = SwamaKit.EmbeddingRunner(container: legacyContainer)
+        let runtime = SwamaRuntime.EmbeddingRunner(container: runtimeContainer)
+        let legacyResult = try await legacy.generateEmbeddings(inputs: inputs)
+        let runtimeResult = try await runtime.generateEmbeddings(inputs: inputs)
+
+        #expect(runtimeResult.embeddings == legacyResult.embeddings)
+        #expect(runtimeResult.usage.promptTokens == legacyResult.usage.promptTokens)
+        #expect(runtimeResult.usage.totalTokens == legacyResult.usage.totalTokens)
+    }
+}
+
+// MARK: - FixedEmbeddingModel
+
+private final class FixedEmbeddingModel: MLXNN.Module, EmbeddingModel {
+    let vocabularySize = 32
+    let poolingStrategy: Pooling.Strategy? = .mean
+    let maxPositionEmbeddings: Int? = nil
+
+    func callAsFunction(
+        _ inputs: MLXArray,
+        positionIds _: MLXArray?,
+        tokenTypeIds _: MLXArray?,
+        attentionMask _: MLXArray?
+    ) -> EmbeddingModelOutput {
+        let values = inputs.asType(.float32).expandedDimensions(axis: -1)
+        return EmbeddingModelOutput(
+            hiddenStates: MLX.concatenated([values, values + 1], axis: -1),
+            pooledOutput: nil
+        )
+    }
+}

--- a/swama/Tests/SwamaRuntimeTests/TokenizerCacheTests.swift
+++ b/swama/Tests/SwamaRuntimeTests/TokenizerCacheTests.swift
@@ -1,0 +1,967 @@
+import Foundation
+import MLXLMCommon
+@testable import SwamaRuntime
+import Testing
+
+// MARK: - TokenizerCacheTests
+
+@Suite("Bounded tokenizer cache", .serialized)
+struct TokenizerCacheTests {
+    @Test func identicalInputsAcrossDirectoriesCoalesceAndShare() async throws {
+        let fixture = try TokenizerFixture()
+        defer { fixture.remove() }
+        let first = try fixture.directory(named: "first")
+        let second = try fixture.directory(named: "second")
+        let loader = CountingTokenizerLoader(delay: .milliseconds(100))
+        let cache = TokenizerCache(
+            configuration: .init(maximumEntries: 4, maximumInputBytes: 1_000_000),
+            diagnostics: .disabled
+        )
+
+        async let firstValue = cache.load(from: first, using: loader)
+        async let secondValue = cache.load(from: second, using: loader)
+        let values = try await [firstValue, secondValue]
+
+        #expect(await loader.calls == 1)
+        #expect(values.compactMap { ($0 as? StubTokenizer)?.identifier } == ["load-1", "load-1"])
+
+        _ = try await cache.load(from: first, using: loader)
+        #expect(await loader.calls == 1)
+    }
+
+    @Test func diagnosticLoaderUsesTheCacheAndTimesHitsAsWellAsMisses() async throws {
+        let fixture = try TokenizerFixture()
+        defer { fixture.remove() }
+        let directory = try fixture.directory(named: "diagnostic-loader")
+        let upstream = CountingTokenizerLoader()
+        let cache = TokenizerCache(
+            configuration: .init(maximumEntries: 4, maximumInputBytes: 1_000_000),
+            diagnostics: .disabled
+        )
+        let missPhases = ModelLoadPhaseRecorder()
+        let hitPhases = ModelLoadPhaseRecorder()
+
+        _ = try await DiagnosticTokenizerLoader(
+            upstream: upstream,
+            phases: missPhases,
+            cache: cache
+        ).load(from: directory)
+        _ = try await DiagnosticTokenizerLoader(
+            upstream: upstream,
+            phases: hitPhases,
+            cache: cache
+        ).load(from: directory)
+
+        #expect(await upstream.calls == 1)
+        #expect(missPhases.phases.tokenizerMs != nil)
+        #expect(hitPhases.phases.tokenizerMs != nil)
+    }
+
+    @Test func everyDeclaredTokenizerInputChangesIdentity() async throws {
+        let fixture = try TokenizerFixture()
+        defer { fixture.remove() }
+        let loader = CountingTokenizerLoader()
+        let cache = TokenizerCache(
+            configuration: .init(
+                maximumEntries: expectedTokenizerInputFileNames.count + 1,
+                maximumInputBytes: 1_000_000
+            ),
+            diagnostics: .disabled
+        )
+        let baseline = try fixture.directory(named: "baseline")
+        _ = try await cache.load(from: baseline, using: loader)
+
+        #expect(TokenizerInputFingerprint.fileNames == expectedTokenizerInputFileNames)
+        for fileName in expectedTokenizerInputFileNames {
+            let changed = try fixture.directory(named: "changed-\(fileName.replacingOccurrences(of: ".", with: "-"))")
+            let data = fileName == "config.json"
+                ? Data(#"{"model_type":"changed-model"}"#.utf8)
+                : Data("changed \(fileName)".utf8)
+            try data.write(to: changed.appendingPathComponent(fileName))
+            _ = try await cache.load(from: changed, using: loader)
+        }
+
+        #expect(await loader.calls == expectedTokenizerInputFileNames.count + 1)
+    }
+
+    @Test func missingAndEmptyOptionalInputsHaveDifferentIdentities() async throws {
+        let fixture = try TokenizerFixture()
+        defer { fixture.remove() }
+        let missing = try fixture.directory(named: "missing")
+        let empty = try fixture.directory(named: "empty")
+        try FileManager.default.removeItem(at: missing.appendingPathComponent("merges.txt"))
+        try Data().write(to: empty.appendingPathComponent("merges.txt"))
+        let loader = CountingTokenizerLoader()
+        let cache = TokenizerCache(
+            configuration: .init(maximumEntries: 4, maximumInputBytes: 1_000_000),
+            diagnostics: .disabled
+        )
+
+        _ = try await cache.load(from: missing, using: loader)
+        _ = try await cache.load(from: empty, using: loader)
+
+        #expect(await loader.calls == 2)
+    }
+
+    @Test func sameSizeContentChangeCannotReuseThePriorEntry() async throws {
+        let fixture = try TokenizerFixture()
+        defer { fixture.remove() }
+        let directory = try fixture.directory(named: "same-size-change")
+        let tokenizerFile = directory.appendingPathComponent("tokenizer.json")
+        let original = try Data(contentsOf: tokenizerFile)
+        let loader = CountingTokenizerLoader()
+        let cache = TokenizerCache(
+            configuration: .init(maximumEntries: 4, maximumInputBytes: 1_000_000),
+            diagnostics: .disabled
+        )
+
+        _ = try await cache.load(from: directory, using: loader)
+        try Data(repeating: 0x78, count: original.count).write(to: tokenizerFile)
+        _ = try await cache.load(from: directory, using: loader)
+
+        #expect(await loader.calls == 2)
+    }
+
+    @Test func invalidModelConfigurationNeverFallsBackToAnOldEntry() async throws {
+        let fixture = try TokenizerFixture()
+        defer { fixture.remove() }
+        let directory = try fixture.directory(named: "invalid-config")
+        let loader = ConfigurationValidatingTokenizerLoader()
+        let cache = TokenizerCache(
+            configuration: .init(maximumEntries: 4, maximumInputBytes: 1_000_000),
+            diagnostics: .disabled
+        )
+
+        _ = try await cache.load(from: directory, using: loader)
+        try Data("not valid json".utf8).write(to: directory.appendingPathComponent("config.json"))
+        await #expect(throws: StubLoaderError.self) {
+            _ = try await cache.load(from: directory, using: loader)
+        }
+        await #expect(throws: StubLoaderError.self) {
+            _ = try await cache.load(from: directory, using: loader)
+        }
+
+        #expect(await loader.calls == 3)
+        #expect(cache.entryCountForTesting() == 1)
+    }
+
+    @Test func modelWeightsAndGenerationPolicyDoNotSplitIdenticalTokenizers() async throws {
+        let fixture = try TokenizerFixture()
+        defer { fixture.remove() }
+        let first = try fixture.directory(named: "first")
+        let second = try fixture.directory(named: "second")
+        for (fileName, firstValue, secondValue) in [
+            ("generation_config.json", "first-stop-policy", "second-stop-policy"),
+            ("model.safetensors", "first-weights", "second-weights"),
+            ("preprocessor_config.json", "first-vision", "second-vision"),
+            (".swama-meta.json", "first-metadata", "second-metadata")
+        ] {
+            try Data(firstValue.utf8).write(to: first.appendingPathComponent(fileName))
+            try Data(secondValue.utf8).write(to: second.appendingPathComponent(fileName))
+        }
+        let loader = CountingTokenizerLoader(delay: .milliseconds(100))
+        let cache = TokenizerCache(
+            configuration: .init(maximumEntries: 4, maximumInputBytes: 1_000_000),
+            diagnostics: .disabled
+        )
+
+        async let firstValue = cache.load(from: first, using: loader)
+        async let secondValue = cache.load(from: second, using: loader)
+        _ = try await [firstValue, secondValue]
+
+        #expect(await loader.calls == 1)
+    }
+
+    @Test func unrelatedModelConfigurationFieldsDoNotSplitTheSameModelType() async throws {
+        let fixture = try TokenizerFixture()
+        defer { fixture.remove() }
+        let first = try fixture.directory(named: "first")
+        let second = try fixture.directory(named: "second")
+        try Data(#"{"model_type":"shared-model","hidden_size":128}"#.utf8)
+            .write(to: first.appendingPathComponent("config.json"))
+        try Data(#"{"model_type":"shared-model","hidden_size":4096}"#.utf8)
+            .write(to: second.appendingPathComponent("config.json"))
+        let loader = CountingTokenizerLoader(delay: .milliseconds(100))
+        let cache = TokenizerCache(
+            configuration: .init(maximumEntries: 4, maximumInputBytes: 1_000_000),
+            diagnostics: .disabled
+        )
+
+        async let firstValue = cache.load(from: first, using: loader)
+        async let secondValue = cache.load(from: second, using: loader)
+        _ = try await [firstValue, secondValue]
+
+        #expect(await loader.calls == 1)
+    }
+
+    @Test func failedLoadsAreNeverCached() async throws {
+        let fixture = try TokenizerFixture()
+        defer { fixture.remove() }
+        let directory = try fixture.directory(named: "failure")
+        let loader = CountingTokenizerLoader(failuresRemaining: 1)
+        let cache = TokenizerCache(
+            configuration: .init(maximumEntries: 4, maximumInputBytes: 1_000_000),
+            diagnostics: .disabled
+        )
+
+        await #expect(throws: StubLoaderError.self) {
+            _ = try await cache.load(from: directory, using: loader)
+        }
+        _ = try await cache.load(from: directory, using: loader)
+        _ = try await cache.load(from: directory, using: loader)
+
+        #expect(await loader.calls == 2)
+    }
+
+    @Test func leastRecentlyUsedEntryIsEvictedAndExplicitPurgeClearsTheRest() async throws {
+        let fixture = try TokenizerFixture()
+        defer { fixture.remove() }
+        let first = try fixture.directory(named: "first", seed: "first")
+        let second = try fixture.directory(named: "second", seed: "second")
+        let third = try fixture.directory(named: "third", seed: "third")
+        let loader = CountingTokenizerLoader()
+        let cache = TokenizerCache(
+            configuration: .init(maximumEntries: 2, maximumInputBytes: 1_000_000),
+            diagnostics: .disabled
+        )
+
+        _ = try await cache.load(from: first, using: loader)
+        _ = try await cache.load(from: second, using: loader)
+        _ = try await cache.load(from: first, using: loader) // first is now most-recently used
+        _ = try await cache.load(from: third, using: loader) // second is evicted
+        _ = try await cache.load(from: second, using: loader)
+        #expect(await loader.calls == 4)
+        #expect(cache.entryCountForTesting() == 2)
+
+        cache.purge()
+        #expect(cache.entryCountForTesting() == 0)
+        _ = try await cache.load(from: second, using: loader)
+        #expect(await loader.calls == 5)
+    }
+
+    @Test func purgeInvalidatesAnInFlightLoadInsteadOfResurrectingIt() async throws {
+        let fixture = try TokenizerFixture()
+        defer { fixture.remove() }
+        let directory = try fixture.directory(named: "in-flight")
+        let loader = CountingTokenizerLoader(delay: .milliseconds(200))
+        let cache = TokenizerCache(
+            configuration: .init(maximumEntries: 4, maximumInputBytes: 1_000_000),
+            diagnostics: .disabled
+        )
+
+        let first = Task { try await cache.load(from: directory, using: loader) }
+        while await loader.calls == 0 {
+            await Task.yield()
+        }
+        cache.purge()
+        await #expect(throws: CancellationError.self) { _ = try await first.value }
+        #expect(cache.entryCountForTesting() == 0)
+
+        _ = try await cache.load(from: directory, using: loader)
+        #expect(await loader.calls == 2)
+    }
+
+    @Test func producerInputDriftRejectsEveryCrossDirectoryWaiter() async throws {
+        let fixture = try TokenizerFixture()
+        defer { fixture.remove() }
+        let firstDirectory = try fixture.directory(named: "first")
+        let secondDirectory = try fixture.directory(named: "second")
+        let loader = SuspendedTokenizerLoader(mutateFileName: "tokenizer_config.json")
+        let cache = TokenizerCache(
+            configuration: .init(maximumEntries: 4, maximumInputBytes: 1_000_000),
+            diagnostics: .disabled
+        )
+
+        let first = Task { try await cache.load(from: firstDirectory, using: loader) }
+        await loader.waitUntilStarted()
+        let second = Task { try await cache.load(from: secondDirectory, using: loader) }
+        while cache.waiterCountForTesting() < 2 {
+            await Task.yield()
+        }
+        await loader.release()
+
+        await #expect(throws: TokenizerCacheError.self) { _ = try await first.value }
+        await #expect(throws: TokenizerCacheError.self) { _ = try await second.value }
+        #expect(cache.entryCountForTesting() == 0)
+    }
+
+    @Test func waiterInputDriftRejectsOnlyThatWaiter() async throws {
+        let fixture = try TokenizerFixture()
+        defer { fixture.remove() }
+        let producerDirectory = try fixture.directory(named: "producer")
+        let changedWaiterDirectory = try fixture.directory(named: "changed-waiter")
+        let loader = SuspendedTokenizerLoader()
+        let cache = TokenizerCache(
+            configuration: .init(maximumEntries: 4, maximumInputBytes: 1_000_000),
+            diagnostics: .disabled
+        )
+
+        let producer = Task { try await cache.load(from: producerDirectory, using: loader) }
+        await loader.waitUntilStarted()
+        let changedWaiter = Task { try await cache.load(from: changedWaiterDirectory, using: loader) }
+        while cache.waiterCountForTesting() < 2 {
+            await Task.yield()
+        }
+        try Data("changed-waiter-input".utf8)
+            .write(to: changedWaiterDirectory.appendingPathComponent("tokenizer_config.json"))
+        await loader.release()
+
+        _ = try await producer.value
+        await #expect(throws: TokenizerCacheError.self) { _ = try await changedWaiter.value }
+        #expect(cache.entryCountForTesting() == 1)
+    }
+
+    @Test func cancellingTheOnlyWaiterReturnsPromptlyAndDropsThePendingLoad() async throws {
+        let fixture = try TokenizerFixture()
+        defer { fixture.remove() }
+        let directory = try fixture.directory(named: "cancel-only")
+        let loader = SuspendedTokenizerLoader()
+        let cache = TokenizerCache(
+            configuration: .init(maximumEntries: 4, maximumInputBytes: 1_000_000),
+            diagnostics: .disabled
+        )
+        let outcome = TokenizerLoadOutcome()
+        let task = Task {
+            do {
+                _ = try await cache.load(from: directory, using: loader)
+                await outcome.record(.value)
+            }
+            catch is CancellationError {
+                await outcome.record(.cancelled)
+            }
+            catch {
+                await outcome.record(.otherError)
+            }
+        }
+        await loader.waitUntilStarted()
+
+        task.cancel()
+        try await waitForOutcome(outcome, timeout: .milliseconds(100))
+        #expect(await outcome.value == .cancelled)
+        #expect(cache.pendingCountForTesting() == 0)
+        await loader.release()
+        await loader.waitUntilFinished()
+        #expect(await loader.wasCancelled)
+        await task.value
+    }
+
+    @Test func cancellingOneWaiterDoesNotKillTheSharedLoadForAnotherWaiter() async throws {
+        let fixture = try TokenizerFixture()
+        defer { fixture.remove() }
+        let firstDirectory = try fixture.directory(named: "first")
+        let secondDirectory = try fixture.directory(named: "second")
+        let loader = SuspendedTokenizerLoader()
+        let cache = TokenizerCache(
+            configuration: .init(maximumEntries: 4, maximumInputBytes: 1_000_000),
+            diagnostics: .disabled
+        )
+        let cancelledOutcome = TokenizerLoadOutcome()
+        let first = Task {
+            do {
+                _ = try await cache.load(from: firstDirectory, using: loader)
+                await cancelledOutcome.record(.value)
+            }
+            catch is CancellationError {
+                await cancelledOutcome.record(.cancelled)
+            }
+            catch {
+                await cancelledOutcome.record(.otherError)
+            }
+        }
+        await loader.waitUntilStarted()
+        let second = Task { try await cache.load(from: secondDirectory, using: loader) }
+        while cache.waiterCountForTesting() < 2 {
+            await Task.yield()
+        }
+
+        first.cancel()
+        try await waitForOutcome(cancelledOutcome, timeout: .milliseconds(100))
+        #expect(await cancelledOutcome.value == .cancelled)
+        #expect(cache.pendingCountForTesting() == 1)
+        #expect(cache.waiterCountForTesting() == 1)
+        await loader.release()
+        _ = try await second.value
+        await first.value
+
+        #expect(await loader.calls == 1)
+        #expect(await !(loader.wasCancelled))
+        #expect(cache.entryCountForTesting() == 1)
+    }
+
+    @Test func inputsChangedDuringLoadAreRejectedAndNeverCachedUnderTheOldFingerprint() async throws {
+        let fixture = try TokenizerFixture()
+        defer { fixture.remove() }
+        let directory = try fixture.directory(named: "changing")
+        let loader = MutatingTokenizerLoader(fileName: "tokenizer_config.json")
+        let cache = TokenizerCache(
+            configuration: .init(maximumEntries: 4, maximumInputBytes: 1_000_000),
+            diagnostics: .disabled
+        )
+
+        await #expect(throws: TokenizerCacheError.self) {
+            _ = try await cache.load(from: directory, using: loader)
+        }
+        #expect(cache.entryCountForTesting() == 0)
+        _ = try await cache.load(from: directory, using: loader)
+        _ = try await cache.load(from: directory, using: loader)
+
+        #expect(await loader.calls == 2)
+        #expect(cache.entryCountForTesting() == 1)
+    }
+
+    @Test func oversizedInputsLoadWithoutEnteringTheCache() async throws {
+        let fixture = try TokenizerFixture()
+        defer { fixture.remove() }
+        let directory = try fixture.directory(named: "oversized")
+        let loader = CountingTokenizerLoader()
+        let cache = TokenizerCache(
+            configuration: .init(maximumEntries: 4, maximumInputBytes: 1),
+            diagnostics: .disabled
+        )
+
+        _ = try await cache.load(from: directory, using: loader)
+        _ = try await cache.load(from: directory, using: loader)
+
+        #expect(await loader.calls == 2)
+        #expect(cache.entryCountForTesting() == 0)
+    }
+
+    @Test func purgeReleasesTheTokenizerOwner() async throws {
+        let fixture = try TokenizerFixture()
+        defer { fixture.remove() }
+        let directory = try fixture.directory(named: "lifetime")
+        var lifetime: TokenizerLifetime? = TokenizerLifetime()
+        let loader = try LifetimeTokenizerLoader(lifetime: #require(lifetime))
+        let cache = TokenizerCache(
+            configuration: .init(maximumEntries: 1, maximumInputBytes: 1_000_000),
+            diagnostics: .disabled
+        )
+        weak let weakLifetime = lifetime
+        lifetime = nil
+
+        var tokenizer: (any MLXLMCommon.Tokenizer)? = try await cache.load(from: directory, using: loader)
+        #expect(weakLifetime != nil)
+        tokenizer = nil
+        _ = tokenizer
+        cache.purge()
+
+        #expect(weakLifetime == nil)
+    }
+
+    @Test func modelPoolGlobalClearReleasesTokenizerBeforeMLXCleanup() async throws {
+        let fixture = try TokenizerFixture()
+        defer { fixture.remove() }
+        let directory = try fixture.directory(named: "pool-clear")
+        var lifetime: TokenizerLifetime? = TokenizerLifetime()
+        let observation = try TokenizerCleanupObservation(lifetime: #require(lifetime))
+        let loader = try LifetimeTokenizerLoader(lifetime: #require(lifetime))
+        let cache = TokenizerCache(
+            configuration: .init(maximumEntries: 1, maximumInputBytes: 1_000_000),
+            diagnostics: .disabled
+        )
+        let owner = TokenizerCacheOwner()
+        var tokenizer: (any MLXLMCommon.Tokenizer)? = try await cache.load(
+            from: directory,
+            using: loader,
+            owner: owner
+        )
+        lifetime = nil
+        tokenizer = nil
+        _ = tokenizer
+        #expect(observation.isAlive)
+
+        let pool = ModelPool(
+            memoryHooks: .init(
+                activeMemory: { 0 },
+                clearCache: { observation.recordCleanup() }
+            ),
+            tokenizerCache: cache,
+            tokenizerCacheOwner: owner
+        )
+        await pool.clearCache()
+
+        #expect(observation.wasReleasedBeforeCleanup)
+        #expect(!observation.isAlive)
+    }
+
+    @Test func clearingOneModelPoolDoesNotCancelAStandaloneTokenizerLoad() async throws {
+        let fixture = try TokenizerFixture()
+        defer { fixture.remove() }
+        let directory = try fixture.directory(named: "standalone-load")
+        let loader = SuspendedTokenizerLoader()
+        let sharedCache = TokenizerCache(
+            configuration: .init(maximumEntries: 2, maximumInputBytes: 1_000_000),
+            diagnostics: .disabled
+        )
+        let standalone = Task {
+            try await sharedCache.load(from: directory, using: loader)
+        }
+        await loader.waitUntilStarted()
+
+        let unrelatedPool = ModelPool(
+            memoryHooks: .init(activeMemory: { 0 }, clearCache: {}),
+            tokenizerCache: sharedCache
+        )
+        await unrelatedPool.clearCache()
+
+        #expect(sharedCache.pendingCountForTesting() == 1)
+        #expect(sharedCache.waiterCountForTesting() == 1)
+        await loader.release()
+        let tokenizer = try await standalone.value
+        #expect((tokenizer as? StubTokenizer)?.identifier == "load-1")
+        #expect(await loader.wasCancelled == false)
+    }
+
+    @Test func ownerScopedPurgePreservesCrossOwnerHits() async throws {
+        let fixture = try TokenizerFixture()
+        defer { fixture.remove() }
+        let directory = try fixture.directory(named: "cross-owner")
+        let loader = CountingTokenizerLoader()
+        let cache = TokenizerCache(
+            configuration: .init(maximumEntries: 1, maximumInputBytes: 1_000_000),
+            diagnostics: .disabled
+        )
+        let firstOwner = TokenizerCacheOwner()
+        let secondOwner = TokenizerCacheOwner()
+
+        _ = try await cache.load(from: directory, using: loader, owner: firstOwner)
+        _ = try await cache.load(from: directory, using: loader, owner: secondOwner)
+        cache.purge(owner: firstOwner)
+        _ = try await cache.load(from: directory, using: loader, owner: secondOwner)
+
+        #expect(await loader.calls == 1)
+        #expect(cache.entryCountForTesting() == 1)
+        cache.purge(owner: secondOwner)
+        #expect(cache.entryCountForTesting() == 0)
+    }
+
+    @Test func releasingAModelPoolReleasesItsTokenizerOwnership() async throws {
+        let fixture = try TokenizerFixture()
+        defer { fixture.remove() }
+        let directory = try fixture.directory(named: "released-pool")
+        var lifetime: TokenizerLifetime? = TokenizerLifetime()
+        let loader = try LifetimeTokenizerLoader(lifetime: #require(lifetime))
+        let cache = TokenizerCache(
+            configuration: .init(maximumEntries: 1, maximumInputBytes: 1_000_000),
+            diagnostics: .disabled
+        )
+        let owner = TokenizerCacheOwner()
+        var tokenizer: (any MLXLMCommon.Tokenizer)? = try await cache.load(
+            from: directory,
+            using: loader,
+            owner: owner
+        )
+        weak let weakLifetime = lifetime
+        lifetime = nil
+        tokenizer = nil
+        _ = tokenizer
+
+        var pool: ModelPool? = ModelPool(
+            memoryHooks: .init(activeMemory: { 0 }, clearCache: {}),
+            tokenizerCache: cache,
+            tokenizerCacheOwner: owner
+        )
+        #expect(pool != nil)
+        pool = nil
+
+        #expect(weakLifetime == nil)
+        #expect(cache.entryCountForTesting() == 0)
+    }
+
+    @Test func diagnosticsEmitHitMissEvictionAndRejectionWithoutPaths() async throws {
+        let fixture = try TokenizerFixture()
+        defer { fixture.remove() }
+        let first = try fixture.directory(named: "first", seed: "first")
+        let second = try fixture.directory(named: "second", seed: "second")
+        let sink = TokenizerDiagnosticSink()
+        let recorder = SwamaDiagnosticRecorder(
+            enabled: true,
+            primaryWrite: { sink.append($0) },
+            fallbackWrite: { sink.append($0) }
+        )
+        recorder.start(mode: .cli)
+        let previous = SwamaDiagnostics.installRecorderForTesting(recorder)
+        defer { SwamaDiagnostics.restoreRecorderForTesting(previous) }
+
+        let loader = CountingTokenizerLoader()
+        let cache = TokenizerCache(
+            configuration: .init(maximumEntries: 1, maximumInputBytes: 1_000_000),
+            diagnostics: .live
+        )
+        _ = try await cache.load(from: first, using: loader) // miss
+        _ = try await cache.load(from: first, using: loader) // hit
+        _ = try await cache.load(from: second, using: loader) // miss + budget eviction
+        cache.purge() // explicit eviction
+
+        let rejectingCache = TokenizerCache(
+            configuration: .init(maximumEntries: 1, maximumInputBytes: 1),
+            diagnostics: .live
+        )
+        _ = try await rejectingCache.load(from: first, using: loader)
+        recorder.stop(outcome: .ok)
+        recorder.flush()
+
+        let events = try diagnosticEvents(from: sink.data)
+        let tokenizerEvents = events.filter { $0.subsystem == "tokenizer" }
+        #expect(tokenizerEvents.map(\.event) == [
+            .tokenizerCacheMiss,
+            .tokenizerCacheHit,
+            .tokenizerCacheMiss,
+            .tokenizerCacheEvicted,
+            .tokenizerCacheEvicted,
+            .tokenizerCacheRejected
+        ])
+        #expect(tokenizerEvents.allSatisfy { event in
+            guard case let .string(fingerprint)? = event.data?["fingerprint"] else {
+                return false
+            }
+
+            return fingerprint.count == 64 && !sink.text.contains(fixture.root.path)
+        })
+        #expect(SwamaDiagnostics.isValidSnapshot(sink.data))
+    }
+
+    @Test func diagnosticSinkFailureNeverChangesTheTokenizerResult() async throws {
+        let fixture = try TokenizerFixture()
+        defer { fixture.remove() }
+        let directory = try fixture.directory(named: "diagnostic-failure")
+        let fallback = TokenizerDiagnosticSink()
+        let recorder = SwamaDiagnosticRecorder(
+            enabled: true,
+            primaryWrite: { _ in throw StubLoaderError.injected },
+            fallbackWrite: { fallback.append($0) }
+        )
+        recorder.start(mode: .cli)
+        let previous = SwamaDiagnostics.installRecorderForTesting(recorder)
+        defer { SwamaDiagnostics.restoreRecorderForTesting(previous) }
+        let loader = CountingTokenizerLoader()
+        let cache = TokenizerCache(
+            configuration: .init(maximumEntries: 1, maximumInputBytes: 1_000_000),
+            diagnostics: .live
+        )
+
+        let miss = try await cache.load(from: directory, using: loader)
+        let hit = try await cache.load(from: directory, using: loader)
+        recorder.stop(outcome: .ok)
+        recorder.flush()
+
+        #expect((miss as? StubTokenizer)?.identifier == "load-1")
+        #expect((hit as? StubTokenizer)?.identifier == "load-1")
+        #expect(await loader.calls == 1)
+        #expect(!fallback.data.isEmpty)
+    }
+}
+
+// MARK: - StubLoaderError
+
+private enum StubLoaderError: Error {
+    case injected
+    case invalidConfiguration
+}
+
+// MARK: - StubTokenizer
+
+private struct StubTokenizer: MLXLMCommon.Tokenizer {
+    let identifier: String
+
+    func encode(text _: String, addSpecialTokens _: Bool) -> [Int] { [identifier.count] }
+    func decode(tokenIds _: [Int], skipSpecialTokens _: Bool) -> String { identifier }
+    func convertTokenToId(_: String) -> Int? { nil }
+    func convertIdToToken(_: Int) -> String? { nil }
+    var bosToken: String? { nil }
+    var eosToken: String? { nil }
+    var unknownToken: String? { nil }
+    func applyChatTemplate(
+        messages _: [[String: any Sendable]],
+        tools _: [[String: any Sendable]]?,
+        additionalContext _: [String: any Sendable]?
+    ) throws -> [Int] { [] }
+}
+
+// MARK: - CountingTokenizerLoader
+
+private actor CountingTokenizerLoader: TokenizerLoader {
+    init(failuresRemaining: Int = 0, delay: Duration? = nil) {
+        self.failuresRemaining = failuresRemaining
+        self.delay = delay
+    }
+
+    var calls: Int { callCount }
+
+    func load(from _: URL) async throws -> any MLXLMCommon.Tokenizer {
+        callCount += 1
+        let current = callCount
+        if failuresRemaining > 0 {
+            failuresRemaining -= 1
+            throw StubLoaderError.injected
+        }
+        if let delay {
+            try? await Task.sleep(for: delay)
+        }
+        return StubTokenizer(identifier: "load-\(current)")
+    }
+
+    private var callCount = 0
+    private var failuresRemaining: Int
+    private let delay: Duration?
+}
+
+// MARK: - ConfigurationValidatingTokenizerLoader
+
+private actor ConfigurationValidatingTokenizerLoader: TokenizerLoader {
+    var calls: Int { callCount }
+
+    func load(from directory: URL) async throws -> any MLXLMCommon.Tokenizer {
+        callCount += 1
+        let data = try Data(contentsOf: directory.appendingPathComponent("config.json"))
+        guard (try? JSONSerialization.jsonObject(with: data)) != nil else {
+            throw StubLoaderError.invalidConfiguration
+        }
+
+        return StubTokenizer(identifier: "load-\(callCount)")
+    }
+
+    private var callCount = 0
+}
+
+// MARK: - MutatingTokenizerLoader
+
+private actor MutatingTokenizerLoader: TokenizerLoader {
+    init(fileName: String) {
+        self.fileName = fileName
+    }
+
+    var calls: Int { callCount }
+
+    func load(from directory: URL) async throws -> any MLXLMCommon.Tokenizer {
+        callCount += 1
+        if callCount == 1 {
+            try Data("mutated-during-load".utf8).write(to: directory.appendingPathComponent(fileName))
+        }
+        return StubTokenizer(identifier: "load-\(callCount)")
+    }
+
+    private let fileName: String
+    private var callCount = 0
+}
+
+// MARK: - SuspendedTokenizerLoader
+
+private actor SuspendedTokenizerLoader: TokenizerLoader {
+    init(mutateFileName: String? = nil) {
+        self.mutateFileName = mutateFileName
+    }
+
+    var calls: Int { callCount }
+    var wasCancelled: Bool { observedCancellation }
+
+    func load(from directory: URL) async throws -> any MLXLMCommon.Tokenizer {
+        callCount += 1
+        let current = callCount
+        await withCheckedContinuation { continuation in
+            if released {
+                continuation.resume()
+            }
+            else {
+                releaseContinuation = continuation
+            }
+        }
+        observedCancellation = Task.isCancelled
+        if let mutateFileName {
+            try Data("mutated-by-producer".utf8).write(to: directory.appendingPathComponent(mutateFileName))
+        }
+        finished = true
+        return StubTokenizer(identifier: "load-\(current)")
+    }
+
+    func waitUntilStarted() async {
+        while callCount == 0 {
+            await Task.yield()
+        }
+    }
+
+    func release() {
+        released = true
+        let continuation = releaseContinuation
+        releaseContinuation = nil
+        continuation?.resume()
+    }
+
+    func waitUntilFinished() async {
+        while !finished {
+            await Task.yield()
+        }
+    }
+
+    private let mutateFileName: String?
+    private var callCount = 0
+    private var released = false
+    private var observedCancellation = false
+    private var finished = false
+    private var releaseContinuation: CheckedContinuation<Void, Never>?
+}
+
+// MARK: - TokenizerLoadOutcome
+
+private actor TokenizerLoadOutcome {
+    enum Value: Equatable {
+        case cancelled
+        case otherError
+        case value
+    }
+
+    var value: Value? { storedValue }
+
+    func record(_ value: Value) {
+        storedValue = value
+    }
+
+    private var storedValue: Value?
+}
+
+// MARK: - TokenizerLifetime
+
+private final class TokenizerLifetime: @unchecked Sendable {}
+
+// MARK: - TokenizerCleanupObservation
+
+private final class TokenizerCleanupObservation: @unchecked Sendable {
+    init(lifetime: TokenizerLifetime) {
+        self.lifetime = lifetime
+    }
+
+    var isAlive: Bool { lock.withLock { lifetime != nil } }
+    var wasReleasedBeforeCleanup: Bool { lock.withLock { releasedBeforeCleanup } }
+
+    func recordCleanup() {
+        lock.withLock {
+            releasedBeforeCleanup = lifetime == nil
+        }
+    }
+
+    private let lock: NSLock = .init()
+    private weak var lifetime: TokenizerLifetime?
+    private var releasedBeforeCleanup = false
+}
+
+// MARK: - LifetimeTokenizer
+
+private struct LifetimeTokenizer: MLXLMCommon.Tokenizer {
+    let lifetime: TokenizerLifetime
+
+    func encode(text _: String, addSpecialTokens _: Bool) -> [Int] { [] }
+    func decode(tokenIds _: [Int], skipSpecialTokens _: Bool) -> String { "" }
+    func convertTokenToId(_: String) -> Int? { nil }
+    func convertIdToToken(_: Int) -> String? { nil }
+    var bosToken: String? { nil }
+    var eosToken: String? { nil }
+    var unknownToken: String? { nil }
+    func applyChatTemplate(
+        messages _: [[String: any Sendable]],
+        tools _: [[String: any Sendable]]?,
+        additionalContext _: [String: any Sendable]?
+    ) throws -> [Int] { [] }
+}
+
+// MARK: - LifetimeTokenizerLoader
+
+private actor LifetimeTokenizerLoader: TokenizerLoader {
+    init(lifetime: TokenizerLifetime) {
+        self.lifetime = lifetime
+    }
+
+    func load(from _: URL) async throws -> any MLXLMCommon.Tokenizer {
+        let value = try #require(lifetime)
+        lifetime = nil
+        return LifetimeTokenizer(lifetime: value)
+    }
+
+    private var lifetime: TokenizerLifetime?
+}
+
+// MARK: - TokenizerDiagnosticSink
+
+private final class TokenizerDiagnosticSink: @unchecked Sendable {
+    var data: Data { lock.withLock { storage } }
+    var text: String { String(decoding: data, as: UTF8.self) }
+
+    func append(_ data: Data) {
+        lock.withLock { storage.append(data) }
+    }
+
+    private let lock: NSLock = .init()
+    private var storage: Data = .init()
+}
+
+// MARK: - TokenizerFixture
+
+private struct TokenizerFixture {
+    let root: URL
+
+    init() throws {
+        root = FileManager.default
+            .temporaryDirectory
+            .appendingPathComponent("swama-tokenizer-cache-tests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    }
+
+    func directory(named name: String, seed: String = "shared") throws -> URL {
+        let directory = root.appendingPathComponent(name)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        for fileName in expectedTokenizerInputFileNames {
+            let data = fileName == "config.json"
+                ? Data(#"{"model_type":"\#(seed)-model"}"#.utf8)
+                : Data("\(seed):\(fileName)".utf8)
+            try data.write(to: directory.appendingPathComponent(fileName))
+        }
+        return directory
+    }
+
+    func remove() {
+        try? FileManager.default.removeItem(at: root)
+    }
+}
+
+private let expectedTokenizerInputFileNames = [
+    "added_tokens.json",
+    "chat_template.jinja",
+    "chat_template.json",
+    "config.json",
+    "merges.txt",
+    "special_tokens_map.json",
+    "tokenizer.json",
+    "tokenizer_config.json",
+    "vocab.json"
+]
+
+private func waitForOutcome(
+    _ outcome: TokenizerLoadOutcome,
+    timeout: Duration
+) async throws {
+    let clock = ContinuousClock()
+    let deadline = clock.now.advanced(by: timeout)
+    while await outcome.value == nil {
+        guard clock.now < deadline else {
+            throw TokenizerCacheTestError.timeout
+        }
+
+        try await Task.sleep(for: .milliseconds(2))
+    }
+}
+
+// MARK: - TokenizerCacheTestError
+
+private enum TokenizerCacheTestError: Error {
+    case timeout
+}
+
+private func diagnosticEvents(from data: Data) throws -> [SwamaDiagnosticEvent] {
+    switch SwamaDiagnosticTimeline.parse(data) {
+    case let .valid(events):
+        events
+    case .degraded:
+        throw StubLoaderError.injected
+    case .unknown:
+        throw StubLoaderError.injected
+    }
+}


### PR DESCRIPTION
## Summary

- add an unexported, package-only `SwamaRuntime` target for language, vision, embedding, tokenizer/prompt-cache, diagnostics, and model lifecycle paths
- make `SwamaCore` depend only on that runtime while leaving every `SwamaKit` production source byte unchanged
- keep both `SwamaRuntime` and `SwamaCore` public symbol manifests empty in this prerequisite; public Core values remain a later change
- add executable lineage and deterministic legacy/runtime parity gates for the temporary v2 duplication
- harden the acceptance oracle for non-empty target graphs with C shims and exact Core direct-dependency checks

This is a transitional v2 boundary: it avoids pulling `MLXAudio*` into Core without rewriting the already accepted legacy `ModelPool` concurrency/teardown state machine. The duplicate runtime is explicitly lineage-gated and intended for removal in v3 after Core consumers migrate.

## Verification

- `SwamaRuntimeTests`: 88/88
- existing `SwamaKitTests`: 171/171
- `SwamaAcceptanceTests`: 45/45
- stable-Xcode `swift build -c release --target SwamaCore`
- SwiftFormat and `git diff --check`
- reverse controls: direct Core product dependency, transitive Audio dependency, public Runtime symbol, canonical audio-model listing, lineage drift, teardown generation drift, and output parity drift

The product test runs used the repository's existing explicit colocated-metallib workaround for #130; this change does not alter metallib delivery.
