### PR TITLE
ci: pin SwiftFormat and refresh formatting baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,14 +44,20 @@ jobs:
     - uses: actions/checkout@v4
     
     - name: Install SwiftFormat
-      run: brew install swiftformat
+      env:
+        SWIFTFORMAT_VERSION: "0.56.2"
+        SWIFTFORMAT_SHA256: "86e117ffebf403581bd1fc66bb9315caf0b9be04a8415466cc9a8e8bef665e3d"
+      run: |
+        curl --fail --location --retry 3 \
+          --output "$RUNNER_TEMP/swiftformat.zip" \
+          "https://github.com/nicklockwood/SwiftFormat/releases/download/${SWIFTFORMAT_VERSION}/swiftformat.zip"
+        echo "${SWIFTFORMAT_SHA256}  $RUNNER_TEMP/swiftformat.zip" | shasum -a 256 --check
+        mkdir -p "$RUNNER_TEMP/swiftformat"
+        unzip -q "$RUNNER_TEMP/swiftformat.zip" -d "$RUNNER_TEMP/swiftformat"
+        chmod +x "$RUNNER_TEMP/swiftformat/swiftformat"
+        echo "$RUNNER_TEMP/swiftformat" >> "$GITHUB_PATH"
     
     - name: Check formatting
       run: |
-        swiftformat . --dryrun --verbose
-        if [ $? -ne 0 ]; then
-          echo "❌ Code formatting issues found. Please run 'swiftformat .' to fix them."
-          exit 1
-        else
-          echo "✅ All files are properly formatted."
-        fi
+        test "$(swiftformat --version)" = "0.56.2"
+        swiftformat . --lint --verbose

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Build.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/Build.swift
@@ -214,10 +214,10 @@ func buildProducts(
 
     let testCount = firstCapture(#"Test run with (\d+) tests"#, in: tests.stdout).flatMap(Int.init) ?? -1
 
-    return .init(
+    return try .init(
         swama: swama,
         probe: probe,
-        report: try [
+        report: [
             "duration_ms": releaseBuild.durationMilliseconds
                 + fixtureBuild.durationMilliseconds
                 + testBuild.durationMilliseconds,

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/MetalBuilder.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/MetalBuilder.swift
@@ -143,7 +143,8 @@ func buildMetallib(
             throw AcceptanceFailure.unknown("metallib link failed: \(linkResult.stderr)")
         }
 
-        let normalizedMetalVersion = toolchain.metalVersion.split(separator: "\n")
+        let normalizedMetalVersion = toolchain.metalVersion
+            .split(separator: "\n")
             .filter { !$0.hasPrefix("InstalledDir:") }
             .joined(separator: "\n")
         return try .init(

--- a/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/ProcessRunner.swift
+++ b/Tools/SwamaAcceptance/Sources/SwamaAcceptanceKit/ProcessRunner.swift
@@ -14,6 +14,8 @@ struct CommandResult: Sendable {
     let timeoutCount: Int
 }
 
+// MARK: - CommandTimeout
+
 private struct CommandTimeout: Error {
     let durationMilliseconds: Double
 }
@@ -108,7 +110,6 @@ private func runCommandAttempt(
     timeout: TimeInterval,
     sampleMemory: Bool
 ) throws -> CommandResult {
-
     let temporary = FileManager.default
         .temporaryDirectory
         .appendingPathComponent("swama-acceptance-command-\(UUID().uuidString)")

--- a/swama/Sources/SwamaKit/Model/TTSRunner.swift
+++ b/swama/Sources/SwamaKit/Model/TTSRunner.swift
@@ -179,8 +179,8 @@ public enum TTSModelResolver {
              "irodori-tts",
              "mlx-community/irodori-tts-600m-v3-voicedesign-8bit":
             return resolution(.irodoriTTS)
-        case "omnivoice",
-             "mlx-community/omnivoice-bf16":
+        case "mlx-community/omnivoice-bf16",
+             "omnivoice":
             return resolution(.omniVoice)
         case "mlx-community/omnivoice":
             return resolution(.omniVoice, repository: requested)

--- a/swama/Sources/SwamaServer/CompletionsHandler.swift
+++ b/swama/Sources/SwamaServer/CompletionsHandler.swift
@@ -592,27 +592,29 @@ public enum CompletionsHandler {
         let completionTokens = result.completionInfo?.generationTokenCount ?? 0
 
         // Convert MLX ToolCalls to OpenAI format
-        let toolCalls: [ResponseToolCall]? = result.toolCalls.isEmpty ? nil : result.toolCalls.enumerated().compactMap { index, toolCall in
-            let argumentsDict = toolCall.function.arguments.mapValues { $0.anyValue }
-            let argumentsJSON: String =
-                if let jsonData = try? JSONSerialization.data(withJSONObject: argumentsDict),
-                let jsonString = String(data: jsonData, encoding: .utf8) {
-                    jsonString
-                }
-                else {
-                    "{}"
-                }
+        let toolCalls: [ResponseToolCall]? = result.toolCalls.isEmpty ? nil : result.toolCalls
+            .enumerated()
+            .compactMap { index, toolCall in
+                let argumentsDict = toolCall.function.arguments.mapValues { $0.anyValue }
+                let argumentsJSON: String =
+                    if let jsonData = try? JSONSerialization.data(withJSONObject: argumentsDict),
+                    let jsonString = String(data: jsonData, encoding: .utf8) {
+                        jsonString
+                    }
+                    else {
+                        "{}"
+                    }
 
-            return ResponseToolCall(
-                index: index,
-                id: "call_\(UUID().uuidString)",
-                type: "function",
-                function: ResponseFunction(
-                    name: toolCall.function.name,
-                    arguments: argumentsJSON
+                return ResponseToolCall(
+                    index: index,
+                    id: "call_\(UUID().uuidString)",
+                    type: "function",
+                    function: ResponseFunction(
+                        name: toolCall.function.name,
+                        arguments: argumentsJSON
+                    )
                 )
-            )
-        }
+            }
 
         // Construct the message content for the response
         let responseMessageContent = MessageContent.text(result.output)
@@ -878,7 +880,7 @@ public enum CompletionsHandler {
     /// in-flight task without keeping a completed task (and its result) alive for the life of a
     /// keep-alive connection. See `runCancellingOnClose` for why this exists.
     private final class CancellableTaskBox<T: Sendable>: @unchecked Sendable {
-        private let lock = NSLock()
+        private let lock: NSLock = .init()
         private var task: Task<T, Error>?
 
         init(_ task: Task<T, Error>) {

--- a/swama/Tests/SwamaKitTests/CompletionsHandlerTests.swift
+++ b/swama/Tests/SwamaKitTests/CompletionsHandlerTests.swift
@@ -502,7 +502,8 @@ final class CompletionsHandlerTests {
             weakSentinel == nil,
             Comment(rawValue: "operation result should be released once the request completes, even though " +
                 "the keep-alive channel stays open -- it is retained today via " +
-                "channel.closeFuture.whenComplete's strong capture of the completed Task")
+                "channel.closeFuture.whenComplete's strong capture of the completed Task"
+            )
         )
 
         // Clean up the testing channel so it doesn't leak past the test. This close happens
@@ -540,6 +541,8 @@ final class CompletionsHandlerTests {
         #expect(weakSentinel == nil)
     }
 }
+
+// MARK: - CancellationFlag
 
 /// Thread-safe boolean box used to coordinate assertions with work happening inside a
 /// separately-scheduled `Task` in the tests above.

--- a/swama/Tests/SwamaKitTests/PromptCacheTests.swift
+++ b/swama/Tests/SwamaKitTests/PromptCacheTests.swift
@@ -1166,10 +1166,10 @@ struct PromptCacheEndToEndTests {
         let runner = ModelRunner(container: container, promptCacheStore: store)
         let parameters = GenerateParameters(maxTokens: 40, maxKVSize: 4096, temperature: 0)
 
-        /// Rebuilt at each call site (rather than shared via one `let`) so the non-Sendable
-        /// `[Chat.Message]` value doesn't get flagged as sent into the cancellable Task below
-        /// while still "in use" by the follow-up calls afterward -- each call site owns its own
-        /// independent value.
+        // Rebuilt at each call site (rather than shared via one `let`) so the non-Sendable
+        // `[Chat.Message]` value doesn't get flagged as sent into the cancellable Task below
+        // while still "in use" by the follow-up calls afterward -- each call site owns its own
+        // independent value.
         func buildMessages() -> [MLXLMCommon.Chat.Message] {
             [.system(words([0])), .user(words([1, 2, 3]))]
         }


### PR DESCRIPTION
## Summary

- pin the CI formatter to the official SwiftFormat 0.56.2 universal release artifact
- verify the downloaded archive SHA-256 and executable version before linting
- run fail-closed lint mode and mechanically format the seven current baseline offenders

This is a CI-only prerequisite for the pending SwamaCore API PR. It prevents Homebrew upgrades and newly-added `--rules all` defaults from changing the gate underneath an unrelated change.

## Evidence

- reviewed exact: `eca86cf86e898dc805f6bf990cde14e83db08e43`
- whole repository with pinned binary: 0/111 files require formatting
- parent main with the same binary: 7/111 files fail
- formatting the parent with that exact binary reproduces all seven changed source files byte-for-byte
- wrong archive SHA, wrong executable version, and an unformatted mutation each fail closed
- Swama tests: 259/259
- acceptance harness: 45/45
- stable release build: passed

The seven source/test changes are formatter output only; there is no Core/API or runtime behavior change.
