### PR TITLE
Add stable SwamaCore API and SwamaEngine

### DIFF
--- a/Tests/AcceptanceFixture/Package.swift
+++ b/Tests/AcceptanceFixture/Package.swift
@@ -5,18 +5,13 @@ let package = Package(
     name: "SwamaAcceptanceFixture",
     platforms: [.macOS("15.4")],
     dependencies: [
-        .package(path: "../../swama"),
-        .package(
-            url: "https://github.com/ml-explore/mlx-swift-lm",
-            revision: "10e0cb7442920d3f67a08e067d6670334e9dadef"
-        )
+        .package(path: "../../swama")
     ],
     targets: [
         .executableTarget(
             name: "SwamaAcceptanceProbe",
             dependencies: [
-                .product(name: "SwamaKit", package: "swama"),
-                .product(name: "MLXLMCommon", package: "mlx-swift-lm")
+                .product(name: "SwamaCore", package: "swama")
             ],
             path: "Sources/SwamaAcceptanceProbe"
         )

--- a/Tests/AcceptanceFixture/Sources/SwamaAcceptanceProbe/main.swift
+++ b/Tests/AcceptanceFixture/Sources/SwamaAcceptanceProbe/main.swift
@@ -22,7 +22,7 @@ private enum ProbeError: Error, LocalizedError {
 
 // MARK: - RunRecord
 
-private struct RunRecord: Codable, Sendable {
+private struct RunRecord: Codable {
     let route: String
     let model: String
     let round: Int
@@ -37,7 +37,7 @@ private struct RunRecord: Codable, Sendable {
 
 // MARK: - CancelRecord
 
-private struct CancelRecord: Codable, Sendable {
+private struct CancelRecord: Codable {
     let route: String
     let model: String
     let observedTokensBeforeCancel: Int
@@ -50,7 +50,7 @@ private struct CancelRecord: Codable, Sendable {
 
 // MARK: - ConcurrentRecord
 
-private struct ConcurrentRecord: Codable, Sendable {
+private struct ConcurrentRecord: Codable {
     let route: String
     let model: String
     let requestCount: Int
@@ -61,7 +61,7 @@ private struct ConcurrentRecord: Codable, Sendable {
 
 // MARK: - SwitchRecord
 
-private struct SwitchRecord: Codable, Sendable {
+private struct SwitchRecord: Codable {
     let route: String
     let models: [String]
     let cycles: Int
@@ -72,7 +72,7 @@ private struct SwitchRecord: Codable, Sendable {
 
 // MARK: - LifecycleRecord
 
-private struct LifecycleRecord: Codable, Sendable {
+private struct LifecycleRecord: Codable {
     let operation: String
     let model: String?
     let completed: Bool
@@ -88,7 +88,7 @@ private final class TokenRecorder: @unchecked Sendable {
 
     func append(_ token: String) {
         let now = DispatchTime.now().uptimeNanoseconds
-        var ready: [CheckedContinuation<Void, Never>] = []
+        var ready = [CheckedContinuation<Void, Never>]()
 
         lock.lock()
         if firstTokenUptime == nil {
@@ -231,7 +231,7 @@ private func runCancellation(
     }
 
     await recorder.wait(untilCount: 2)
-    guard !task.isCancelled else {
+    guard task.isCancelled == false else {
         throw ProbeError.cancellationDidNotStart
     }
 
@@ -287,7 +287,7 @@ private func runConcurrent(
             }
         }
 
-        var values: [String] = []
+        var values = [String]()
         for try await value in group {
             values.append(value)
         }
@@ -312,8 +312,8 @@ private func runSwitching(
     cycles: Int,
     settleMilliseconds: Int
 ) async throws -> SwitchRecord {
-    var runs: [RunRecord] = []
-    var residentBytesAfterClear: [UInt64] = []
+    var runs = [RunRecord]()
+    var residentBytesAfterClear = [UInt64]()
 
     for cycle in 0 ..< cycles {
         for (index, model) in models.enumerated() {
@@ -376,7 +376,7 @@ private struct SwamaAcceptanceProbe {
 
             let model = arguments[1]
             let prompt = arguments.dropFirst(4).joined(separator: " ")
-            var records: [RunRecord] = []
+            var records = [RunRecord]()
             for round in 0 ..< rounds {
                 try await records.append(
                     runOnce(

--- a/Tests/AcceptanceFixture/Sources/SwamaAcceptanceProbe/main.swift
+++ b/Tests/AcceptanceFixture/Sources/SwamaAcceptanceProbe/main.swift
@@ -1,13 +1,12 @@
-import Darwin
 import Foundation
-import MLXLMCommon
-import SwamaKit
+import SwamaCore
 
 // MARK: - ProbeError
 
 private enum ProbeError: Error, LocalizedError {
     case invalidArguments(String)
     case cancellationDidNotStart
+    case cancellationReturnedResponse
 
     var errorDescription: String? {
         switch self {
@@ -15,6 +14,8 @@ private enum ProbeError: Error, LocalizedError {
             message
         case .cancellationDidNotStart:
             "generation completed before the cancellation witness observed two tokens"
+        case .cancellationReturnedResponse:
+            "cancelled generation returned a response instead of throwing CancellationError"
         }
     }
 }
@@ -67,6 +68,14 @@ private struct SwitchRecord: Codable, Sendable {
     let runs: [RunRecord]
     let residentBytesAfterClear: [UInt64]
     let peakResidentBytes: UInt64
+}
+
+// MARK: - LifecycleRecord
+
+private struct LifecycleRecord: Codable, Sendable {
+    let operation: String
+    let model: String?
+    let completed: Bool
 }
 
 // MARK: - TokenRecorder
@@ -122,21 +131,13 @@ private final class TokenRecorder: @unchecked Sendable {
     }
 }
 
-private func peakResidentBytes() -> UInt64 {
-    var usage = rusage()
-    guard getrusage(RUSAGE_SELF, &usage) == 0 else {
-        return 0
-    }
-
-    // ru_maxrss is bytes on Darwin (kilobytes on Linux).
-    return UInt64(max(0, usage.ru_maxrss))
-}
+private let engine: SwamaEngine = .init()
 
 private func currentResidentBytes() -> UInt64 {
     let process = Process()
     let pipe = Pipe()
     process.executableURL = URL(fileURLWithPath: "/bin/ps")
-    process.arguments = ["-o", "rss=", "-p", String(getpid())]
+    process.arguments = ["-o", "rss=", "-p", String(ProcessInfo.processInfo.processIdentifier)]
     process.standardOutput = pipe
     process.standardError = FileHandle.nullDevice
 
@@ -158,8 +159,8 @@ private func currentResidentBytes() -> UInt64 {
     }
 }
 
-private func parameters(maxTokens: Int) -> GenerateParameters {
-    GenerateParameters(
+private func parameters(maxTokens: Int) -> GenerationOptions {
+    GenerationOptions(
         maxTokens: maxTokens,
         temperature: 0,
         topP: 1,
@@ -175,28 +176,32 @@ private func runOnce(
 ) async throws -> RunRecord {
     let recorder = TokenRecorder()
     let start = DispatchTime.now().uptimeNanoseconds
-    let result = try await ModelPool.shared.run(modelName: model) { runner in
-        try await runner.runChat(
-            userInput: UserInput(chat: [.user(prompt)]),
-            parameters: parameters(maxTokens: maxTokens),
-            onToken: { token in recorder.append(token) }
-        )
-    }
+    let result = try await engine.generate(
+        GenerationRequest(
+            model: .init(model),
+            messages: [.init(role: .user, text: prompt)],
+            options: parameters(maxTokens: maxTokens)
+        ),
+        onEvent: { event in
+            if case let .textDelta(token) = event {
+                recorder.append(token)
+            }
+        }
+    )
     let end = DispatchTime.now().uptimeNanoseconds
     let snapshot = recorder.snapshot()
-    let info = result.completionInfo
 
     return RunRecord(
         route: "core",
         model: model,
         round: round,
-        promptTokens: result.promptTokens,
-        generatedTokens: info?.generationTokenCount ?? snapshot.count,
+        promptTokens: result.usage.promptTokens,
+        generatedTokens: result.usage.completionTokens,
         ttftMilliseconds: snapshot.firstTokenUptime.map { Double($0 - start) / 1_000_000 },
         totalMilliseconds: Double(end - start) / 1_000_000,
-        tokensPerSecond: info?.tokensPerSecond,
+        tokensPerSecond: result.metrics?.tokensPerSecond,
         output: snapshot.output.isEmpty ? result.output : snapshot.output,
-        peakResidentBytes: peakResidentBytes()
+        peakResidentBytes: currentResidentBytes()
     )
 }
 
@@ -211,13 +216,18 @@ private func runCancellation(
 
     let recorder = TokenRecorder()
     let task = Task {
-        try await ModelPool.shared.run(modelName: model) { runner in
-            try await runner.runChat(
-                userInput: UserInput(chat: [.user(prompt)]),
-                parameters: parameters(maxTokens: maxTokens),
-                onToken: { token in recorder.append(token) }
-            )
-        }
+        try await engine.generate(
+            GenerationRequest(
+                model: .init(model),
+                messages: [.init(role: .user, text: prompt)],
+                options: parameters(maxTokens: maxTokens)
+            ),
+            onEvent: { event in
+                if case let .textDelta(token) = event {
+                    recorder.append(token)
+                }
+            }
+        )
     }
 
     await recorder.wait(untilCount: 2)
@@ -227,7 +237,13 @@ private func runCancellation(
 
     let cancelStart = DispatchTime.now().uptimeNanoseconds
     task.cancel()
-    let cancelledResult = try await task.value
+    do {
+        _ = try await task.value
+        throw ProbeError.cancellationReturnedResponse
+    }
+    catch is CancellationError {
+        // The public Core contract never returns a partial terminal response on cancellation.
+    }
     let cancelEnd = DispatchTime.now().uptimeNanoseconds
     let cancelledSnapshot = recorder.snapshot()
 
@@ -243,10 +259,10 @@ private func runCancellation(
         model: model,
         observedTokensBeforeCancel: cancelledSnapshot.count,
         cancellationMilliseconds: Double(cancelEnd - cancelStart) / 1_000_000,
-        cancelledOutput: cancelledSnapshot.output.isEmpty ? cancelledResult.output : cancelledSnapshot.output,
+        cancelledOutput: cancelledSnapshot.output,
         followupOutput: followup.output,
         followupGeneratedTokens: followup.generatedTokens,
-        peakResidentBytes: peakResidentBytes()
+        peakResidentBytes: currentResidentBytes()
     )
 }
 
@@ -285,7 +301,7 @@ private func runConcurrent(
         requestCount: requestCount,
         totalMilliseconds: Double(end - start) / 1_000_000,
         outputs: outputs,
-        peakResidentBytes: peakResidentBytes()
+        peakResidentBytes: currentResidentBytes()
     )
 }
 
@@ -309,7 +325,7 @@ private func runSwitching(
                     round: cycle * models.count + index
                 )
             )
-            await ModelPool.shared.clearCache()
+            await engine.clearCache()
             try await Task.sleep(nanoseconds: UInt64(settleMilliseconds) * 1_000_000)
             residentBytesAfterClear.append(currentResidentBytes())
         }
@@ -321,7 +337,7 @@ private func runSwitching(
         cycles: cycles,
         runs: runs,
         residentBytesAfterClear: residentBytesAfterClear,
-        peakResidentBytes: peakResidentBytes()
+        peakResidentBytes: currentResidentBytes()
     )
 }
 
@@ -340,7 +356,9 @@ private struct SwamaAcceptanceProbe {
     static func main() async throws {
         let arguments = Array(CommandLine.arguments.dropFirst())
         guard let command = arguments.first else {
-            throw ProbeError.invalidArguments("expected generate, cancel, concurrent, or switch")
+            throw ProbeError.invalidArguments(
+                "expected generate, cancel, concurrent, switch, embed, models, fetch, remove, or clear"
+            )
         }
 
         switch command {
@@ -438,6 +456,52 @@ private struct SwamaAcceptanceProbe {
                     settleMilliseconds: settleMilliseconds
                 )
             )
+
+        case "embed":
+            guard arguments.count >= 3 else {
+                throw ProbeError.invalidArguments("usage: SwamaAcceptanceProbe embed MODEL INPUT...")
+            }
+
+            try await encode(engine.embed(.init(
+                model: .init(arguments[1]),
+                inputs: Array(arguments.dropFirst(2))
+            )))
+
+        case "models":
+            try await encode(engine.models())
+
+        case "fetch":
+            guard arguments.count == 2 else {
+                throw ProbeError.invalidArguments("usage: SwamaAcceptanceProbe fetch MODEL")
+            }
+
+            try await engine.fetch(.init(arguments[1]))
+            try encode(LifecycleRecord(operation: "fetch", model: arguments[1], completed: true))
+
+        case "remove":
+            guard arguments.count == 2 else {
+                throw ProbeError.invalidArguments("usage: SwamaAcceptanceProbe remove MODEL")
+            }
+
+            try await engine.remove(.init(arguments[1]))
+            try encode(LifecycleRecord(operation: "remove", model: arguments[1], completed: true))
+
+        case "clear":
+            guard arguments.count <= 2 else {
+                throw ProbeError.invalidArguments("usage: SwamaAcceptanceProbe clear [MODEL]")
+            }
+
+            if let model = arguments.dropFirst().first {
+                await engine.clearCache(for: .init(model))
+            }
+            else {
+                await engine.clearCache()
+            }
+            try encode(LifecycleRecord(
+                operation: "clear",
+                model: arguments.dropFirst().first,
+                completed: true
+            ))
 
         default:
             throw ProbeError.invalidArguments("unknown command: \(command)")

--- a/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
+++ b/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
@@ -256,7 +256,7 @@ struct AcceptanceTests {
         )
         var report = reliabilityReport()
         var gates = try reliabilityGateStatus(report, contract: contract)
-        #expect(!gates.values.contains(false))
+        #expect(gates.values.contains(false) == false)
 
         var cancel = try report.object("cancel_then_recover")
         cancel["observedTokensBeforeCancel"] = 99
@@ -506,7 +506,7 @@ struct AcceptanceTests {
         )
         #expect(build.contains("--target"))
         #expect(build.contains("SwamaCore"))
-        #expect(!build.contains("dump-symbol-graph"))
+        #expect(build.contains("dump-symbol-graph") == false)
 
         let extract = symbolGraphExtractCommand(
             extractor: URL(fileURLWithPath: "/toolchain/swift-symbolgraph-extract"),
@@ -952,8 +952,8 @@ struct AcceptanceTests {
         #expect(parsedModules[0] == "Swift")
         #expect(parsedModules[1] == "Other")
         for malformed in [
-            validDemanglerOutput.replacingOccurrences(
-                of: "Demangling for $sSN",
+            validDemanglerOutput.replacing(
+                "Demangling for $sSN",
                 with: "Demangling for $s5Other4TypeV"
             ),
             "\n" + validDemanglerOutput,
@@ -1721,7 +1721,7 @@ struct AcceptanceTests {
         try Data("stale".utf8).write(to: staleArtifact)
 
         let current = try prepareAcceptanceBuildScratch(root: temporary, identity: "current")
-        #expect(!FileManager.default.fileExists(atPath: staleArtifact.path))
+        #expect(FileManager.default.fileExists(atPath: staleArtifact.path) == false)
         let partialArtifact = current.fixture.appendingPathComponent("partial-object")
         try FileManager.default.createDirectory(at: current.fixture, withIntermediateDirectories: true)
         try Data("partial".utf8).write(to: partialArtifact)

--- a/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
+++ b/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
@@ -995,7 +995,7 @@ struct AcceptanceTests {
         #expect(concatenatedModules == [nil])
     }
 
-    @Test func coreBoundaryTurnsGreenWhenTheDependencyFreeTargetExists() throws {
+    @Test func coreAndConsumerBoundariesTurnGreenForThePublicCoreAPI() throws {
         let paths = try WorkspacePaths.discover(explicit: repositoryRoot.path)
         let contract = try AcceptanceContract.load(from: paths.contract)
         let report = try architectureReport(
@@ -1010,11 +1010,11 @@ struct AcceptanceTests {
         let compiler = try report.object("compiler_public_api")
         #expect(try compiler.string("status") == "ready")
         #expect(try compiler.boolean("passed"))
-        #expect(try compiler.integer("symbol_count") == 0)
-        #expect(try compiler.array("symbols").isEmpty)
+        #expect(try compiler.integer("symbol_count") > 0)
+        #expect(try !compiler.array("symbols").isEmpty)
         #expect(try compiler.array("violations").isEmpty)
         #expect(try compiler.string("manifest_sha256")
-            == "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
+            == "21a39b984973a71da521dce19820c0796b425001e5ef9e0c213bbec8952f6c40"
         )
         let dependencies = try report.object("core_target_dependencies")
         #expect(try dependencies.string("status") == "ready")
@@ -1026,11 +1026,11 @@ struct AcceptanceTests {
             stage: .consumerBoundary,
             paths: paths
         )
-        #expect(try consumerReport.boolean("passed") == false)
-        #expect(try consumerReport.object("external_consumer_boundary").boolean("passed") == false)
+        #expect(try consumerReport.boolean("passed"))
+        #expect(try consumerReport.object("external_consumer_boundary").boolean("passed"))
     }
 
-    @Test func consumerBoundaryNamesEveryCurrentMLXDependencyAndImport() throws {
+    @Test func consumerBoundaryAcceptsThePureCoreFixture() throws {
         let paths = try WorkspacePaths.discover(explicit: repositoryRoot.path)
         let contract = try AcceptanceContract.load(from: paths.contract)
         let report = try externalConsumerBoundaryReport(
@@ -1038,10 +1038,9 @@ struct AcceptanceTests {
             expectedPackage: paths.package,
             contract: contract.coreGuards
         )
-
-        #expect(try report.boolean("passed") == false)
-        #expect(try report.array("unexpected_products").contains { ($0 as? String) == "MLXLMCommon" })
-        #expect(try report.array("unexpected_imports").contains { ($0 as? String) == "MLXLMCommon" })
+        #expect(try report.boolean("passed"))
+        #expect(try report.array("unexpected_products").isEmpty)
+        #expect(try report.array("unexpected_imports").isEmpty)
     }
 
     @Test func consumerBoundaryRejectsExtraPathPackagesAndByNameTargets() throws {
@@ -1249,25 +1248,37 @@ struct AcceptanceTests {
         ]))
     }
 
-    @Test func runtimeAndCoreCompilerPublicManifestsStayEmpty() throws {
+    @Test func runtimeStaysPrivateAndCoreManifestMatchesV1() throws {
         let paths = try WorkspacePaths.discover(explicit: repositoryRoot.path)
         let contract = try AcceptanceContract.load(from: paths.contract).coreGuards
         let developerDirectory = URL(fileURLWithPath: "/Applications/Xcode.app/Contents/Developer")
 
-        for target in ["SwamaRuntime", "SwamaCore"] {
-            let report = try compilerPublicAPIReport(
-                target: target,
-                paths: paths,
-                developerDirectory: developerDirectory,
-                contract: contract
-            )
-            #expect(try report.boolean("passed"), "\(target) public API guard failed")
-            #expect(try report.integer("symbol_count") == 0)
-            #expect(try report.array("symbols").isEmpty)
-            #expect(try report
-                .string("manifest_sha256") == "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
-            )
-        }
+        let runtime = try compilerPublicAPIReport(
+            target: "SwamaRuntime",
+            paths: paths,
+            developerDirectory: developerDirectory,
+            contract: contract
+        )
+        #expect(try runtime.boolean("passed"))
+        #expect(try runtime.integer("symbol_count") == 0)
+        #expect(try runtime.array("symbols").isEmpty)
+        #expect(try runtime
+            .string("manifest_sha256") == "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
+        )
+
+        let core = try compilerPublicAPIReport(
+            target: "SwamaCore",
+            paths: paths,
+            developerDirectory: developerDirectory,
+            contract: contract
+        )
+        #expect(try core.boolean("passed"))
+        #expect(try core.integer("symbol_count") > 0)
+        #expect(try !core.array("symbols").isEmpty)
+        #expect(try core.array("violations").isEmpty)
+        #expect(try core.string("manifest_sha256")
+            == "21a39b984973a71da521dce19820c0796b425001e5ef9e0c213bbec8952f6c40"
+        )
     }
 
     @Test func targetDependencyGraphRejectsAMissingLibraryProduct() throws {

--- a/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
+++ b/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
@@ -1010,11 +1010,11 @@ struct AcceptanceTests {
         let compiler = try report.object("compiler_public_api")
         #expect(try compiler.string("status") == "ready")
         #expect(try compiler.boolean("passed"))
-        #expect(try compiler.integer("symbol_count") > 0)
-        #expect(try !compiler.array("symbols").isEmpty)
+        #expect(try compiler.integer("symbol_count") == 160)
+        #expect(try compiler.array("symbols").count == 160)
         #expect(try compiler.array("violations").isEmpty)
         #expect(try compiler.string("manifest_sha256")
-            == "21a39b984973a71da521dce19820c0796b425001e5ef9e0c213bbec8952f6c40"
+            == "9cc4b4759e3c104f8832a0eb9a5369d85141b1c817217e0df42aec1405c5ba39"
         )
         let dependencies = try report.object("core_target_dependencies")
         #expect(try dependencies.string("status") == "ready")
@@ -1273,11 +1273,11 @@ struct AcceptanceTests {
             contract: contract
         )
         #expect(try core.boolean("passed"))
-        #expect(try core.integer("symbol_count") > 0)
-        #expect(try !core.array("symbols").isEmpty)
+        #expect(try core.integer("symbol_count") == 160)
+        #expect(try core.array("symbols").count == 160)
         #expect(try core.array("violations").isEmpty)
         #expect(try core.string("manifest_sha256")
-            == "21a39b984973a71da521dce19820c0796b425001e5ef9e0c213bbec8952f6c40"
+            == "9cc4b4759e3c104f8832a0eb9a5369d85141b1c817217e0df42aec1405c5ba39"
         )
     }
 

--- a/swama/Package.swift
+++ b/swama/Package.swift
@@ -133,5 +133,9 @@ let package = Package(
                 .product(name: "MLXNN", package: "mlx-swift"),
             ]
         ),
+        .testTarget(
+            name: "SwamaCoreTests",
+            dependencies: ["SwamaCore"]
+        ),
     ]
 )

--- a/swama/Sources/SwamaCore/CoreValues.swift
+++ b/swama/Sources/SwamaCore/CoreValues.swift
@@ -329,6 +329,16 @@ public enum FinishReason: String, Hashable, Codable, Sendable {
     case length
     case toolCall = "tool_call"
     case unknown
+
+    public init(from decoder: Decoder) throws {
+        let rawValue = try decoder.singleValueContainer().decode(String.self)
+        self = Self(rawValue: rawValue) ?? .unknown
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
 }
 
 // MARK: - Usage

--- a/swama/Sources/SwamaCore/CoreValues.swift
+++ b/swama/Sources/SwamaCore/CoreValues.swift
@@ -21,7 +21,9 @@ public struct ModelID: RawRepresentable, Hashable, Codable, Sendable, CustomStri
     }
 
     public let rawValue: String
-    public var description: String { rawValue }
+    public var description: String {
+        rawValue
+    }
 }
 
 // MARK: - SwamaConfiguration
@@ -351,7 +353,9 @@ public struct Usage: Hashable, Codable, Sendable {
 
     public var promptTokens: Int
     public var completionTokens: Int
-    public var totalTokens: Int { promptTokens + completionTokens }
+    public var totalTokens: Int {
+        promptTokens + completionTokens
+    }
 }
 
 // MARK: - GenerationMetrics
@@ -482,5 +486,7 @@ public struct SwamaError: Error, Hashable, Codable, Sendable, LocalizedError {
     public var code: Code
     public var message: String
     public var model: ModelID?
-    public var errorDescription: String? { message }
+    public var errorDescription: String? {
+        message
+    }
 }

--- a/swama/Sources/SwamaCore/CoreValues.swift
+++ b/swama/Sources/SwamaCore/CoreValues.swift
@@ -1,0 +1,476 @@
+import Foundation
+
+// MARK: - ModelID
+
+public struct ModelID: RawRepresentable, Hashable, Codable, Sendable, CustomStringConvertible {
+    public init(rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public init(_ rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    public init(from decoder: Decoder) throws {
+        rawValue = try decoder.singleValueContainer().decode(String.self)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+
+    public let rawValue: String
+    public var description: String { rawValue }
+}
+
+// MARK: - SwamaConfiguration
+
+public struct SwamaConfiguration: Hashable, Codable, Sendable {
+    public init(defaultContextLimit: Int? = nil) {
+        self.defaultContextLimit = defaultContextLimit
+    }
+
+    public var defaultContextLimit: Int?
+}
+
+// MARK: - JSONValue
+
+public enum JSONValue: Hashable, Codable, Sendable {
+    case null
+    case bool(Bool)
+    case int(Int)
+    case double(Double)
+    case string(String)
+    case array([JSONValue])
+    case object([String: JSONValue])
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self = .null
+        }
+        else if let value = try? container.decode(Bool.self) {
+            self = .bool(value)
+        }
+        else if let value = try? container.decode(Int.self) {
+            self = .int(value)
+        }
+        else if let value = try? container.decode(Double.self) {
+            self = .double(value)
+        }
+        else if let value = try? container.decode(String.self) {
+            self = .string(value)
+        }
+        else if let value = try? container.decode([JSONValue].self) {
+            self = .array(value)
+        }
+        else if let value = try? container.decode([String: JSONValue].self) {
+            self = .object(value)
+        }
+        else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "unsupported JSON value"
+            )
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .null:
+            try container.encodeNil()
+        case let .bool(value):
+            try container.encode(value)
+        case let .int(value):
+            try container.encode(value)
+        case let .double(value):
+            try container.encode(value)
+        case let .string(value):
+            try container.encode(value)
+        case let .array(value):
+            try container.encode(value)
+        case let .object(value):
+            try container.encode(value)
+        }
+    }
+}
+
+// MARK: - ToolDefinition
+
+public struct ToolDefinition: Hashable, Codable, Sendable {
+    public init(name: String, description: String? = nil, parameters: JSONValue) {
+        self.name = name
+        self.description = description
+        self.parameters = parameters
+    }
+
+    public var name: String
+    public var description: String?
+    public var parameters: JSONValue
+}
+
+// MARK: - ToolCall
+
+public struct ToolCall: Hashable, Codable, Sendable {
+    public init(id: String? = nil, name: String, arguments: [String: JSONValue]) {
+        self.id = id
+        self.name = name
+        self.arguments = arguments
+    }
+
+    public var id: String?
+    public var name: String
+    public var arguments: [String: JSONValue]
+}
+
+// MARK: - ContentPart
+
+public enum ContentPart: Hashable, Codable, Sendable {
+    case text(String)
+    case imageURL(URL)
+    case imageData(Data, mediaType: String)
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case text
+        case url
+        case data
+        case mediaType = "media_type"
+    }
+
+    private enum Kind: String, Codable {
+        case text
+        case imageURL = "image_url"
+        case imageData = "image_data"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        switch try container.decode(Kind.self, forKey: .type) {
+        case .text:
+            self = try .text(container.decode(String.self, forKey: .text))
+        case .imageURL:
+            self = try .imageURL(container.decode(URL.self, forKey: .url))
+        case .imageData:
+            self = try .imageData(
+                container.decode(Data.self, forKey: .data),
+                mediaType: container.decode(String.self, forKey: .mediaType)
+            )
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case let .text(value):
+            try container.encode(Kind.text, forKey: .type)
+            try container.encode(value, forKey: .text)
+
+        case let .imageURL(value):
+            try container.encode(Kind.imageURL, forKey: .type)
+            try container.encode(value, forKey: .url)
+
+        case let .imageData(data, mediaType):
+            try container.encode(Kind.imageData, forKey: .type)
+            try container.encode(data, forKey: .data)
+            try container.encode(mediaType, forKey: .mediaType)
+        }
+    }
+}
+
+// MARK: - Message
+
+public struct Message: Hashable, Codable, Sendable {
+    public enum Role: String, Codable, Sendable {
+        case system
+        case user
+        case assistant
+        case tool
+    }
+
+    public init(
+        role: Role,
+        content: [ContentPart],
+        toolCalls: [ToolCall] = [],
+        toolCallID: String? = nil
+    ) {
+        self.role = role
+        self.content = content
+        self.toolCalls = toolCalls
+        self.toolCallID = toolCallID
+    }
+
+    public init(role: Role, text: String) {
+        self.init(role: role, content: [.text(text)])
+    }
+
+    public var role: Role
+    public var content: [ContentPart]
+    public var toolCalls: [ToolCall]
+    public var toolCallID: String?
+}
+
+// MARK: - GenerationOptions
+
+public struct GenerationOptions: Hashable, Codable, Sendable {
+    public init(
+        maxTokens: Int? = nil,
+        temperature: Float = 0.6,
+        topP: Float = 1,
+        topK: Int = 0,
+        minP: Float = 0,
+        repetitionPenalty: Float? = nil,
+        repetitionContextSize: Int = 20,
+        presencePenalty: Float? = nil,
+        presenceContextSize: Int = 20,
+        frequencyPenalty: Float? = nil,
+        frequencyContextSize: Int = 20,
+        seed: UInt64? = nil,
+        contextLimit: Int? = nil
+    ) {
+        self.maxTokens = maxTokens
+        self.temperature = temperature
+        self.topP = topP
+        self.topK = topK
+        self.minP = minP
+        self.repetitionPenalty = repetitionPenalty
+        self.repetitionContextSize = repetitionContextSize
+        self.presencePenalty = presencePenalty
+        self.presenceContextSize = presenceContextSize
+        self.frequencyPenalty = frequencyPenalty
+        self.frequencyContextSize = frequencyContextSize
+        self.seed = seed
+        self.contextLimit = contextLimit
+    }
+
+    public var maxTokens: Int?
+    public var temperature: Float
+    public var topP: Float
+    public var topK: Int
+    public var minP: Float
+    public var repetitionPenalty: Float?
+    public var repetitionContextSize: Int
+    public var presencePenalty: Float?
+    public var presenceContextSize: Int
+    public var frequencyPenalty: Float?
+    public var frequencyContextSize: Int
+    public var seed: UInt64?
+    public var contextLimit: Int?
+}
+
+// MARK: - GenerationRequest
+
+public struct GenerationRequest: Hashable, Codable, Sendable {
+    public init(
+        model: ModelID,
+        messages: [Message],
+        options: GenerationOptions = .init(),
+        tools: [ToolDefinition] = []
+    ) {
+        self.model = model
+        self.messages = messages
+        self.options = options
+        self.tools = tools
+    }
+
+    public var model: ModelID
+    public var messages: [Message]
+    public var options: GenerationOptions
+    public var tools: [ToolDefinition]
+}
+
+// MARK: - GenerationEvent
+
+public enum GenerationEvent: Hashable, Codable, Sendable {
+    case textDelta(String)
+    case toolCall(ToolCall)
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case text
+        case toolCall = "tool_call"
+    }
+
+    private enum Kind: String, Codable {
+        case textDelta = "text_delta"
+        case toolCall = "tool_call"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        switch try container.decode(Kind.self, forKey: .type) {
+        case .textDelta:
+            self = try .textDelta(container.decode(String.self, forKey: .text))
+        case .toolCall:
+            self = try .toolCall(container.decode(ToolCall.self, forKey: .toolCall))
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case let .textDelta(value):
+            try container.encode(Kind.textDelta, forKey: .type)
+            try container.encode(value, forKey: .text)
+
+        case let .toolCall(value):
+            try container.encode(Kind.toolCall, forKey: .type)
+            try container.encode(value, forKey: .toolCall)
+        }
+    }
+}
+
+// MARK: - FinishReason
+
+public enum FinishReason: String, Hashable, Codable, Sendable {
+    case completed
+    case length
+    case toolCall = "tool_call"
+    case unknown
+}
+
+// MARK: - Usage
+
+public struct Usage: Hashable, Codable, Sendable {
+    public init(promptTokens: Int, completionTokens: Int) {
+        self.promptTokens = promptTokens
+        self.completionTokens = completionTokens
+    }
+
+    public var promptTokens: Int
+    public var completionTokens: Int
+    public var totalTokens: Int { promptTokens + completionTokens }
+}
+
+// MARK: - GenerationMetrics
+
+public struct GenerationMetrics: Hashable, Codable, Sendable {
+    public init(promptSeconds: Double, generationSeconds: Double, tokensPerSecond: Double) {
+        self.promptSeconds = promptSeconds
+        self.generationSeconds = generationSeconds
+        self.tokensPerSecond = tokensPerSecond
+    }
+
+    public var promptSeconds: Double
+    public var generationSeconds: Double
+    public var tokensPerSecond: Double
+}
+
+// MARK: - GenerationResponse
+
+public struct GenerationResponse: Hashable, Codable, Sendable {
+    public init(
+        output: String,
+        toolCalls: [ToolCall],
+        usage: Usage,
+        finishReason: FinishReason,
+        metrics: GenerationMetrics? = nil
+    ) {
+        self.output = output
+        self.toolCalls = toolCalls
+        self.usage = usage
+        self.finishReason = finishReason
+        self.metrics = metrics
+    }
+
+    public var output: String
+    public var toolCalls: [ToolCall]
+    public var usage: Usage
+    public var finishReason: FinishReason
+    public var metrics: GenerationMetrics?
+}
+
+// MARK: - EmbeddingRequest
+
+public struct EmbeddingRequest: Hashable, Codable, Sendable {
+    public init(model: ModelID, inputs: [String]) {
+        self.model = model
+        self.inputs = inputs
+    }
+
+    public var model: ModelID
+    public var inputs: [String]
+}
+
+// MARK: - EmbeddingResponse
+
+public struct EmbeddingResponse: Hashable, Codable, Sendable {
+    public init(embeddings: [[Float]], usage: Usage) {
+        self.embeddings = embeddings
+        self.usage = usage
+    }
+
+    public var embeddings: [[Float]]
+    public var usage: Usage
+}
+
+// MARK: - ModelCapabilities
+
+public struct ModelCapabilities: Hashable, Codable, Sendable {
+    public init(
+        textGeneration: Bool = false,
+        vision: Bool = false,
+        tools: Bool = false,
+        embeddings: Bool = false
+    ) {
+        self.textGeneration = textGeneration
+        self.vision = vision
+        self.tools = tools
+        self.embeddings = embeddings
+    }
+
+    public var textGeneration: Bool
+    public var vision: Bool
+    public var tools: Bool
+    public var embeddings: Bool
+}
+
+// MARK: - ModelInfo
+
+public struct ModelInfo: Identifiable, Hashable, Codable, Sendable {
+    public init(
+        id: ModelID,
+        created: Date,
+        sizeInBytes: Int64,
+        capabilities: ModelCapabilities
+    ) {
+        self.id = id
+        self.created = created
+        self.sizeInBytes = sizeInBytes
+        self.capabilities = capabilities
+    }
+
+    public var id: ModelID
+    public var created: Date
+    public var sizeInBytes: Int64
+    public var capabilities: ModelCapabilities
+}
+
+// MARK: - SwamaError
+
+public struct SwamaError: Error, Hashable, Codable, Sendable, LocalizedError {
+    public enum Code: String, Hashable, Codable, Sendable {
+        case invalidRequest = "invalid_request"
+        case invalidImage = "invalid_image"
+        case modelNotFound = "model_not_found"
+        case modelLoadFailed = "model_load_failed"
+        case contextLimitExceeded = "context_limit_exceeded"
+        case embeddingFailed = "embedding_failed"
+        case downloadFailed = "download_failed"
+        case removalFailed = "removal_failed"
+        case backendFailure = "backend_failure"
+    }
+
+    public init(code: Code, message: String, model: ModelID? = nil) {
+        self.code = code
+        self.message = message
+        self.model = model
+    }
+
+    public var code: Code
+    public var message: String
+    public var model: ModelID?
+    public var errorDescription: String? { message }
+}

--- a/swama/Sources/SwamaCore/SwamaEngine.swift
+++ b/swama/Sources/SwamaCore/SwamaEngine.swift
@@ -74,7 +74,7 @@ public actor SwamaEngine {
     }
 
     public func clearCache(for model: ModelID) async {
-        guard !model.rawValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        guard RuntimeCoreEngine.isValidModelID(model.rawValue) else {
             return
         }
 
@@ -92,11 +92,9 @@ public actor SwamaEngine {
         guard !request.messages.isEmpty else {
             throw invalidRequest("Generation requires at least one message.", model: request.model)
         }
-        guard request.messages.allSatisfy({ !$0.content.isEmpty || !$0.toolCalls.isEmpty }) else {
-            throw invalidRequest("Every message must contain content or tool calls.", model: request.model)
-        }
 
         for message in request.messages {
+            try validate(message, model: request.model)
             for part in message.content {
                 if case let .imageData(data, mediaType) = part,
                    data.isEmpty || mediaType.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -114,12 +112,18 @@ public actor SwamaEngine {
         }
         let options = request.options
         guard options.maxTokens.map({ $0 > 0 }) ?? true,
+              options.temperature.isFinite,
               options.temperature >= 0,
+              options.topP.isFinite,
               (0 ... 1).contains(options.topP),
               options.topK >= 0,
+              options.minP.isFinite,
               (0 ... 1).contains(options.minP),
+              options.repetitionPenalty.map({ $0.isFinite && $0 >= 0 }) ?? true,
               options.repetitionContextSize > 0,
+              options.presencePenalty.map({ $0.isFinite && (-2 ... 2).contains($0) }) ?? true,
               options.presenceContextSize > 0,
+              options.frequencyPenalty.map({ $0.isFinite && (-2 ... 2).contains($0) }) ?? true,
               options.frequencyContextSize > 0,
               options.contextLimit.map({ $0 > 0 }) ?? true
         else {
@@ -137,8 +141,25 @@ public actor SwamaEngine {
     }
 
     private func validate(_ model: ModelID) throws {
-        guard !model.rawValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            throw invalidRequest("Model identifier must be non-empty.", model: nil)
+        guard RuntimeCoreEngine.isValidModelID(model.rawValue) else {
+            throw invalidRequest("Model identifier is invalid.", model: nil)
+        }
+    }
+
+    private func validate(_ message: Message, model: ModelID) throws {
+        let toolCallID = message.toolCallID?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let isValid =
+            switch message.role {
+            case .system,
+                 .user:
+                !message.content.isEmpty && message.toolCalls.isEmpty && message.toolCallID == nil
+            case .assistant:
+                (!message.content.isEmpty || !message.toolCalls.isEmpty) && message.toolCallID == nil
+            case .tool:
+                !message.content.isEmpty && message.toolCalls.isEmpty && toolCallID?.isEmpty == false
+            }
+        guard isValid else {
+            throw invalidRequest("Message fields are invalid for its role.", model: model)
         }
     }
 

--- a/swama/Sources/SwamaCore/SwamaEngine.swift
+++ b/swama/Sources/SwamaCore/SwamaEngine.swift
@@ -89,7 +89,7 @@ public actor SwamaEngine {
 
     private func validate(_ request: GenerationRequest) throws {
         try validate(request.model)
-        guard !request.messages.isEmpty else {
+        guard request.messages.isEmpty == false else {
             throw invalidRequest("Generation requires at least one message.", model: request.model)
         }
 
@@ -104,7 +104,7 @@ public actor SwamaEngine {
             }
         }
         for tool in request.tools {
-            guard !tool.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+            guard tool.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false,
                   case .object = tool.parameters
             else {
                 throw invalidRequest("Tools require a name and an object parameter schema.", model: request.model)
@@ -133,8 +133,8 @@ public actor SwamaEngine {
 
     private func validate(_ request: EmbeddingRequest) throws {
         try validate(request.model)
-        guard !request.inputs.isEmpty,
-              request.inputs.allSatisfy({ !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty })
+        guard request.inputs.isEmpty == false,
+              request.inputs.allSatisfy({ $0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false })
         else {
             throw invalidRequest("Embedding inputs must be non-empty.", model: request.model)
         }
@@ -152,11 +152,14 @@ public actor SwamaEngine {
             switch message.role {
             case .system,
                  .user:
-                !message.content.isEmpty && message.toolCalls.isEmpty && message.toolCallID == nil
+                message.content.isEmpty == false && message.toolCalls.isEmpty && message.toolCallID == nil
             case .assistant:
-                (!message.content.isEmpty || !message.toolCalls.isEmpty) && message.toolCallID == nil
+                (message.content.isEmpty == false || message.toolCalls.isEmpty == false) && message.toolCallID == nil
             case .tool:
-                !message.content.isEmpty && message.toolCalls.isEmpty && toolCallID?.isEmpty == false
+                message.content.isEmpty == false &&
+                    message.content.allSatisfy(\.isText) &&
+                    message.toolCalls.isEmpty &&
+                    toolCallID?.isEmpty == false
             }
         guard isValid else {
             throw invalidRequest("Message fields are invalid for its role.", model: model)
@@ -165,6 +168,15 @@ public actor SwamaEngine {
 
     private func invalidRequest(_ message: String, model: ModelID?) -> SwamaError {
         .init(code: .invalidRequest, message: message, model: model)
+    }
+}
+
+private extension ContentPart {
+    var isText: Bool {
+        if case .text = self {
+            return true
+        }
+        return false
     }
 }
 
@@ -285,10 +297,14 @@ private extension Message {
 private extension Message.Role {
     var runtimeValue: RuntimeMessageRole {
         switch self {
-        case .system: .system
-        case .user: .user
-        case .assistant: .assistant
-        case .tool: .tool
+        case .system:
+            .system
+        case .user:
+            .user
+        case .assistant:
+            .assistant
+        case .tool:
+            .tool
         }
     }
 }
@@ -296,9 +312,12 @@ private extension Message.Role {
 private extension ContentPart {
     var runtimeValue: RuntimeContentPart {
         switch self {
-        case let .text(value): .text(value)
-        case let .imageURL(value): .imageURL(value)
-        case let .imageData(data, mediaType): .imageData(data, mediaType: mediaType)
+        case let .text(value):
+            .text(value)
+        case let .imageURL(value):
+            .imageURL(value)
+        case let .imageData(data, mediaType):
+            .imageData(data, mediaType: mediaType)
         }
     }
 }
@@ -306,13 +325,20 @@ private extension ContentPart {
 private extension JSONValue {
     var runtimeValue: RuntimeJSONValue {
         switch self {
-        case .null: .null
-        case let .bool(value): .bool(value)
-        case let .int(value): .int(value)
-        case let .double(value): .double(value)
-        case let .string(value): .string(value)
-        case let .array(value): .array(value.map(\.runtimeValue))
-        case let .object(value): .object(value.mapValues(\.runtimeValue))
+        case .null:
+            .null
+        case let .bool(value):
+            .bool(value)
+        case let .int(value):
+            .int(value)
+        case let .double(value):
+            .double(value)
+        case let .string(value):
+            .string(value)
+        case let .array(value):
+            .array(value.map(\.runtimeValue))
+        case let .object(value):
+            .object(value.mapValues(\.runtimeValue))
         }
     }
 }
@@ -320,13 +346,20 @@ private extension JSONValue {
 private extension RuntimeJSONValue {
     var coreValue: JSONValue {
         switch self {
-        case .null: .null
-        case let .bool(value): .bool(value)
-        case let .int(value): .int(value)
-        case let .double(value): .double(value)
-        case let .string(value): .string(value)
-        case let .array(value): .array(value.map(\.coreValue))
-        case let .object(value): .object(value.mapValues(\.coreValue))
+        case .null:
+            .null
+        case let .bool(value):
+            .bool(value)
+        case let .int(value):
+            .int(value)
+        case let .double(value):
+            .double(value)
+        case let .string(value):
+            .string(value)
+        case let .array(value):
+            .array(value.map(\.coreValue))
+        case let .object(value):
+            .object(value.mapValues(\.coreValue))
         }
     }
 }
@@ -372,8 +405,10 @@ private extension GenerationOptions {
 private extension RuntimeGenerationEvent {
     var coreValue: GenerationEvent {
         switch self {
-        case let .textDelta(value): .textDelta(value)
-        case let .toolCall(value): .toolCall(value.coreValue)
+        case let .textDelta(value):
+            .textDelta(value)
+        case let .toolCall(value):
+            .toolCall(value.coreValue)
         }
     }
 }
@@ -399,9 +434,12 @@ private extension RuntimeUsage {
 private extension RuntimeFinishReason {
     var coreValue: FinishReason {
         switch self {
-        case .completed: .completed
-        case .length: .length
-        case .toolCall: .toolCall
+        case .completed:
+            .completed
+        case .length:
+            .length
+        case .toolCall:
+            .toolCall
         }
     }
 }
@@ -448,15 +486,24 @@ private extension RuntimeCoreError {
     var coreValue: SwamaError {
         let coreCode: SwamaError.Code =
             switch code {
-            case .invalidRequest: .invalidRequest
-            case .invalidImage: .invalidImage
-            case .modelNotFound: .modelNotFound
-            case .modelLoadFailed: .modelLoadFailed
-            case .contextLimitExceeded: .contextLimitExceeded
-            case .embeddingFailed: .embeddingFailed
-            case .downloadFailed: .downloadFailed
-            case .removalFailed: .removalFailed
-            case .backendFailure: .backendFailure
+            case .invalidRequest:
+                .invalidRequest
+            case .invalidImage:
+                .invalidImage
+            case .modelNotFound:
+                .modelNotFound
+            case .modelLoadFailed:
+                .modelLoadFailed
+            case .contextLimitExceeded:
+                .contextLimitExceeded
+            case .embeddingFailed:
+                .embeddingFailed
+            case .downloadFailed:
+                .downloadFailed
+            case .removalFailed:
+                .removalFailed
+            case .backendFailure:
+                .backendFailure
             }
         return .init(
             code: coreCode,
@@ -469,15 +516,24 @@ private extension RuntimeCoreError {
 private extension SwamaError.Code {
     var safeMessage: String {
         switch self {
-        case .invalidRequest: "The request is invalid."
-        case .invalidImage: "An image could not be decoded."
-        case .modelNotFound: "The requested model is not available locally."
-        case .modelLoadFailed: "The requested model could not be loaded."
-        case .contextLimitExceeded: "The request exceeds the configured context limit."
-        case .embeddingFailed: "The embedding request failed."
-        case .downloadFailed: "The model could not be downloaded."
-        case .removalFailed: "The model could not be removed."
-        case .backendFailure: "The local model backend failed."
+        case .invalidRequest:
+            "The request is invalid."
+        case .invalidImage:
+            "An image could not be decoded."
+        case .modelNotFound:
+            "The requested model is not available locally."
+        case .modelLoadFailed:
+            "The requested model could not be loaded."
+        case .contextLimitExceeded:
+            "The request exceeds the configured context limit."
+        case .embeddingFailed:
+            "The embedding request failed."
+        case .downloadFailed:
+            "The model could not be downloaded."
+        case .removalFailed:
+            "The model could not be removed."
+        case .backendFailure:
+            "The local model backend failed."
         }
     }
 }

--- a/swama/Sources/SwamaCore/SwamaEngine.swift
+++ b/swama/Sources/SwamaCore/SwamaEngine.swift
@@ -1,0 +1,462 @@
+import Foundation
+import SwamaRuntime
+
+// MARK: - SwamaEngine
+
+public actor SwamaEngine {
+    public init(configuration: SwamaConfiguration = .init()) {
+        backend = RuntimeEngineBackend(configuration: configuration)
+    }
+
+    init(backend: any SwamaEngineBackend) {
+        self.backend = backend
+    }
+
+    public func generate(
+        _ request: GenerationRequest,
+        onEvent: (@Sendable (GenerationEvent) async throws -> Void)? = nil
+    ) async throws -> GenerationResponse {
+        try validate(request)
+        do {
+            let response = try await backend.generate(request, onEvent: onEvent)
+            try Task.checkCancellation()
+            return response
+        }
+        catch is CancellationError {
+            throw CancellationError()
+        }
+        catch let error as SwamaError {
+            throw error
+        }
+        catch {
+            throw SwamaError(
+                code: .backendFailure,
+                message: "The local model backend failed.",
+                model: request.model
+            )
+        }
+    }
+
+    public func embed(_ request: EmbeddingRequest) async throws -> EmbeddingResponse {
+        try validate(request)
+        do {
+            let response = try await backend.embed(request)
+            try Task.checkCancellation()
+            return response
+        }
+        catch is CancellationError {
+            throw CancellationError()
+        }
+        catch let error as SwamaError {
+            throw error
+        }
+        catch {
+            throw SwamaError(
+                code: .backendFailure,
+                message: "The local embedding backend failed.",
+                model: request.model
+            )
+        }
+    }
+
+    public func models() async throws -> [ModelInfo] {
+        try await backend.models()
+    }
+
+    public func fetch(_ model: ModelID) async throws {
+        try validate(model)
+        try await backend.fetch(model)
+    }
+
+    public func remove(_ model: ModelID) async throws {
+        try validate(model)
+        try await backend.remove(model)
+    }
+
+    public func clearCache(for model: ModelID) async {
+        guard !model.rawValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return
+        }
+
+        await backend.clearCache(for: model)
+    }
+
+    public func clearCache() async {
+        await backend.clearCache()
+    }
+
+    private let backend: any SwamaEngineBackend
+
+    private func validate(_ request: GenerationRequest) throws {
+        try validate(request.model)
+        guard !request.messages.isEmpty else {
+            throw invalidRequest("Generation requires at least one message.", model: request.model)
+        }
+        guard request.messages.allSatisfy({ !$0.content.isEmpty || !$0.toolCalls.isEmpty }) else {
+            throw invalidRequest("Every message must contain content or tool calls.", model: request.model)
+        }
+
+        for message in request.messages {
+            for part in message.content {
+                if case let .imageData(data, mediaType) = part,
+                   data.isEmpty || mediaType.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                {
+                    throw invalidRequest("Image data and media type must be non-empty.", model: request.model)
+                }
+            }
+        }
+        for tool in request.tools {
+            guard !tool.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                  case .object = tool.parameters
+            else {
+                throw invalidRequest("Tools require a name and an object parameter schema.", model: request.model)
+            }
+        }
+        let options = request.options
+        guard options.maxTokens.map({ $0 > 0 }) ?? true,
+              options.temperature >= 0,
+              (0 ... 1).contains(options.topP),
+              options.topK >= 0,
+              (0 ... 1).contains(options.minP),
+              options.repetitionContextSize > 0,
+              options.presenceContextSize > 0,
+              options.frequencyContextSize > 0,
+              options.contextLimit.map({ $0 > 0 }) ?? true
+        else {
+            throw invalidRequest("Generation options are outside their supported ranges.", model: request.model)
+        }
+    }
+
+    private func validate(_ request: EmbeddingRequest) throws {
+        try validate(request.model)
+        guard !request.inputs.isEmpty,
+              request.inputs.allSatisfy({ !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty })
+        else {
+            throw invalidRequest("Embedding inputs must be non-empty.", model: request.model)
+        }
+    }
+
+    private func validate(_ model: ModelID) throws {
+        guard !model.rawValue.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw invalidRequest("Model identifier must be non-empty.", model: nil)
+        }
+    }
+
+    private func invalidRequest(_ message: String, model: ModelID?) -> SwamaError {
+        .init(code: .invalidRequest, message: message, model: model)
+    }
+}
+
+// MARK: - SwamaEngineBackend
+
+protocol SwamaEngineBackend: Sendable {
+    func generate(
+        _ request: GenerationRequest,
+        onEvent: (@Sendable (GenerationEvent) async throws -> Void)?
+    ) async throws -> GenerationResponse
+
+    func embed(_ request: EmbeddingRequest) async throws -> EmbeddingResponse
+    func models() async throws -> [ModelInfo]
+    func fetch(_ model: ModelID) async throws
+    func remove(_ model: ModelID) async throws
+    func clearCache(for model: ModelID) async
+    func clearCache() async
+}
+
+// MARK: - RuntimeEngineBackend
+
+private struct RuntimeEngineBackend: SwamaEngineBackend {
+    init(configuration: SwamaConfiguration) {
+        runtime = RuntimeCoreEngine(defaultContextLimit: configuration.defaultContextLimit)
+    }
+
+    func generate(
+        _ request: GenerationRequest,
+        onEvent: (@Sendable (GenerationEvent) async throws -> Void)?
+    ) async throws -> GenerationResponse {
+        do {
+            let result = try await runtime.generate(request.runtimeValue) { event in
+                try await onEvent?(event.coreValue)
+            }
+            return result.coreValue
+        }
+        catch is CancellationError {
+            throw CancellationError()
+        }
+        catch let error as RuntimeCoreError {
+            throw error.coreValue
+        }
+    }
+
+    func embed(_ request: EmbeddingRequest) async throws -> EmbeddingResponse {
+        do {
+            return try await runtime.embed(.init(
+                model: request.model.rawValue,
+                inputs: request.inputs
+            ))
+            .coreValue
+        }
+        catch is CancellationError {
+            throw CancellationError()
+        }
+        catch let error as RuntimeCoreError {
+            throw error.coreValue
+        }
+    }
+
+    func models() async throws -> [ModelInfo] {
+        await runtime.models().map(\.coreValue)
+    }
+
+    func fetch(_ model: ModelID) async throws {
+        do {
+            try await runtime.fetch(model.rawValue)
+        }
+        catch let error as RuntimeCoreError {
+            throw error.coreValue
+        }
+    }
+
+    func remove(_ model: ModelID) async throws {
+        do {
+            try await runtime.remove(model.rawValue)
+        }
+        catch let error as RuntimeCoreError {
+            throw error.coreValue
+        }
+    }
+
+    func clearCache(for model: ModelID) async {
+        await runtime.clearCache(for: model.rawValue)
+    }
+
+    func clearCache() async {
+        await runtime.clearCache()
+    }
+
+    private let runtime: RuntimeCoreEngine
+}
+
+// MARK: - Runtime mapping
+
+private extension GenerationRequest {
+    var runtimeValue: RuntimeGenerationRequest {
+        .init(
+            model: model.rawValue,
+            messages: messages.map(\.runtimeValue),
+            options: options.runtimeValue,
+            tools: tools.map(\.runtimeValue)
+        )
+    }
+}
+
+private extension Message {
+    var runtimeValue: RuntimeMessage {
+        .init(
+            role: role.runtimeValue,
+            content: content.map(\.runtimeValue),
+            toolCalls: toolCalls.map(\.runtimeValue),
+            toolCallID: toolCallID
+        )
+    }
+}
+
+private extension Message.Role {
+    var runtimeValue: RuntimeMessageRole {
+        switch self {
+        case .system: .system
+        case .user: .user
+        case .assistant: .assistant
+        case .tool: .tool
+        }
+    }
+}
+
+private extension ContentPart {
+    var runtimeValue: RuntimeContentPart {
+        switch self {
+        case let .text(value): .text(value)
+        case let .imageURL(value): .imageURL(value)
+        case let .imageData(data, mediaType): .imageData(data, mediaType: mediaType)
+        }
+    }
+}
+
+private extension JSONValue {
+    var runtimeValue: RuntimeJSONValue {
+        switch self {
+        case .null: .null
+        case let .bool(value): .bool(value)
+        case let .int(value): .int(value)
+        case let .double(value): .double(value)
+        case let .string(value): .string(value)
+        case let .array(value): .array(value.map(\.runtimeValue))
+        case let .object(value): .object(value.mapValues(\.runtimeValue))
+        }
+    }
+}
+
+private extension RuntimeJSONValue {
+    var coreValue: JSONValue {
+        switch self {
+        case .null: .null
+        case let .bool(value): .bool(value)
+        case let .int(value): .int(value)
+        case let .double(value): .double(value)
+        case let .string(value): .string(value)
+        case let .array(value): .array(value.map(\.coreValue))
+        case let .object(value): .object(value.mapValues(\.coreValue))
+        }
+    }
+}
+
+private extension ToolDefinition {
+    var runtimeValue: RuntimeToolDefinition {
+        .init(name: name, description: description, parameters: parameters.runtimeValue)
+    }
+}
+
+private extension ToolCall {
+    var runtimeValue: RuntimeToolCall {
+        .init(id: id, name: name, arguments: arguments.mapValues(\.runtimeValue))
+    }
+}
+
+private extension RuntimeToolCall {
+    var coreValue: ToolCall {
+        .init(id: id, name: name, arguments: arguments.mapValues(\.coreValue))
+    }
+}
+
+private extension GenerationOptions {
+    var runtimeValue: RuntimeGenerationOptions {
+        .init(
+            maxTokens: maxTokens,
+            temperature: temperature,
+            topP: topP,
+            topK: topK,
+            minP: minP,
+            repetitionPenalty: repetitionPenalty,
+            repetitionContextSize: repetitionContextSize,
+            presencePenalty: presencePenalty,
+            presenceContextSize: presenceContextSize,
+            frequencyPenalty: frequencyPenalty,
+            frequencyContextSize: frequencyContextSize,
+            seed: seed,
+            contextLimit: contextLimit
+        )
+    }
+}
+
+private extension RuntimeGenerationEvent {
+    var coreValue: GenerationEvent {
+        switch self {
+        case let .textDelta(value): .textDelta(value)
+        case let .toolCall(value): .toolCall(value.coreValue)
+        }
+    }
+}
+
+private extension RuntimeGenerationResult {
+    var coreValue: GenerationResponse {
+        .init(
+            output: output,
+            toolCalls: toolCalls.map(\.coreValue),
+            usage: usage.coreValue,
+            finishReason: finishReason.coreValue,
+            metrics: metrics?.coreValue
+        )
+    }
+}
+
+private extension RuntimeUsage {
+    var coreValue: Usage {
+        .init(promptTokens: promptTokens, completionTokens: completionTokens)
+    }
+}
+
+private extension RuntimeFinishReason {
+    var coreValue: FinishReason {
+        switch self {
+        case .completed: .completed
+        case .length: .length
+        case .toolCall: .toolCall
+        }
+    }
+}
+
+private extension RuntimeGenerationMetrics {
+    var coreValue: GenerationMetrics {
+        .init(
+            promptSeconds: promptSeconds,
+            generationSeconds: generationSeconds,
+            tokensPerSecond: tokensPerSecond
+        )
+    }
+}
+
+private extension RuntimeEmbeddingResult {
+    var coreValue: EmbeddingResponse {
+        .init(embeddings: embeddings, usage: usage.coreValue)
+    }
+}
+
+private extension RuntimeModelInfo {
+    var coreValue: ModelInfo {
+        .init(
+            id: .init(id),
+            created: Date(timeIntervalSince1970: TimeInterval(created)),
+            sizeInBytes: sizeInBytes,
+            capabilities: capabilities.coreValue
+        )
+    }
+}
+
+private extension RuntimeModelCapabilities {
+    var coreValue: ModelCapabilities {
+        .init(
+            textGeneration: textGeneration,
+            vision: vision,
+            tools: tools,
+            embeddings: embeddings
+        )
+    }
+}
+
+private extension RuntimeCoreError {
+    var coreValue: SwamaError {
+        let coreCode: SwamaError.Code =
+            switch code {
+            case .invalidRequest: .invalidRequest
+            case .invalidImage: .invalidImage
+            case .modelNotFound: .modelNotFound
+            case .modelLoadFailed: .modelLoadFailed
+            case .contextLimitExceeded: .contextLimitExceeded
+            case .embeddingFailed: .embeddingFailed
+            case .downloadFailed: .downloadFailed
+            case .removalFailed: .removalFailed
+            case .backendFailure: .backendFailure
+            }
+        return .init(
+            code: coreCode,
+            message: coreCode.safeMessage,
+            model: model.map { ModelID($0) }
+        )
+    }
+}
+
+private extension SwamaError.Code {
+    var safeMessage: String {
+        switch self {
+        case .invalidRequest: "The request is invalid."
+        case .invalidImage: "An image could not be decoded."
+        case .modelNotFound: "The requested model is not available locally."
+        case .modelLoadFailed: "The requested model could not be loaded."
+        case .contextLimitExceeded: "The request exceeds the configured context limit."
+        case .embeddingFailed: "The embedding request failed."
+        case .downloadFailed: "The model could not be downloaded."
+        case .removalFailed: "The model could not be removed."
+        case .backendFailure: "The local model backend failed."
+        }
+    }
+}

--- a/swama/Sources/SwamaRuntime/CoreBridge/RuntimeCoreEngine.swift
+++ b/swama/Sources/SwamaRuntime/CoreBridge/RuntimeCoreEngine.swift
@@ -526,15 +526,16 @@ package actor RuntimeCoreEngine {
     }
 
     private nonisolated static func isVersionSeparatedNemotronAudio(_ components: [Substring]) -> Bool {
-        guard let familyIndex = components.firstIndex(of: "nemotron") else {
-            return false
+        for familyIndex in components.indices where components[familyIndex] == "nemotron" {
+            let nextFamily = components
+                .dropFirst(familyIndex + 1)
+                .drop(while: { $0.allSatisfy(\.isNumber) })
+                .first
+            if nextFamily == "asr" || nextFamily == "speech" {
+                return true
+            }
         }
-
-        let nextFamily = components
-            .dropFirst(familyIndex + 1)
-            .drop(while: { $0.allSatisfy(\.isNumber) })
-            .first
-        return nextFamily == "asr" || nextFamily == "speech"
+        return false
     }
 
     private nonisolated static func containsComponentSequence(

--- a/swama/Sources/SwamaRuntime/CoreBridge/RuntimeCoreEngine.swift
+++ b/swama/Sources/SwamaRuntime/CoreBridge/RuntimeCoreEngine.swift
@@ -506,6 +506,9 @@ package actor RuntimeCoreEngine {
         }) {
             return true
         }
+        if isVersionSeparatedNemotronAudio(components) {
+            return true
+        }
         let families = [
             ["whisper"], ["funasr"], ["qwen3", "asr"], ["glm", "asr"], ["glmasr"],
             ["sensevoice"], ["voxtral"], ["cohere", "transcribe"], ["parakeet"],
@@ -520,6 +523,18 @@ package actor RuntimeCoreEngine {
         return families.contains { family in
             containsComponentSequence(family, in: components)
         }
+    }
+
+    private nonisolated static func isVersionSeparatedNemotronAudio(_ components: [Substring]) -> Bool {
+        guard let familyIndex = components.firstIndex(of: "nemotron") else {
+            return false
+        }
+
+        let nextFamily = components
+            .dropFirst(familyIndex + 1)
+            .drop(while: { $0.allSatisfy(\.isNumber) })
+            .first
+        return nextFamily == "asr" || nextFamily == "speech"
     }
 
     private nonisolated static func containsComponentSequence(

--- a/swama/Sources/SwamaRuntime/CoreBridge/RuntimeCoreEngine.swift
+++ b/swama/Sources/SwamaRuntime/CoreBridge/RuntimeCoreEngine.swift
@@ -1,0 +1,639 @@
+import CoreImage
+import Foundation
+import MLXLMCommon
+
+// MARK: - RuntimeMessageRole
+
+package enum RuntimeMessageRole: String, Sendable {
+    case system
+    case user
+    case assistant
+    case tool
+}
+
+// MARK: - RuntimeContentPart
+
+package enum RuntimeContentPart: Sendable {
+    case text(String)
+    case imageURL(URL)
+    case imageData(Data, mediaType: String)
+}
+
+// MARK: - RuntimeJSONValue
+
+package enum RuntimeJSONValue: Hashable, Sendable {
+    case null
+    case bool(Bool)
+    case int(Int)
+    case double(Double)
+    case string(String)
+    case array([RuntimeJSONValue])
+    case object([String: RuntimeJSONValue])
+
+    var sendableValue: any Sendable {
+        switch self {
+        case .null:
+            NSNull()
+        case let .bool(value):
+            value
+        case let .int(value):
+            value
+        case let .double(value):
+            value
+        case let .string(value):
+            value
+        case let .array(value):
+            value.map(\.sendableValue)
+        case let .object(value):
+            value.mapValues(\.sendableValue)
+        }
+    }
+
+    init(_ value: MLXLMCommon.JSONValue) {
+        self =
+            switch value {
+            case .null:
+                .null
+            case let .bool(value):
+                .bool(value)
+            case let .int(value):
+                .int(value)
+            case let .double(value):
+                .double(value)
+            case let .string(value):
+                .string(value)
+            case let .array(value):
+                .array(value.map(Self.init))
+            case let .object(value):
+                .object(value.mapValues(Self.init))
+            }
+    }
+}
+
+// MARK: - RuntimeToolCall
+
+package struct RuntimeToolCall: Hashable, Sendable {
+    package init(id: String?, name: String, arguments: [String: RuntimeJSONValue]) {
+        self.id = id
+        self.name = name
+        self.arguments = arguments
+    }
+
+    package let id: String?
+    package let name: String
+    package let arguments: [String: RuntimeJSONValue]
+
+    init(_ value: MLXLMCommon.ToolCall) {
+        id = value.id
+        name = value.function.name
+        arguments = value.function.arguments.mapValues(RuntimeJSONValue.init)
+    }
+
+    var mlxValue: MLXLMCommon.ToolCall {
+        .init(
+            function: .init(
+                name: name,
+                arguments: arguments.mapValues { value in
+                    MLXLMCommon.JSONValue.from(value.sendableValue)
+                }
+            ),
+            id: id
+        )
+    }
+}
+
+// MARK: - RuntimeToolDefinition
+
+package struct RuntimeToolDefinition: Hashable, Sendable {
+    package init(name: String, description: String?, parameters: RuntimeJSONValue) {
+        self.name = name
+        self.description = description
+        self.parameters = parameters
+    }
+
+    package let name: String
+    package let description: String?
+    package let parameters: RuntimeJSONValue
+
+    var mlxValue: [String: any Sendable] {
+        var function: [String: any Sendable] = [
+            "name": name,
+            "parameters": parameters.sendableValue
+        ]
+        if let description {
+            function["description"] = description
+        }
+        return [
+            "type": "function",
+            "function": function
+        ]
+    }
+}
+
+// MARK: - RuntimeMessage
+
+package struct RuntimeMessage: Sendable {
+    package init(
+        role: RuntimeMessageRole,
+        content: [RuntimeContentPart],
+        toolCalls: [RuntimeToolCall],
+        toolCallID: String?
+    ) {
+        self.role = role
+        self.content = content
+        self.toolCalls = toolCalls
+        self.toolCallID = toolCallID
+    }
+
+    package let role: RuntimeMessageRole
+    package let content: [RuntimeContentPart]
+    package let toolCalls: [RuntimeToolCall]
+    package let toolCallID: String?
+}
+
+// MARK: - RuntimeGenerationOptions
+
+package struct RuntimeGenerationOptions: Sendable {
+    package init(
+        maxTokens: Int?,
+        temperature: Float,
+        topP: Float,
+        topK: Int,
+        minP: Float,
+        repetitionPenalty: Float?,
+        repetitionContextSize: Int,
+        presencePenalty: Float?,
+        presenceContextSize: Int,
+        frequencyPenalty: Float?,
+        frequencyContextSize: Int,
+        seed: UInt64?,
+        contextLimit: Int?
+    ) {
+        self.maxTokens = maxTokens
+        self.temperature = temperature
+        self.topP = topP
+        self.topK = topK
+        self.minP = minP
+        self.repetitionPenalty = repetitionPenalty
+        self.repetitionContextSize = repetitionContextSize
+        self.presencePenalty = presencePenalty
+        self.presenceContextSize = presenceContextSize
+        self.frequencyPenalty = frequencyPenalty
+        self.frequencyContextSize = frequencyContextSize
+        self.seed = seed
+        self.contextLimit = contextLimit
+    }
+
+    package let maxTokens: Int?
+    package let temperature: Float
+    package let topP: Float
+    package let topK: Int
+    package let minP: Float
+    package let repetitionPenalty: Float?
+    package let repetitionContextSize: Int
+    package let presencePenalty: Float?
+    package let presenceContextSize: Int
+    package let frequencyPenalty: Float?
+    package let frequencyContextSize: Int
+    package let seed: UInt64?
+    package let contextLimit: Int?
+}
+
+// MARK: - RuntimeGenerationRequest
+
+package struct RuntimeGenerationRequest: Sendable {
+    package init(
+        model: String,
+        messages: [RuntimeMessage],
+        options: RuntimeGenerationOptions,
+        tools: [RuntimeToolDefinition]
+    ) {
+        self.model = model
+        self.messages = messages
+        self.options = options
+        self.tools = tools
+    }
+
+    package let model: String
+    package let messages: [RuntimeMessage]
+    package let options: RuntimeGenerationOptions
+    package let tools: [RuntimeToolDefinition]
+}
+
+// MARK: - RuntimeGenerationEvent
+
+package enum RuntimeGenerationEvent: Sendable {
+    case textDelta(String)
+    case toolCall(RuntimeToolCall)
+}
+
+// MARK: - RuntimeFinishReason
+
+package enum RuntimeFinishReason: String, Sendable {
+    case completed
+    case length
+    case toolCall
+}
+
+// MARK: - RuntimeUsage
+
+package struct RuntimeUsage: Hashable, Sendable {
+    package init(promptTokens: Int, completionTokens: Int) {
+        self.promptTokens = promptTokens
+        self.completionTokens = completionTokens
+    }
+
+    package let promptTokens: Int
+    package let completionTokens: Int
+
+    package var totalTokens: Int { promptTokens + completionTokens }
+}
+
+// MARK: - RuntimeGenerationMetrics
+
+package struct RuntimeGenerationMetrics: Hashable, Sendable {
+    package init(promptSeconds: Double, generationSeconds: Double, tokensPerSecond: Double) {
+        self.promptSeconds = promptSeconds
+        self.generationSeconds = generationSeconds
+        self.tokensPerSecond = tokensPerSecond
+    }
+
+    package let promptSeconds: Double
+    package let generationSeconds: Double
+    package let tokensPerSecond: Double
+}
+
+// MARK: - RuntimeGenerationResult
+
+package struct RuntimeGenerationResult: Sendable {
+    package let output: String
+    package let toolCalls: [RuntimeToolCall]
+    package let usage: RuntimeUsage
+    package let finishReason: RuntimeFinishReason
+    package let metrics: RuntimeGenerationMetrics?
+}
+
+// MARK: - RuntimeEmbeddingRequest
+
+package struct RuntimeEmbeddingRequest: Sendable {
+    package init(model: String, inputs: [String]) {
+        self.model = model
+        self.inputs = inputs
+    }
+
+    package let model: String
+    package let inputs: [String]
+}
+
+// MARK: - RuntimeEmbeddingResult
+
+package struct RuntimeEmbeddingResult: Sendable {
+    package let embeddings: [[Float]]
+    package let usage: RuntimeUsage
+}
+
+// MARK: - RuntimeModelCapabilities
+
+package struct RuntimeModelCapabilities: Hashable, Sendable {
+    package init(textGeneration: Bool, vision: Bool, tools: Bool, embeddings: Bool) {
+        self.textGeneration = textGeneration
+        self.vision = vision
+        self.tools = tools
+        self.embeddings = embeddings
+    }
+
+    package let textGeneration: Bool
+    package let vision: Bool
+    package let tools: Bool
+    package let embeddings: Bool
+}
+
+// MARK: - RuntimeModelInfo
+
+package struct RuntimeModelInfo: Sendable {
+    package let id: String
+    package let created: Int
+    package let sizeInBytes: Int64
+    package let capabilities: RuntimeModelCapabilities
+}
+
+// MARK: - RuntimeCoreErrorCode
+
+package enum RuntimeCoreErrorCode: String, Sendable {
+    case invalidRequest
+    case invalidImage
+    case modelNotFound
+    case modelLoadFailed
+    case contextLimitExceeded
+    case embeddingFailed
+    case downloadFailed
+    case removalFailed
+    case backendFailure
+}
+
+// MARK: - RuntimeCoreError
+
+package struct RuntimeCoreError: Error, Sendable {
+    package let code: RuntimeCoreErrorCode
+    package let model: String?
+}
+
+// MARK: - RuntimeCoreEngine
+
+package actor RuntimeCoreEngine {
+    package init(defaultContextLimit: Int? = nil) {
+        pool = ModelPool()
+        self.defaultContextLimit = defaultContextLimit
+    }
+
+    init(pool: ModelPool, defaultContextLimit: Int? = nil) {
+        self.pool = pool
+        self.defaultContextLimit = defaultContextLimit
+    }
+
+    package func generate(
+        _ request: RuntimeGenerationRequest,
+        onEvent: (@Sendable (RuntimeGenerationEvent) async throws -> Void)? = nil
+    ) async throws -> RuntimeGenerationResult {
+        try rejectUnsupportedAudioModel(request.model)
+        do {
+            let parameters = makeParameters(request.options)
+            let contextLimit = request.options.contextLimit ?? defaultContextLimit
+            let messages = request.messages
+            let tools = request.tools
+            let result = try await pool.run(modelName: request.model) { runner in
+                let input = try self.makeUserInput(messages, tools: tools)
+                return try await runner.runChat(
+                    userInput: input,
+                    parameters: parameters,
+                    contextLimit: contextLimit,
+                    onToken: { token in
+                        try await onEvent?(.textDelta(token))
+                    },
+                    onToolCall: { toolCall in
+                        try await onEvent?(.toolCall(.init(toolCall)))
+                    }
+                )
+            }
+
+            try Task.checkCancellation()
+            if result.completionInfo?.stopReason == .cancelled {
+                throw CancellationError()
+            }
+
+            let toolCalls = result.toolCalls.map(RuntimeToolCall.init)
+            let completionTokens = result.completionInfo?.generationTokenCount ?? 0
+            return RuntimeGenerationResult(
+                output: result.output,
+                toolCalls: toolCalls,
+                usage: .init(
+                    promptTokens: result.promptTokens,
+                    completionTokens: completionTokens
+                ),
+                finishReason: finishReason(
+                    result.completionInfo?.stopReason,
+                    hasToolCalls: !toolCalls.isEmpty
+                ),
+                metrics: result.completionInfo.map {
+                    .init(
+                        promptSeconds: $0.promptTime,
+                        generationSeconds: $0.generateTime,
+                        tokensPerSecond: $0.tokensPerSecond
+                    )
+                }
+            )
+        }
+        catch is CancellationError {
+            throw CancellationError()
+        }
+        catch {
+            throw mapError(error, model: request.model, fallback: .backendFailure)
+        }
+    }
+
+    package func embed(_ request: RuntimeEmbeddingRequest) async throws -> RuntimeEmbeddingResult {
+        try rejectUnsupportedAudioModel(request.model)
+        do {
+            let result = try await pool.runEmbeddingWithConcurrencyControl(modelName: request.model) { runner in
+                try await runner.generateEmbeddings(inputs: request.inputs)
+            }
+            try Task.checkCancellation()
+            return .init(
+                embeddings: result.embeddings,
+                usage: .init(promptTokens: result.usage.promptTokens, completionTokens: 0)
+            )
+        }
+        catch is CancellationError {
+            throw CancellationError()
+        }
+        catch {
+            throw mapError(error, model: request.model, fallback: .embeddingFailed)
+        }
+    }
+
+    package func models() -> [RuntimeModelInfo] {
+        ModelManager.models()
+            .filter { !Self.isUnsupportedAudioModelID($0.id) }
+            .map { model in
+                RuntimeModelInfo(
+                    id: model.id,
+                    created: model.created,
+                    sizeInBytes: model.sizeInBytes,
+                    capabilities: capabilities(for: model.id)
+                )
+            }
+            .sorted { $0.id < $1.id }
+    }
+
+    package func fetch(_ model: String) async throws {
+        try rejectUnsupportedAudioModel(model)
+        do {
+            _ = try await ModelDownloader.fetchModel(modelName: model)
+        }
+        catch {
+            throw mapError(error, model: model, fallback: .downloadFailed)
+        }
+    }
+
+    package func remove(_ model: String) async throws {
+        try rejectUnsupportedAudioModel(model)
+        await pool.remove(modelName: model)
+        do {
+            guard try ModelPaths.removeModel(model) else {
+                throw RuntimeCoreError(code: .modelNotFound, model: model)
+            }
+        }
+        catch let error as RuntimeCoreError {
+            throw error
+        }
+        catch {
+            throw RuntimeCoreError(code: .removalFailed, model: model)
+        }
+    }
+
+    package func clearCache(for model: String) async {
+        guard !Self.isUnsupportedAudioModelID(model) else {
+            return
+        }
+
+        await pool.remove(modelName: model)
+    }
+
+    package func clearCache() async {
+        await pool.clearCache()
+    }
+
+    private let pool: ModelPool
+    private let defaultContextLimit: Int?
+
+    static func isUnsupportedAudioModelID(_ model: String) -> Bool {
+        let value = model.lowercased()
+        let markers = [
+            "whisper", "qwen3-asr", "glm-asr", "glmasr", "sensevoice", "voxtral",
+            "parakeet", "moss-transcribe", "nemotron", "canary", "moonshine", "wav2vec",
+            "mms-", "granite-speech", "tts", "orpheus", "marvis", "chatterbox", "vyvo",
+            "fish-speech", "soprano", "kokoro", "cosyvoice", "omnivoice"
+        ]
+        return markers.contains(where: value.contains)
+    }
+
+    private func rejectUnsupportedAudioModel(_ model: String) throws {
+        guard !Self.isUnsupportedAudioModelID(model) else {
+            throw RuntimeCoreError(code: .invalidRequest, model: model)
+        }
+    }
+
+    private nonisolated func makeUserInput(
+        _ messages: [RuntimeMessage],
+        tools: [RuntimeToolDefinition]
+    ) throws -> MLXLMCommon.UserInput {
+        let chat = try messages.map(makeChatMessage)
+        return .init(
+            chat: chat,
+            tools: tools.isEmpty ? nil : tools.map(\.mlxValue)
+        )
+    }
+
+    private nonisolated func makeChatMessage(_ message: RuntimeMessage) throws -> MLXLMCommon.Chat.Message {
+        var textParts: [String] = []
+        var images: [MLXLMCommon.UserInput.Image] = []
+        for part in message.content {
+            switch part {
+            case let .text(text):
+                textParts.append(text)
+            case let .imageURL(url):
+                images.append(.url(url))
+            case let .imageData(data, _):
+                guard let image = CIImage(data: data) else {
+                    throw RuntimeCoreError(code: .invalidImage, model: nil)
+                }
+
+                images.append(.ciImage(image))
+            }
+        }
+        let text = textParts.joined(separator: "\n")
+
+        switch message.role {
+        case .system:
+            return .system(text, images: images)
+
+        case .user:
+            return .user(text, images: images)
+
+        case .assistant:
+            return .assistant(
+                text,
+                images: images,
+                toolCalls: message.toolCalls.isEmpty ? nil : message.toolCalls.map(\.mlxValue)
+            )
+
+        case .tool:
+            return .tool(text, id: message.toolCallID)
+        }
+    }
+
+    private func makeParameters(_ options: RuntimeGenerationOptions) -> GenerateParameters {
+        .init(
+            maxTokens: options.maxTokens,
+            temperature: options.temperature,
+            topP: options.topP,
+            topK: options.topK,
+            minP: options.minP,
+            repetitionPenalty: options.repetitionPenalty,
+            repetitionContextSize: options.repetitionContextSize,
+            presencePenalty: options.presencePenalty,
+            presenceContextSize: options.presenceContextSize,
+            frequencyPenalty: options.frequencyPenalty,
+            frequencyContextSize: options.frequencyContextSize,
+            seed: options.seed
+        )
+    }
+
+    private func finishReason(
+        _ stopReason: GenerateStopReason?,
+        hasToolCalls: Bool
+    ) -> RuntimeFinishReason {
+        if hasToolCalls {
+            return .toolCall
+        }
+        return stopReason == .length ? .length : .completed
+    }
+
+    private func capabilities(for model: String) -> RuntimeModelCapabilities {
+        Self.capabilities(for: model, modelType: modelType(for: model))
+    }
+
+    static func capabilities(for model: String, modelType: String?) -> RuntimeModelCapabilities {
+        let normalized = model.lowercased()
+        let embeddingHint = ["embed", "bge", "e5-", "gte-"].contains(where: normalized.contains)
+        let supportedEmbeddingTypes: Set<String> = [
+            "bert", "roberta", "xlm-roberta", "distilbert", "nomic_bert", "qwen3",
+            "lfm2", "gemma3", "gemma3_text", "gemma3n"
+        ]
+        let embedding = embeddingHint && modelType.map(supportedEmbeddingTypes.contains) == true
+        let textGeneration = !embeddingHint
+        let vision = textGeneration && ModelTypeDetector.isVLMModelName(model)
+        return .init(
+            textGeneration: textGeneration,
+            vision: vision,
+            tools: textGeneration,
+            embeddings: embedding
+        )
+    }
+
+    private func modelType(for model: String) -> String? {
+        let url = ModelPaths.getModelDirectory(for: model).appendingPathComponent("config.json")
+        guard let data = try? Data(contentsOf: url),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return nil
+        }
+
+        return (object["model_type"] as? String)?.lowercased()
+    }
+
+    private func mapError(
+        _ error: Error,
+        model: String?,
+        fallback: RuntimeCoreErrorCode
+    ) -> RuntimeCoreError {
+        if let error = error as? RuntimeCoreError {
+            return error
+        }
+        if let error = error as? ModelPoolError {
+            return switch error {
+            case .modelNotFoundLocally:
+                .init(code: .modelNotFound, model: model)
+            case .failedToLoadModel:
+                .init(code: .modelLoadFailed, model: model)
+            }
+        }
+        if error is ContextLimitError {
+            return .init(code: .contextLimitExceeded, model: model)
+        }
+        if error is EmbeddingError {
+            return .init(code: .embeddingFailed, model: model)
+        }
+        return .init(code: fallback, model: model)
+    }
+}

--- a/swama/Sources/SwamaRuntime/CoreBridge/RuntimeCoreEngine.swift
+++ b/swama/Sources/SwamaRuntime/CoreBridge/RuntimeCoreEngine.swift
@@ -4,7 +4,7 @@ import MLXLMCommon
 
 // MARK: - RuntimeMessageRole
 
-package enum RuntimeMessageRole: String, Sendable {
+package enum RuntimeMessageRole: String {
     case system
     case user
     case assistant
@@ -13,7 +13,7 @@ package enum RuntimeMessageRole: String, Sendable {
 
 // MARK: - RuntimeContentPart
 
-package enum RuntimeContentPart: Sendable {
+package enum RuntimeContentPart {
     case text(String)
     case imageURL(URL)
     case imageData(Data, mediaType: String)
@@ -21,7 +21,7 @@ package enum RuntimeContentPart: Sendable {
 
 // MARK: - RuntimeJSONValue
 
-package enum RuntimeJSONValue: Hashable, Sendable {
+package enum RuntimeJSONValue: Hashable {
     case null
     case bool(Bool)
     case int(Int)
@@ -72,7 +72,7 @@ package enum RuntimeJSONValue: Hashable, Sendable {
 
 // MARK: - RuntimeToolCall
 
-package struct RuntimeToolCall: Hashable, Sendable {
+package struct RuntimeToolCall: Hashable {
     package init(id: String?, name: String, arguments: [String: RuntimeJSONValue]) {
         self.id = id
         self.name = name
@@ -104,7 +104,7 @@ package struct RuntimeToolCall: Hashable, Sendable {
 
 // MARK: - RuntimeToolDefinition
 
-package struct RuntimeToolDefinition: Hashable, Sendable {
+package struct RuntimeToolDefinition: Hashable {
     package init(name: String, description: String?, parameters: RuntimeJSONValue) {
         self.name = name
         self.description = description
@@ -132,7 +132,7 @@ package struct RuntimeToolDefinition: Hashable, Sendable {
 
 // MARK: - RuntimeMessage
 
-package struct RuntimeMessage: Sendable {
+package struct RuntimeMessage {
     package init(
         role: RuntimeMessageRole,
         content: [RuntimeContentPart],
@@ -153,7 +153,7 @@ package struct RuntimeMessage: Sendable {
 
 // MARK: - RuntimeGenerationOptions
 
-package struct RuntimeGenerationOptions: Sendable {
+package struct RuntimeGenerationOptions {
     package init(
         maxTokens: Int?,
         temperature: Float,
@@ -201,7 +201,7 @@ package struct RuntimeGenerationOptions: Sendable {
 
 // MARK: - RuntimeGenerationRequest
 
-package struct RuntimeGenerationRequest: Sendable {
+package struct RuntimeGenerationRequest {
     package init(
         model: String,
         messages: [RuntimeMessage],
@@ -222,14 +222,14 @@ package struct RuntimeGenerationRequest: Sendable {
 
 // MARK: - RuntimeGenerationEvent
 
-package enum RuntimeGenerationEvent: Sendable {
+package enum RuntimeGenerationEvent {
     case textDelta(String)
     case toolCall(RuntimeToolCall)
 }
 
 // MARK: - RuntimeFinishReason
 
-package enum RuntimeFinishReason: String, Sendable {
+package enum RuntimeFinishReason: String {
     case completed
     case length
     case toolCall
@@ -237,7 +237,7 @@ package enum RuntimeFinishReason: String, Sendable {
 
 // MARK: - RuntimeUsage
 
-package struct RuntimeUsage: Hashable, Sendable {
+package struct RuntimeUsage: Hashable {
     package init(promptTokens: Int, completionTokens: Int) {
         self.promptTokens = promptTokens
         self.completionTokens = completionTokens
@@ -246,12 +246,14 @@ package struct RuntimeUsage: Hashable, Sendable {
     package let promptTokens: Int
     package let completionTokens: Int
 
-    package var totalTokens: Int { promptTokens + completionTokens }
+    package var totalTokens: Int {
+        promptTokens + completionTokens
+    }
 }
 
 // MARK: - RuntimeGenerationMetrics
 
-package struct RuntimeGenerationMetrics: Hashable, Sendable {
+package struct RuntimeGenerationMetrics: Hashable {
     package init(promptSeconds: Double, generationSeconds: Double, tokensPerSecond: Double) {
         self.promptSeconds = promptSeconds
         self.generationSeconds = generationSeconds
@@ -265,7 +267,7 @@ package struct RuntimeGenerationMetrics: Hashable, Sendable {
 
 // MARK: - RuntimeGenerationResult
 
-package struct RuntimeGenerationResult: Sendable {
+package struct RuntimeGenerationResult {
     package let output: String
     package let toolCalls: [RuntimeToolCall]
     package let usage: RuntimeUsage
@@ -275,7 +277,7 @@ package struct RuntimeGenerationResult: Sendable {
 
 // MARK: - RuntimeEmbeddingRequest
 
-package struct RuntimeEmbeddingRequest: Sendable {
+package struct RuntimeEmbeddingRequest {
     package init(model: String, inputs: [String]) {
         self.model = model
         self.inputs = inputs
@@ -287,14 +289,14 @@ package struct RuntimeEmbeddingRequest: Sendable {
 
 // MARK: - RuntimeEmbeddingResult
 
-package struct RuntimeEmbeddingResult: Sendable {
+package struct RuntimeEmbeddingResult {
     package let embeddings: [[Float]]
     package let usage: RuntimeUsage
 }
 
 // MARK: - RuntimeModelCapabilities
 
-package struct RuntimeModelCapabilities: Hashable, Sendable {
+package struct RuntimeModelCapabilities: Hashable {
     package init(textGeneration: Bool, vision: Bool, tools: Bool, embeddings: Bool) {
         self.textGeneration = textGeneration
         self.vision = vision
@@ -310,7 +312,7 @@ package struct RuntimeModelCapabilities: Hashable, Sendable {
 
 // MARK: - RuntimeModelInfo
 
-package struct RuntimeModelInfo: Sendable {
+package struct RuntimeModelInfo {
     package let id: String
     package let created: Int
     package let sizeInBytes: Int64
@@ -319,7 +321,7 @@ package struct RuntimeModelInfo: Sendable {
 
 // MARK: - RuntimeCoreErrorCode
 
-package enum RuntimeCoreErrorCode: String, Sendable {
+package enum RuntimeCoreErrorCode: String {
     case invalidRequest
     case invalidImage
     case modelNotFound
@@ -333,7 +335,7 @@ package enum RuntimeCoreErrorCode: String, Sendable {
 
 // MARK: - RuntimeCoreError
 
-package struct RuntimeCoreError: Error, Sendable {
+package struct RuntimeCoreError: Error {
     package let code: RuntimeCoreErrorCode
     package let model: String?
 }
@@ -393,7 +395,7 @@ package actor RuntimeCoreEngine {
                 ),
                 finishReason: finishReason(
                     result.completionInfo?.stopReason,
-                    hasToolCalls: !toolCalls.isEmpty
+                    hasToolCalls: toolCalls.isEmpty == false
                 ),
                 metrics: result.completionInfo.map {
                     .init(
@@ -435,7 +437,7 @@ package actor RuntimeCoreEngine {
 
     package func models() -> [RuntimeModelInfo] {
         ModelManager.models()
-            .filter { !Self.isUnsupportedAudioModelID($0.id) }
+            .filter { Self.isUnsupportedAudioModelID($0.id) == false }
             .map { model in
                 RuntimeModelInfo(
                     id: model.id,
@@ -476,7 +478,7 @@ package actor RuntimeCoreEngine {
     }
 
     package func clearCache(for model: String) async {
-        guard Self.isValidModelID(model), !Self.isUnsupportedAudioModelID(model) else {
+        guard Self.isValidModelID(model), Self.isUnsupportedAudioModelID(model) == false else {
             return
         }
 
@@ -496,7 +498,14 @@ package actor RuntimeCoreEngine {
 
     static func isUnsupportedAudioModelID(_ model: String) -> Bool {
         let repositoryName = model.split(separator: "/").last.map(String.init) ?? model
-        let components = repositoryName.lowercased().split(whereSeparator: { !$0.isLetter && !$0.isNumber })
+        let components = repositoryName.lowercased()
+            .split(whereSeparator: { $0.isLetter == false && $0.isNumber == false })
+        let fusedFamilyPrefixes = ["sensevoice", "cosyvoice", "vyvotts"]
+        if components.contains(where: { component in
+            fusedFamilyPrefixes.contains(where: { component.hasPrefix($0) })
+        }) {
+            return true
+        }
         let families = [
             ["whisper"], ["funasr"], ["qwen3", "asr"], ["glm", "asr"], ["glmasr"],
             ["sensevoice"], ["voxtral"], ["cohere", "transcribe"], ["parakeet"],
@@ -505,7 +514,7 @@ package actor RuntimeCoreEngine {
             ["canary"], ["moonshine"], ["wav2vec"], ["wav2vec2"], ["mms"], ["lasr"],
             ["granite", "speech"], ["tts"], ["orpheus"], ["marvis"], ["chatterbox"],
             ["vyvo"], ["fish", "speech"], ["fish", "audio"], ["soprano"], ["kokoro"],
-            ["cosyvoice"], ["omnivoice"], ["pocket", "tts"], ["moss", "tts"],
+            ["cosyvoice"], ["omnivoice"], ["ttsd"], ["pocket", "tts"], ["moss", "tts"],
             ["echo", "tts"], ["kitten", "tts"], ["irodori", "tts"], ["outetts"]
         ]
         return families.contains { family in
@@ -536,7 +545,7 @@ package actor RuntimeCoreEngine {
     }
 
     private func rejectUnsupportedAudioModel(_ model: String) throws {
-        guard !Self.isUnsupportedAudioModelID(model) else {
+        guard Self.isUnsupportedAudioModelID(model) == false else {
             throw RuntimeCoreError(code: .invalidRequest, model: model)
         }
     }
@@ -553,8 +562,8 @@ package actor RuntimeCoreEngine {
     }
 
     private nonisolated func makeChatMessage(_ message: RuntimeMessage) throws -> MLXLMCommon.Chat.Message {
-        var textParts: [String] = []
-        var images: [MLXLMCommon.UserInput.Image] = []
+        var textParts = [String]()
+        var images = [MLXLMCommon.UserInput.Image]()
         for part in message.content {
             switch part {
             case let .text(text):
@@ -624,12 +633,12 @@ package actor RuntimeCoreEngine {
     static func capabilities(for model: String, modelType: String?) -> RuntimeModelCapabilities {
         let normalized = model.lowercased()
         let embeddingHint = ["embed", "bge", "e5-", "gte-"].contains(where: normalized.contains)
-        let supportedEmbeddingTypes: Set<String> = [
+        let supportedEmbeddingTypes: Set = [
             "bert", "roberta", "xlm-roberta", "distilbert", "nomic_bert", "qwen3",
             "lfm2", "gemma3", "gemma3_text", "gemma3n"
         ]
         let embedding = embeddingHint && modelType.map(supportedEmbeddingTypes.contains) == true
-        let textGeneration = !embeddingHint
+        let textGeneration = embeddingHint == false
         let vision = textGeneration && ModelTypeDetector.isVLMModelName(model)
         return .init(
             textGeneration: textGeneration,

--- a/swama/Sources/SwamaRuntime/CoreBridge/RuntimeCoreEngine.swift
+++ b/swama/Sources/SwamaRuntime/CoreBridge/RuntimeCoreEngine.swift
@@ -355,6 +355,7 @@ package actor RuntimeCoreEngine {
         _ request: RuntimeGenerationRequest,
         onEvent: (@Sendable (RuntimeGenerationEvent) async throws -> Void)? = nil
     ) async throws -> RuntimeGenerationResult {
+        try validateModelID(request.model)
         try rejectUnsupportedAudioModel(request.model)
         do {
             let parameters = makeParameters(request.options)
@@ -412,6 +413,7 @@ package actor RuntimeCoreEngine {
     }
 
     package func embed(_ request: RuntimeEmbeddingRequest) async throws -> RuntimeEmbeddingResult {
+        try validateModelID(request.model)
         try rejectUnsupportedAudioModel(request.model)
         do {
             let result = try await pool.runEmbeddingWithConcurrencyControl(modelName: request.model) { runner in
@@ -446,6 +448,7 @@ package actor RuntimeCoreEngine {
     }
 
     package func fetch(_ model: String) async throws {
+        try validateModelID(model)
         try rejectUnsupportedAudioModel(model)
         do {
             _ = try await ModelDownloader.fetchModel(modelName: model)
@@ -456,6 +459,7 @@ package actor RuntimeCoreEngine {
     }
 
     package func remove(_ model: String) async throws {
+        try validateModelID(model)
         try rejectUnsupportedAudioModel(model)
         await pool.remove(modelName: model)
         do {
@@ -472,7 +476,7 @@ package actor RuntimeCoreEngine {
     }
 
     package func clearCache(for model: String) async {
-        guard !Self.isUnsupportedAudioModelID(model) else {
+        guard Self.isValidModelID(model), !Self.isUnsupportedAudioModelID(model) else {
             return
         }
 
@@ -486,15 +490,49 @@ package actor RuntimeCoreEngine {
     private let pool: ModelPool
     private let defaultContextLimit: Int?
 
+    package nonisolated static func isValidModelID(_ model: String) -> Bool {
+        ModelPaths.isValidModelIdentifier(model)
+    }
+
     static func isUnsupportedAudioModelID(_ model: String) -> Bool {
-        let value = model.lowercased()
-        let markers = [
-            "whisper", "qwen3-asr", "glm-asr", "glmasr", "sensevoice", "voxtral",
-            "parakeet", "moss-transcribe", "nemotron", "canary", "moonshine", "wav2vec",
-            "mms-", "granite-speech", "tts", "orpheus", "marvis", "chatterbox", "vyvo",
-            "fish-speech", "soprano", "kokoro", "cosyvoice", "omnivoice"
+        let repositoryName = model.split(separator: "/").last.map(String.init) ?? model
+        let components = repositoryName.lowercased().split(whereSeparator: { !$0.isLetter && !$0.isNumber })
+        let families = [
+            ["whisper"], ["funasr"], ["qwen3", "asr"], ["glm", "asr"], ["glmasr"],
+            ["sensevoice"], ["voxtral"], ["cohere", "transcribe"], ["parakeet"],
+            ["fireredasr"], ["firered", "asr"], ["fire", "red", "asr"],
+            ["moss", "transcribe"], ["nemotron", "asr"], ["nemotron", "speech"],
+            ["canary"], ["moonshine"], ["wav2vec"], ["wav2vec2"], ["mms"], ["lasr"],
+            ["granite", "speech"], ["tts"], ["orpheus"], ["marvis"], ["chatterbox"],
+            ["vyvo"], ["fish", "speech"], ["fish", "audio"], ["soprano"], ["kokoro"],
+            ["cosyvoice"], ["omnivoice"], ["pocket", "tts"], ["moss", "tts"],
+            ["echo", "tts"], ["kitten", "tts"], ["irodori", "tts"], ["outetts"]
         ]
-        return markers.contains(where: value.contains)
+        return families.contains { family in
+            containsComponentSequence(family, in: components)
+        }
+    }
+
+    private nonisolated static func containsComponentSequence(
+        _ sequence: [String],
+        in components: [Substring]
+    ) -> Bool {
+        guard components.count >= sequence.count else {
+            return false
+        }
+
+        for start in 0 ... (components.count - sequence.count) {
+            if sequence.indices.allSatisfy({ components[start + $0] == sequence[$0] }) {
+                return true
+            }
+        }
+        return false
+    }
+
+    private func validateModelID(_ model: String) throws {
+        guard Self.isValidModelID(model) else {
+            throw RuntimeCoreError(code: .invalidRequest, model: model)
+        }
     }
 
     private func rejectUnsupportedAudioModel(_ model: String) throws {

--- a/swama/Sources/SwamaRuntime/Model/ModelCreator.swift
+++ b/swama/Sources/SwamaRuntime/Model/ModelCreator.swift
@@ -4,7 +4,10 @@ package enum ModelCreator {
     package static func run(from path: String, name: String) async throws {
         ModelDownloader.printMessage("Creating model from path: \(path) with name: \(name)")
 
-        let modelDir = ModelPaths.activeModelsDirectory.appendingPathComponent(name)
+        let modelDir = try ModelPaths.containedModelDirectory(
+            in: ModelPaths.activeModelsDirectory,
+            modelName: name
+        )
         let sourceURL = URL(fileURLWithPath: path)
 
         // Check if the model directory already exists

--- a/swama/Sources/SwamaRuntime/Model/ModelDownloader.swift
+++ b/swama/Sources/SwamaRuntime/Model/ModelDownloader.swift
@@ -51,7 +51,7 @@ package enum ModelDownloader {
             allowedExtensions.contains(where: { info.path.hasSuffix(".\($0)") })
         }
 
-        if filteredFileInfos.isEmpty, !fileInfos.isEmpty {
+        if filteredFileInfos.isEmpty, fileInfos.isEmpty == false {
             printMessage(
                 "Warning: No files with allowed extensions found for model \(resolvedModelName). Allowed: \(allowedExtensions.joined(separator: ", "))"
             )

--- a/swama/Sources/SwamaRuntime/Model/ModelDownloader.swift
+++ b/swama/Sources/SwamaRuntime/Model/ModelDownloader.swift
@@ -15,7 +15,10 @@ package enum ModelDownloader {
     package static func downloadModel(resolvedModelName: String) async throws {
         printMessage("Pulling model: \(resolvedModelName)")
 
-        let modelDir = ModelPaths.getModelDirectory(for: resolvedModelName)
+        let modelDir = try ModelPaths.containedModelDirectory(
+            in: ModelPaths.activeModelsDirectory,
+            modelName: resolvedModelName
+        )
         try FileManager.default.createDirectory(at: modelDir, withIntermediateDirectories: true)
         let swamaRegistry = ProcessInfo.processInfo.environment["SWAMA_REGISTRY"] ?? "HUGGING_FACE"
 
@@ -68,7 +71,7 @@ package enum ModelDownloader {
         for (idx, info) in filteredFileInfos.enumerated() {
             let file = info.path
             let remoteSize = info.size
-            let dest = modelDir.appendingPathComponent(file)
+            let dest = try ModelPaths.containedURL(in: modelDir, relativePath: file)
 
             try FileManager.default.createDirectory(
                 at: dest.deletingLastPathComponent(),

--- a/swama/Sources/SwamaRuntime/Model/ModelPaths.swift
+++ b/swama/Sources/SwamaRuntime/Model/ModelPaths.swift
@@ -18,7 +18,7 @@ package enum ModelPaths {
     /// The custom path for storing models (dynamically read from environment).
     package static var customModelsDirectory: URL? {
         if let customPath = ProcessInfo.processInfo.environment["SWAMA_MODELS"],
-           !customPath.isEmpty
+           customPath.isEmpty == false
         {
             return URL(fileURLWithPath: customPath)
         }
@@ -49,11 +49,11 @@ package enum ModelPaths {
     /// filesystem-backed operation share the same traversal boundary.
     package static func isValidModelIdentifier(_ modelName: String) -> Bool {
         guard modelName == modelName.trimmingCharacters(in: .whitespacesAndNewlines),
-              !modelName.isEmpty,
+              modelName.isEmpty == false,
               modelName.utf8.count <= 192,
-              !modelName.hasPrefix("/"),
-              !modelName.contains("\\"),
-              !modelName.unicodeScalars.contains(where: CharacterSet.controlCharacters.contains)
+              modelName.hasPrefix("/") == false,
+              modelName.contains("\\") == false,
+              modelName.unicodeScalars.contains(where: CharacterSet.controlCharacters.contains) == false
         else {
             return false
         }
@@ -67,23 +67,23 @@ package enum ModelPaths {
         return components.allSatisfy { component in
             component != "." &&
                 component != ".." &&
-                !component.isEmpty &&
+                component.isEmpty == false &&
                 component.unicodeScalars.allSatisfy(allowed.contains)
         }
     }
 
     /// Resolve a relative path below `root`, rejecting traversal before any filesystem access.
     static func containedURL(in root: URL, relativePath: String) throws -> URL {
-        guard !relativePath.isEmpty,
-              !relativePath.hasPrefix("/"),
-              !relativePath.contains("\\"),
-              !relativePath.unicodeScalars.contains(where: CharacterSet.controlCharacters.contains)
+        guard relativePath.isEmpty == false,
+              relativePath.hasPrefix("/") == false,
+              relativePath.contains("\\") == false,
+              relativePath.unicodeScalars.contains(where: CharacterSet.controlCharacters.contains) == false
         else {
             throw ModelPathError.invalidRelativePath
         }
 
         let components = relativePath.split(separator: "/", omittingEmptySubsequences: false)
-        guard components.allSatisfy({ !$0.isEmpty && $0 != "." && $0 != ".." }) else {
+        guard components.allSatisfy({ $0.isEmpty == false && $0 != "." && $0 != ".." }) else {
             throw ModelPathError.invalidRelativePath
         }
 

--- a/swama/Sources/SwamaRuntime/Model/ModelPaths.swift
+++ b/swama/Sources/SwamaRuntime/Model/ModelPaths.swift
@@ -1,5 +1,11 @@
 import Foundation
 
+// MARK: - ModelPathError
+
+enum ModelPathError: Error {
+    case invalidRelativePath
+}
+
 // MARK: - ModelPaths
 
 /// Centralized configuration for model storage paths.
@@ -38,26 +44,111 @@ package enum ModelPaths {
 
     // MARK: - Model directory resolution
 
+    /// Model IDs accepted by the Core/runtime boundary. They are either a local alias or a
+    /// Hugging Face-style `owner/repository` identifier. Keeping this grammar here makes every
+    /// filesystem-backed operation share the same traversal boundary.
+    package static func isValidModelIdentifier(_ modelName: String) -> Bool {
+        guard modelName == modelName.trimmingCharacters(in: .whitespacesAndNewlines),
+              !modelName.isEmpty,
+              modelName.utf8.count <= 192,
+              !modelName.hasPrefix("/"),
+              !modelName.contains("\\"),
+              !modelName.unicodeScalars.contains(where: CharacterSet.controlCharacters.contains)
+        else {
+            return false
+        }
+
+        let components = modelName.split(separator: "/", omittingEmptySubsequences: false)
+        guard (1 ... 2).contains(components.count) else {
+            return false
+        }
+
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_."))
+        return components.allSatisfy { component in
+            component != "." &&
+                component != ".." &&
+                !component.isEmpty &&
+                component.unicodeScalars.allSatisfy(allowed.contains)
+        }
+    }
+
+    /// Resolve a relative path below `root`, rejecting traversal before any filesystem access.
+    static func containedURL(in root: URL, relativePath: String) throws -> URL {
+        guard !relativePath.isEmpty,
+              !relativePath.hasPrefix("/"),
+              !relativePath.contains("\\"),
+              !relativePath.unicodeScalars.contains(where: CharacterSet.controlCharacters.contains)
+        else {
+            throw ModelPathError.invalidRelativePath
+        }
+
+        let components = relativePath.split(separator: "/", omittingEmptySubsequences: false)
+        guard components.allSatisfy({ !$0.isEmpty && $0 != "." && $0 != ".." }) else {
+            throw ModelPathError.invalidRelativePath
+        }
+
+        let standardizedRoot = root.standardizedFileURL
+        let candidate = standardizedRoot.appendingPathComponent(relativePath).standardizedFileURL
+        guard isDescendant(candidate, of: standardizedRoot),
+              existingPrefixesStayContained(
+                  components: components,
+                  standardizedRoot: standardizedRoot
+              )
+        else {
+            throw ModelPathError.invalidRelativePath
+        }
+
+        return candidate
+    }
+
+    static func containedModelDirectory(in root: URL, modelName: String) throws -> URL {
+        guard isValidModelIdentifier(modelName) else {
+            throw ModelPathError.invalidRelativePath
+        }
+
+        return try containedURL(in: root, relativePath: modelName)
+    }
+
     /// Get the local directory for a model, checking custom → preferred → legacy locations.
     package static func getModelDirectory(for modelName: String) -> URL {
-        let customPath = customModelsDirectory?.appendingPathComponent(modelName)
-        let preferredPath = preferredModelsDirectory.appendingPathComponent(modelName)
-        let legacyPath = legacyModelsDirectory.appendingPathComponent(modelName)
+        let customRoot = customModelsDirectory
+        let customPath = customRoot.flatMap {
+            try? containedModelDirectory(in: $0, modelName: modelName)
+        }
+        let preferredPath = try? containedModelDirectory(
+            in: preferredModelsDirectory,
+            modelName: modelName
+        )
+        let legacyPath = try? containedModelDirectory(
+            in: legacyModelsDirectory,
+            modelName: modelName
+        )
 
         // Check if model exists in custom location first
         if let customPath,
+           let customRoot,
            FileManager.default.fileExists(atPath: customPath.appendingPathComponent(".swama-meta.json").path)
         {
-            return parseModelMetadataPath(from: customPath.appendingPathComponent(".swama-meta.json"))
+            return parseModelMetadataPath(
+                from: customPath.appendingPathComponent(".swama-meta.json"),
+                within: customRoot
+            )
         }
 
         // Check if model exists in preferred location
-        if FileManager.default.fileExists(atPath: preferredPath.appendingPathComponent(".swama-meta.json").path) {
-            return parseModelMetadataPath(from: preferredPath.appendingPathComponent(".swama-meta.json"))
+        if let preferredPath,
+           FileManager.default.fileExists(atPath: preferredPath.appendingPathComponent(".swama-meta.json").path)
+        {
+            return parseModelMetadataPath(
+                from: preferredPath.appendingPathComponent(".swama-meta.json"),
+                within: preferredModelsDirectory
+            )
         }
 
         // Check if model exists in legacy location
-        if FileManager.default.fileExists(atPath: legacyPath.appendingPathComponent(".swama-meta.json").path) {
+        if let legacyPath,
+           FileManager.default.fileExists(atPath: legacyPath.appendingPathComponent(".swama-meta.json").path)
+        {
             return legacyPath
         }
 
@@ -65,10 +156,10 @@ package enum ModelPaths {
         if let customPath {
             return customPath
         }
-        return preferredPath
+        return preferredPath ?? preferredModelsDirectory.appendingPathComponent(".invalid-model-identifier")
     }
 
-    private static func parseModelMetadataPath(from metaURL: URL) -> URL {
+    private static func parseModelMetadataPath(from metaURL: URL, within root: URL) -> URL {
         guard let data = try? Data(contentsOf: metaURL),
               let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let path = json["path"] as? String
@@ -76,13 +167,48 @@ package enum ModelPaths {
             return metaURL.deletingLastPathComponent()
         }
 
-        return URL(fileURLWithPath: path)
+        let standardizedRoot = root.standardizedFileURL
+        let candidate = URL(fileURLWithPath: path).standardizedFileURL
+        guard isDescendant(candidate, of: standardizedRoot),
+              isDescendant(candidate.resolvingSymlinksInPath(), of: standardizedRoot.resolvingSymlinksInPath())
+        else {
+            return metaURL.deletingLastPathComponent()
+        }
+
+        return candidate
+    }
+
+    private static func isDescendant(_ candidate: URL, of root: URL) -> Bool {
+        let rootPrefix = root.path.hasSuffix("/") ? root.path : root.path + "/"
+        return candidate.path.hasPrefix(rootPrefix)
+    }
+
+    private static func existingPrefixesStayContained(
+        components: [Substring],
+        standardizedRoot: URL
+    ) -> Bool {
+        let resolvedRoot = standardizedRoot.resolvingSymlinksInPath()
+        var prefix = standardizedRoot
+        for component in components {
+            prefix.appendPathComponent(String(component))
+            guard FileManager.default.fileExists(atPath: prefix.path) else {
+                break
+            }
+            guard isDescendant(prefix.resolvingSymlinksInPath(), of: resolvedRoot) else {
+                return false
+            }
+        }
+        return true
     }
 
     // MARK: - Existence & listing
 
     /// A model exists locally iff its directory contains a `.swama-meta.json`.
     package static func modelExistsLocally(_ modelName: String) -> Bool {
+        guard isValidModelIdentifier(modelName) else {
+            return false
+        }
+
         let metaPath = getModelDirectory(for: modelName).appendingPathComponent(".swama-meta.json").path
         return FileManager.default.fileExists(atPath: metaPath)
     }
@@ -101,11 +227,15 @@ package enum ModelPaths {
     /// Remove a model from disk. Returns true if found and deleted, false otherwise.
     package static func removeModel(_ modelName: String) throws -> Bool {
         // Check all candidate locations in priority order for a metadata file.
-        let locations = [
-            customModelsDirectory?.appendingPathComponent(modelName),
-            preferredModelsDirectory.appendingPathComponent(modelName),
-            legacyModelsDirectory.appendingPathComponent(modelName)
-        ].compactMap(\.self)
+        guard isValidModelIdentifier(modelName) else {
+            throw ModelPathError.invalidRelativePath
+        }
+
+        let roots = [customModelsDirectory, preferredModelsDirectory, legacyModelsDirectory]
+            .compactMap(\.self)
+        let locations = try roots.map {
+            try containedModelDirectory(in: $0, modelName: modelName)
+        }
 
         for location in locations {
             let metadataFile = location.appendingPathComponent(".swama-meta.json")

--- a/swama/Sources/SwamaRuntime/Model/ModelRunner.swift
+++ b/swama/Sources/SwamaRuntime/Model/ModelRunner.swift
@@ -78,6 +78,7 @@ package actor ModelRunner {
     package nonisolated func runChat(
         userInput: MLXLMCommon.UserInput,
         parameters: GenerateParameters,
+        contextLimit: Int? = nil,
         onToken: (@Sendable (String) async throws -> Void)? = nil,
         onToolCall: (@Sendable (MLXLMCommon.ToolCall) async throws -> Void)? = nil
     ) async throws -> ChatRunResult {
@@ -124,7 +125,15 @@ package actor ModelRunner {
 
             let rawOutputStorage = RawOutputBuffer()
             let hasMediaInput = userInput.hasMediaContent
-            let configuredContextLimit = await ContextLimitConfig.shared.currentLimit()
+            // Intentional Core divergence: a request-scoped value avoids mutating the legacy
+            // process-global ContextLimitConfig when multiple SwamaEngine instances overlap.
+            let configuredContextLimit: Int =
+                if let contextLimit {
+                    contextLimit
+                }
+                else {
+                    await ContextLimitConfig.shared.currentLimit()
+                }
             let effectiveContextLimit = hasMediaInput
                 ? min(configuredContextLimit, InferenceSafetyLimits.multimodalContextLimit)
                 : configuredContextLimit

--- a/swama/Sources/SwamaRuntime/Model/ModelRunner.swift
+++ b/swama/Sources/SwamaRuntime/Model/ModelRunner.swift
@@ -168,6 +168,7 @@ package actor ModelRunner {
                 )
             }
 
+            let generationTools = effectiveInput.tools
             let lmInput = try await container.prepare(input: effectiveInput)
 
             promptTokens = tokenLength(lmInput.text.tokens)
@@ -240,7 +241,8 @@ package actor ModelRunner {
                     let stream = try generate(
                         input: lmInput,
                         parameters: generationParameters,
-                        context: context
+                        context: context,
+                        tools: generationTools
                     )
                     return PromptCacheGenerationRun(stream: stream, task: nil, cache: nil, prefillMs: nil)
 
@@ -254,7 +256,8 @@ package actor ModelRunner {
                         cache: reusedCache,
                         fullHistory: lmInput.text.tokens,
                         context: context,
-                        generationParameters: generationParameters
+                        generationParameters: generationParameters,
+                        tools: generationTools
                     )
 
                 case .miss:
@@ -266,7 +269,8 @@ package actor ModelRunner {
                         cache: freshCache,
                         fullHistory: nil,
                         context: context,
-                        generationParameters: generationParameters
+                        generationParameters: generationParameters,
+                        tools: generationTools
                     )
                 }
             }
@@ -765,7 +769,8 @@ private func buildPromptCacheGenerationRun(
     cache: [KVCache],
     fullHistory: MLXArray?,
     context: ModelContext,
-    generationParameters: GenerateParameters
+    generationParameters: GenerateParameters,
+    tools: [[String: any Sendable]]?
 ) throws -> PromptCacheGenerationRun {
     let baseProcessor: LogitProcessor? = generationParameters.processor()
     let strategy = promptCacheIteratorStrategy(
@@ -817,7 +822,8 @@ private func buildPromptCacheGenerationRun(
         promptTokenCount: iterInput.text.tokens.size,
         modelConfiguration: context.configuration,
         tokenizer: context.tokenizer,
-        iterator: iterator
+        iterator: iterator,
+        tools: tools
     )
 
     return PromptCacheGenerationRun(stream: stream, task: task, cache: cache, prefillMs: prefillMs)

--- a/swama/Sources/SwamaRuntime/Model/ModelRunner.swift
+++ b/swama/Sources/SwamaRuntime/Model/ModelRunner.swift
@@ -22,7 +22,7 @@ private enum InferenceSafetyLimits {
 // MARK: - ModelRunner
 
 package actor ModelRunner {
-    package struct ChatRunResult: Sendable {
+    package struct ChatRunResult {
         package let output: String
         package let analysis: String?
         package let promptTokens: Int
@@ -120,7 +120,7 @@ package actor ModelRunner {
             var output = ""
             var promptTokens = 0
             var capturedCompletionInfo: GenerateCompletionInfo?
-            var toolCalls: [MLXLMCommon.ToolCall] = []
+            var toolCalls = [MLXLMCommon.ToolCall]()
             var didRecordFirstToken = false
 
             let rawOutputStorage = RawOutputBuffer()
@@ -290,7 +290,7 @@ package actor ModelRunner {
                 do {
                     switch generationEvent {
                     case let .chunk(chunkString):
-                        if !didRecordFirstToken, !chunkString.isEmpty {
+                        if didRecordFirstToken == false, chunkString.isEmpty == false {
                             SwamaDiagnostics.firstToken(diagnosticOperation, model: modelName)
                             didRecordFirstToken = true
                         }
@@ -312,7 +312,7 @@ package actor ModelRunner {
                         capturedCompletionInfo = info
 
                     case let .toolCall(toolCall):
-                        if !didRecordFirstToken {
+                        if didRecordFirstToken == false {
                             SwamaDiagnostics.firstToken(diagnosticOperation, model: modelName)
                             didRecordFirstToken = true
                         }
@@ -423,7 +423,7 @@ private func trimChatMessagesInternal(
     guard limit > 0 else {
         return chatMessages
     }
-    guard !chatMessages.isEmpty else {
+    guard chatMessages.isEmpty == false else {
         return chatMessages
     }
 
@@ -431,7 +431,7 @@ private func trimChatMessagesInternal(
         if message.role == .system || message.role == .tool {
             return true
         }
-        return !message.images.isEmpty || !message.videos.isEmpty
+        return message.images.isEmpty == false || message.videos.isEmpty == false
     }
 
     func buildInput(with messages: [MLXLMCommon.Chat.Message]) -> MLXLMCommon.UserInput {
@@ -444,19 +444,19 @@ private func trimChatMessagesInternal(
     }
 
     func hasMedia(_ messages: [MLXLMCommon.Chat.Message]) -> Bool {
-        messages.contains { !$0.images.isEmpty || !$0.videos.isEmpty }
+        messages.contains { $0.images.isEmpty == false || $0.videos.isEmpty == false }
     }
 
     func hasNonEmptyUserMessage(_ messages: [MLXLMCommon.Chat.Message]) -> Bool {
         messages.contains {
-            $0.role == .user && !$0.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            $0.role == .user && $0.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
         }
     }
 
     func countTokensForTrim(_ messages: [MLXLMCommon.Chat.Message]) async throws -> Int {
         // For text-only chat, use model-accurate token counting via prepare(input:)
         // to avoid template-estimation mismatch for multimodal-capable models.
-        if !hasMedia(messages) {
+        if hasMedia(messages) == false {
             return try await tokenCount(for: buildInput(with: messages), container: container)
         }
 
@@ -471,7 +471,7 @@ private func trimChatMessagesInternal(
     var workingMessages = chatMessages
     var didTrimContent = false
     var trimmableIndices = workingMessages.enumerated()
-        .filter { !isProtected($0.element) }
+        .filter { isProtected($0.element) == false }
         .map(\.offset)
 
     var currentTokenCount = try await countTokensForTrim(workingMessages)
@@ -533,9 +533,9 @@ private func trimChatMessagesInternal(
 
     // Never collapse to an empty-user prompt. If trimming removed all user text,
     // restore the latest non-empty user message from the original request.
-    if !hasNonEmptyUserMessage(workingMessages),
+    if hasNonEmptyUserMessage(workingMessages) == false,
        let fallbackUser = chatMessages.reversed().first(where: {
-           $0.role == .user && !$0.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+           $0.role == .user && $0.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
        })
     {
         workingMessages = [fallbackUser]
@@ -609,7 +609,7 @@ private extension MLXLMCommon.UserInput {
         case .text:
             false
         case let .chat(messages):
-            messages.contains { !$0.images.isEmpty || !$0.videos.isEmpty }
+            messages.contains { $0.images.isEmpty == false || $0.videos.isEmpty == false }
         case let .messages(messages):
             messages.contains { message in
                 message.keys.contains { key in

--- a/swama/Tests/SwamaCoreTests/SwamaCoreTests.swift
+++ b/swama/Tests/SwamaCoreTests/SwamaCoreTests.swift
@@ -176,12 +176,14 @@ struct SwamaCoreTests {
         let engine = SwamaEngine(backend: backend)
         let model = ModelID("org/model")
         let toolCall = ToolCall(name: "lookup", arguments: [:])
+        let imageURL = try #require(URL(string: "https://example.invalid/tool-result.png"))
         let invalidMessages: [Message] = [
             .init(role: .user, content: [.text("hi")], toolCalls: [toolCall]),
             .init(role: .system, content: [.text("hi")], toolCallID: "call-1"),
             .init(role: .assistant, content: [.text("hi")], toolCallID: "call-1"),
             .init(role: .tool, content: [.text("result")]),
-            .init(role: .tool, content: [.text("result")], toolCalls: [toolCall], toolCallID: "call-1")
+            .init(role: .tool, content: [.text("result")], toolCalls: [toolCall], toolCallID: "call-1"),
+            .init(role: .tool, content: [.imageURL(imageURL)], toolCallID: "call-1")
         ]
         let invalidOptions: [GenerationOptions] = [
             .init(temperature: .infinity),
@@ -267,10 +269,22 @@ private actor StubBackend: SwamaEngineBackend {
         return .init(embeddings: [[1]], usage: .init(promptTokens: 1, completionTokens: 0))
     }
 
-    func models() async throws -> [ModelInfo] { [] }
-    func fetch(_: ModelID) async throws { fetchCalls += 1 }
-    func remove(_: ModelID) async throws { removeCalls += 1 }
-    func clearCache(for _: ModelID) async { modelCacheClearCalls += 1 }
+    func models() async throws -> [ModelInfo] {
+        []
+    }
+
+    func fetch(_: ModelID) async throws {
+        fetchCalls += 1
+    }
+
+    func remove(_: ModelID) async throws {
+        removeCalls += 1
+    }
+
+    func clearCache(for _: ModelID) async {
+        modelCacheClearCalls += 1
+    }
+
     func clearCache() async {}
 
     private let generationResponse: GenerationResponse

--- a/swama/Tests/SwamaCoreTests/SwamaCoreTests.swift
+++ b/swama/Tests/SwamaCoreTests/SwamaCoreTests.swift
@@ -1,0 +1,158 @@
+import Foundation
+@testable import SwamaCore
+import Testing
+
+// MARK: - SwamaCoreTests
+
+@Suite("SwamaCore public contract")
+struct SwamaCoreTests {
+    @Test func publicValuesHaveStableCodableRoundTrips() throws {
+        let modelID = ModelID("org/model")
+        let encodedModelID = try JSONEncoder().encode(modelID)
+        #expect(try JSONDecoder().decode(String.self, from: encodedModelID) == "org/model")
+        #expect(try JSONDecoder().decode(ModelID.self, from: Data("\"org/model\"".utf8)) == modelID)
+
+        let request = try GenerationRequest(
+            model: .init("org/model"),
+            messages: [
+                .init(role: .system, text: "Be concise."),
+                .init(role: .user, content: [
+                    .text("Describe this."),
+                    .imageURL(#require(URL(string: "https://example.invalid/image.png"))),
+                    .imageData(Data([0x01, 0x02]), mediaType: "image/png")
+                ])
+            ],
+            options: .init(maxTokens: 32, temperature: 0, seed: 7, contextLimit: 4096),
+            tools: [.init(
+                name: "lookup",
+                description: "Look up a value",
+                parameters: .object(["key": .object(["type": .string("string")])])
+            )]
+        )
+
+        let data = try JSONEncoder().encode(request)
+        #expect(try JSONDecoder().decode(GenerationRequest.self, from: data) == request)
+
+        let response = GenerationResponse(
+            output: "done",
+            toolCalls: [.init(id: "call-1", name: "lookup", arguments: ["key": .string("x")])],
+            usage: .init(promptTokens: 4, completionTokens: 2),
+            finishReason: .toolCall,
+            metrics: .init(promptSeconds: 0.1, generationSeconds: 0.2, tokensPerSecond: 10)
+        )
+        #expect(try JSONDecoder().decode(
+            GenerationResponse.self,
+            from: JSONEncoder().encode(response)
+        ) == response)
+    }
+
+    @Test func engineForwardsAwaitedEventsAndResult() async throws {
+        let response = GenerationResponse(
+            output: "hello",
+            toolCalls: [],
+            usage: .init(promptTokens: 2, completionTokens: 1),
+            finishReason: .completed
+        )
+        let backend = StubBackend(generationResponse: response)
+        let engine = SwamaEngine(backend: backend)
+        let events = EventCollector()
+
+        let result = try await engine.generate(.init(
+            model: .init("org/model"),
+            messages: [.init(role: .user, text: "hi")]
+        )) { event in
+            await events.append(event)
+        }
+
+        #expect(result == response)
+        #expect(await events.values == [.textDelta("hello")])
+    }
+
+    @Test func cancellationNeverReturnsAPartialResponse() async throws {
+        let backend = StubBackend(
+            generationResponse: .init(
+                output: "partial",
+                toolCalls: [],
+                usage: .init(promptTokens: 1, completionTokens: 1),
+                finishReason: .completed
+            ),
+            cancelGeneration: true
+        )
+        let engine = SwamaEngine(backend: backend)
+
+        do {
+            _ = try await engine.generate(.init(
+                model: .init("org/model"),
+                messages: [.init(role: .user, text: "hi")]
+            ))
+            Issue.record("cancelled generation returned a response")
+        }
+        catch {
+            #expect(error is CancellationError)
+        }
+    }
+
+    @Test func invalidRequestsFailBeforeBackendExecution() async throws {
+        let backend = StubBackend(generationResponse: .init(
+            output: "unexpected",
+            toolCalls: [],
+            usage: .init(promptTokens: 0, completionTokens: 0),
+            finishReason: .completed
+        ))
+        let engine = SwamaEngine(backend: backend)
+
+        do {
+            _ = try await engine.generate(.init(model: .init(""), messages: []))
+            Issue.record("invalid request unexpectedly succeeded")
+        }
+        catch let error as SwamaError {
+            #expect(error.code == .invalidRequest)
+        }
+        #expect(await backend.generationCalls == 0)
+    }
+}
+
+// MARK: - EventCollector
+
+private actor EventCollector {
+    func append(_ event: GenerationEvent) {
+        values.append(event)
+    }
+
+    private(set) var values: [GenerationEvent] = []
+}
+
+// MARK: - StubBackend
+
+private actor StubBackend: SwamaEngineBackend {
+    init(generationResponse: GenerationResponse, cancelGeneration: Bool = false) {
+        self.generationResponse = generationResponse
+        self.cancelGeneration = cancelGeneration
+    }
+
+    func generate(
+        _: GenerationRequest,
+        onEvent: (@Sendable (GenerationEvent) async throws -> Void)?
+    ) async throws -> GenerationResponse {
+        generationCalls += 1
+        try await onEvent?(.textDelta(generationResponse.output))
+        if cancelGeneration {
+            throw CancellationError()
+        }
+        return generationResponse
+    }
+
+    func embed(_: EmbeddingRequest) async throws -> EmbeddingResponse {
+        .init(embeddings: [[1]], usage: .init(promptTokens: 1, completionTokens: 0))
+    }
+
+    func models() async throws -> [ModelInfo] { [] }
+    func fetch(_: ModelID) async throws {}
+    func remove(_: ModelID) async throws {}
+    func clearCache(for _: ModelID) async {}
+    func clearCache() async {}
+
+    private let generationResponse: GenerationResponse
+    private let cancelGeneration: Bool
+    private(set) var generationCalls = 0
+}

--- a/swama/Tests/SwamaCoreTests/SwamaCoreTests.swift
+++ b/swama/Tests/SwamaCoreTests/SwamaCoreTests.swift
@@ -44,6 +44,11 @@ struct SwamaCoreTests {
             GenerationResponse.self,
             from: JSONEncoder().encode(response)
         ) == response)
+        #expect(try JSONDecoder().decode(
+            FinishReason.self,
+            from: Data("\"future_backend_reason\"".utf8)
+        ) == .unknown)
+        #expect(try String(decoding: JSONEncoder().encode(FinishReason.unknown), as: UTF8.self) == "\"unknown\"")
     }
 
     @Test func engineForwardsAwaitedEventsAndResult() async throws {
@@ -110,6 +115,121 @@ struct SwamaCoreTests {
         }
         #expect(await backend.generationCalls == 0)
     }
+
+    @Test func invalidModelIdentifiersNeverReachLifecycleBackends() async throws {
+        let backend = StubBackend(generationResponse: emptyResponse)
+        let engine = SwamaEngine(backend: backend)
+        let invalidIDs = [
+            "../outside", "/absolute", "org//model", "org/./model", "org/../model",
+            "org\\model", "org/model/extra", " org/model", "org/model\n"
+        ]
+
+        for rawValue in invalidIDs {
+            let model = ModelID(rawValue)
+            do {
+                _ = try await engine.generate(.init(
+                    model: model,
+                    messages: [.init(role: .user, text: "hi")]
+                ))
+                Issue.record("invalid model ID reached generation: \(rawValue)")
+            }
+            catch let error as SwamaError {
+                #expect(error.code == .invalidRequest)
+            }
+
+            do {
+                _ = try await engine.embed(.init(model: model, inputs: ["hi"]))
+                Issue.record("invalid model ID reached embedding: \(rawValue)")
+            }
+            catch let error as SwamaError {
+                #expect(error.code == .invalidRequest)
+            }
+
+            do {
+                try await engine.fetch(model)
+                Issue.record("invalid model ID reached fetch: \(rawValue)")
+            }
+            catch let error as SwamaError {
+                #expect(error.code == .invalidRequest)
+            }
+
+            do {
+                try await engine.remove(model)
+                Issue.record("invalid model ID reached removal: \(rawValue)")
+            }
+            catch let error as SwamaError {
+                #expect(error.code == .invalidRequest)
+            }
+
+            await engine.clearCache(for: model)
+        }
+
+        #expect(await backend.generationCalls == 0)
+        #expect(await backend.embeddingCalls == 0)
+        #expect(await backend.fetchCalls == 0)
+        #expect(await backend.removeCalls == 0)
+        #expect(await backend.modelCacheClearCalls == 0)
+    }
+
+    @Test func invalidRoleFieldsAndSamplingValuesFailBeforeBackendExecution() async throws {
+        let backend = StubBackend(generationResponse: emptyResponse)
+        let engine = SwamaEngine(backend: backend)
+        let model = ModelID("org/model")
+        let toolCall = ToolCall(name: "lookup", arguments: [:])
+        let invalidMessages: [Message] = [
+            .init(role: .user, content: [.text("hi")], toolCalls: [toolCall]),
+            .init(role: .system, content: [.text("hi")], toolCallID: "call-1"),
+            .init(role: .assistant, content: [.text("hi")], toolCallID: "call-1"),
+            .init(role: .tool, content: [.text("result")]),
+            .init(role: .tool, content: [.text("result")], toolCalls: [toolCall], toolCallID: "call-1")
+        ]
+        let invalidOptions: [GenerationOptions] = [
+            .init(temperature: .infinity),
+            .init(temperature: .nan),
+            .init(topP: .infinity),
+            .init(minP: .nan),
+            .init(repetitionPenalty: -0.1),
+            .init(repetitionPenalty: .infinity),
+            .init(presencePenalty: 2.1),
+            .init(presencePenalty: .nan),
+            .init(frequencyPenalty: -2.1),
+            .init(frequencyPenalty: .infinity)
+        ]
+
+        for message in invalidMessages {
+            do {
+                _ = try await engine.generate(.init(model: model, messages: [message]))
+                Issue.record("role-inapplicable message fields reached the backend")
+            }
+            catch let error as SwamaError {
+                #expect(error.code == .invalidRequest)
+            }
+        }
+        for options in invalidOptions {
+            do {
+                _ = try await engine.generate(.init(
+                    model: model,
+                    messages: [.init(role: .user, text: "hi")],
+                    options: options
+                ))
+                Issue.record("invalid sampling value reached the backend")
+            }
+            catch let error as SwamaError {
+                #expect(error.code == .invalidRequest)
+            }
+        }
+
+        #expect(await backend.generationCalls == 0)
+    }
+
+    private var emptyResponse: GenerationResponse {
+        .init(
+            output: "",
+            toolCalls: [],
+            usage: .init(promptTokens: 0, completionTokens: 0),
+            finishReason: .completed
+        )
+    }
 }
 
 // MARK: - EventCollector
@@ -143,16 +263,21 @@ private actor StubBackend: SwamaEngineBackend {
     }
 
     func embed(_: EmbeddingRequest) async throws -> EmbeddingResponse {
-        .init(embeddings: [[1]], usage: .init(promptTokens: 1, completionTokens: 0))
+        embeddingCalls += 1
+        return .init(embeddings: [[1]], usage: .init(promptTokens: 1, completionTokens: 0))
     }
 
     func models() async throws -> [ModelInfo] { [] }
-    func fetch(_: ModelID) async throws {}
-    func remove(_: ModelID) async throws {}
-    func clearCache(for _: ModelID) async {}
+    func fetch(_: ModelID) async throws { fetchCalls += 1 }
+    func remove(_: ModelID) async throws { removeCalls += 1 }
+    func clearCache(for _: ModelID) async { modelCacheClearCalls += 1 }
     func clearCache() async {}
 
     private let generationResponse: GenerationResponse
     private let cancelGeneration: Bool
     private(set) var generationCalls = 0
+    private(set) var embeddingCalls = 0
+    private(set) var fetchCalls = 0
+    private(set) var removeCalls = 0
+    private(set) var modelCacheClearCalls = 0
 }

--- a/swama/Tests/SwamaRuntimeTests/RuntimeCoreEngineTests.swift
+++ b/swama/Tests/SwamaRuntimeTests/RuntimeCoreEngineTests.swift
@@ -18,7 +18,7 @@ struct RuntimeCoreEngineTests {
             await events.append(event)
         }
 
-        #expect(!result.output.isEmpty)
+        #expect(result.output.isEmpty == false)
         #expect(result.usage.promptTokens > 0)
         #expect(result.usage.completionTokens == 4)
         #expect(result.finishReason == .length)
@@ -119,6 +119,12 @@ struct RuntimeCoreEngineTests {
             "beshkenadze/cohere-transcribe-03-2026-mlx-fp16",
             "FireRedTeam/FireRedASR-AED-L-MLX",
             "mlx-community/LASR-CTC-Large",
+            "moss-ttsd",
+            "cosyvoice2",
+            "cosyvoice3",
+            "mlx-community/SenseVoiceSmall",
+            "mlx-community/VyvoTTS-EN-Beta-4bit",
+            "OpenMOSS-Team/MOSS-TTSD-v1.0",
             "mlx-community/Qwen3-ASR-0.6B-4bit",
             "mlx-community/Qwen3-TTS-0.6B",
             "mlx-community/Kokoro-82M"
@@ -131,7 +137,7 @@ struct RuntimeCoreEngineTests {
             "mlx-community/gemma-3-4b-it-4bit",
             "acme/watts-language-model"
         ] {
-            #expect(!RuntimeCoreEngine.isUnsupportedAudioModelID(model))
+            #expect(RuntimeCoreEngine.isUnsupportedAudioModelID(model) == false)
         }
     }
 
@@ -158,7 +164,7 @@ struct RuntimeCoreEngineTests {
         }
 
         let invalid = "../outside-model-root"
-        #expect(!RuntimeCoreEngine.isValidModelID(invalid))
+        #expect(RuntimeCoreEngine.isValidModelID(invalid) == false)
         do {
             try await RuntimeCoreEngine(pool: makePool()).remove(invalid)
             Issue.record("runtime accepted a traversing model ID")
@@ -210,17 +216,17 @@ struct RuntimeCoreEngineTests {
             modelType: "gemma3"
         )
         #expect(supported.embeddings)
-        #expect(!supported.textGeneration)
-        #expect(!supported.vision)
+        #expect(supported.textGeneration == false)
+        #expect(supported.vision == false)
 
         let unsupported = RuntimeCoreEngine.capabilities(
             for: "mlx-community/nomicai-modernbert-embed-base-4bit",
             modelType: "modernbert"
         )
-        #expect(!unsupported.embeddings)
-        #expect(!unsupported.textGeneration)
-        #expect(!unsupported.vision)
-        #expect(!unsupported.tools)
+        #expect(unsupported.embeddings == false)
+        #expect(unsupported.textGeneration == false)
+        #expect(unsupported.vision == false)
+        #expect(unsupported.tools == false)
     }
 
     @Test func audioIdentifiersCannotEnterTheCoreRuntime() async throws {
@@ -379,11 +385,21 @@ private func makeToolSchemaContainer() -> MLXLMCommon.ModelContainer {
 // MARK: - ToolScriptTokenizer
 
 private struct ToolScriptTokenizer: MLXLMCommon.Tokenizer {
-    var bosToken: String? { nil }
-    var eosToken: String? { nil }
-    var unknownToken: String? { nil }
+    var bosToken: String? {
+        nil
+    }
 
-    func encode(text _: String, addSpecialTokens _: Bool) -> [Int] { [0] }
+    var eosToken: String? {
+        nil
+    }
+
+    var unknownToken: String? {
+        nil
+    }
+
+    func encode(text _: String, addSpecialTokens _: Bool) -> [Int] {
+        [0]
+    }
 
     func decode(tokenIds: [Int], skipSpecialTokens _: Bool) -> String {
         tokenIds.map { token in
@@ -395,7 +411,12 @@ private struct ToolScriptTokenizer: MLXLMCommon.Tokenizer {
     }
 
     func convertTokenToId(_ token: String) -> Int? {
-        token.isEmpty ? 0 : 1
+        if token.isEmpty {
+            0
+        }
+        else {
+            1
+        }
     }
 
     func convertIdToToken(_ id: Int) -> String? {
@@ -426,7 +447,9 @@ private struct ToolScriptProcessor: UserInputProcessor {
 
 private final class ToolScriptModel: MLXNN.Module, LLMModel, KVCacheDimensionProvider {
     let kvHeads = [1]
-    var loraLayers: [MLXNN.Module] { [] }
+    var loraLayers: [MLXNN.Module] {
+        []
+    }
 
     func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
         let sequenceLength = inputs.dim(1)

--- a/swama/Tests/SwamaRuntimeTests/RuntimeCoreEngineTests.swift
+++ b/swama/Tests/SwamaRuntimeTests/RuntimeCoreEngineTests.swift
@@ -1,5 +1,9 @@
 import Foundation
+import MLX
 @testable import MLXEmbedders
+import MLXLLM
+@preconcurrency import MLXLMCommon
+import MLXNN
 @testable import SwamaRuntime
 import Testing
 
@@ -111,6 +115,10 @@ struct RuntimeCoreEngineTests {
     @Test func publicModelCatalogRejectsLegacyAudioIdentifiers() {
         for model in [
             "whisper-tiny",
+            "funasr",
+            "beshkenadze/cohere-transcribe-03-2026-mlx-fp16",
+            "FireRedTeam/FireRedASR-AED-L-MLX",
+            "mlx-community/LASR-CTC-Large",
             "mlx-community/Qwen3-ASR-0.6B-4bit",
             "mlx-community/Qwen3-TTS-0.6B",
             "mlx-community/Kokoro-82M"
@@ -120,9 +128,79 @@ struct RuntimeCoreEngineTests {
         for model in [
             "mlx-community/Qwen3-1.7B-4bit",
             "mlx-community/embeddinggemma-300m-4bit",
-            "mlx-community/gemma-3-4b-it-4bit"
+            "mlx-community/gemma-3-4b-it-4bit",
+            "acme/watts-language-model"
         ] {
             #expect(!RuntimeCoreEngine.isUnsupportedAudioModelID(model))
+        }
+    }
+
+    @Test func modelIdentifiersAndFilesystemOperationsRejectTraversal() async throws {
+        let fileManager = FileManager.default
+        let temporaryRoot = fileManager.temporaryDirectory
+            .appendingPathComponent("swama-core-path-test-\(UUID().uuidString)")
+        let modelsRoot = temporaryRoot.appendingPathComponent("models")
+        let outsideRoot = temporaryRoot.appendingPathComponent("outside-model-root")
+        try fileManager.createDirectory(at: modelsRoot, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: outsideRoot, withIntermediateDirectories: true)
+        try Data("{}".utf8).write(to: outsideRoot.appendingPathComponent(".swama-meta.json"))
+
+        let priorModelsRoot = ProcessInfo.processInfo.environment["SWAMA_MODELS"]
+        setenv("SWAMA_MODELS", modelsRoot.path, 1)
+        defer {
+            if let priorModelsRoot {
+                setenv("SWAMA_MODELS", priorModelsRoot, 1)
+            }
+            else {
+                unsetenv("SWAMA_MODELS")
+            }
+            try? fileManager.removeItem(at: temporaryRoot)
+        }
+
+        let invalid = "../outside-model-root"
+        #expect(!RuntimeCoreEngine.isValidModelID(invalid))
+        do {
+            try await RuntimeCoreEngine(pool: makePool()).remove(invalid)
+            Issue.record("runtime accepted a traversing model ID")
+        }
+        catch let error as RuntimeCoreError {
+            #expect(error.code == .invalidRequest)
+        }
+        #expect(fileManager.fileExists(atPath: outsideRoot.path))
+
+        let containedModel = modelsRoot.appendingPathComponent("org/model")
+        try fileManager.createDirectory(at: containedModel, withIntermediateDirectories: true)
+        let forgedMetadata = try JSONSerialization.data(withJSONObject: ["path": outsideRoot.path])
+        try forgedMetadata.write(to: containedModel.appendingPathComponent(".swama-meta.json"))
+        #expect(ModelPaths.getModelDirectory(for: "org/model").standardizedFileURL == containedModel
+            .standardizedFileURL
+        )
+
+        do {
+            _ = try ModelPaths.removeModel(invalid)
+            Issue.record("filesystem boundary accepted a traversing model ID")
+        }
+        catch {
+            #expect(error is ModelPathError)
+        }
+        #expect(fileManager.fileExists(atPath: outsideRoot.path))
+
+        do {
+            _ = try ModelPaths.containedURL(in: modelsRoot, relativePath: "../../escaped.json")
+            Issue.record("download destination escaped its model directory")
+        }
+        catch {
+            #expect(error is ModelPathError)
+        }
+
+        let symlink = modelsRoot.appendingPathComponent("linked-outside")
+        try fileManager.createSymbolicLink(at: symlink, withDestinationURL: outsideRoot)
+        do {
+            _ = try ModelPaths.containedURL(in: modelsRoot, relativePath: "linked-outside/file.json")
+            Issue.record("symlinked download destination escaped its model directory")
+        }
+        catch {
+            #expect(error is ModelPathError)
         }
     }
 
@@ -180,6 +258,51 @@ struct RuntimeCoreEngineTests {
         #expect(RuntimeToolCall(call.mlxValue) == call)
     }
 
+    @Test func toolSchemasReachBypassCacheMissAndCacheHitGeneration() async throws {
+        let tool = RuntimeToolDefinition(
+            name: "lookup",
+            description: nil,
+            parameters: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "enabled": .object(["type": .string("boolean")]),
+                    "count": .object(["type": .string("integer")])
+                ])
+            ])
+        )
+        let tools = [tool.mlxValue]
+        let parameters = GenerateParameters(maxTokens: 1, temperature: 0)
+
+        let bypassRunner = ModelRunner(
+            container: makeToolSchemaContainer(),
+            promptCacheStore: PromptCacheStore()
+        )
+        let bypass = try await bypassRunner.runChat(
+            userInput: .init(
+                chat: [.user("first", images: [.url(#require(URL(string: "https://example.invalid/image.png")))])],
+                tools: tools
+            ),
+            parameters: parameters
+        )
+        assertTypedToolCall(bypass.toolCalls)
+
+        let cacheRunner = ModelRunner(
+            container: makeToolSchemaContainer(),
+            promptCacheStore: PromptCacheStore()
+        )
+        let miss = try await cacheRunner.runChat(
+            userInput: .init(chat: [.user("first")], tools: tools),
+            parameters: parameters
+        )
+        assertTypedToolCall(miss.toolCalls)
+
+        let hit = try await cacheRunner.runChat(
+            userInput: .init(chat: [.user("first"), .user("second")], tools: tools),
+            parameters: parameters
+        )
+        assertTypedToolCall(hit.toolCalls)
+    }
+
     private func request(maxTokens: Int) -> RuntimeGenerationRequest {
         .init(
             model: "test/model",
@@ -223,6 +346,99 @@ struct RuntimeCoreEngineTests {
                 loadEmbedding: { _ in fatalError("unexpected embedding load") }
             )
         )
+    }
+}
+
+private func assertTypedToolCall(_ calls: [MLXLMCommon.ToolCall]) {
+    #expect(calls.count == 1)
+    guard let call = calls.first else {
+        return
+    }
+
+    let runtimeCall = RuntimeToolCall(call)
+    #expect(runtimeCall.name == "lookup")
+    #expect(runtimeCall.arguments["enabled"] == .bool(true))
+    #expect(runtimeCall.arguments["count"] == .int(2))
+}
+
+private func makeToolSchemaContainer() -> MLXLMCommon.ModelContainer {
+    let tokenizer = ToolScriptTokenizer()
+    let configuration = MLXLMCommon.ModelConfiguration(
+        id: "tool-schema-test",
+        toolCallFormat: .lfm2
+    )
+    let context = MLXLMCommon.ModelContext(
+        configuration: configuration,
+        model: ToolScriptModel(),
+        processor: ToolScriptProcessor(),
+        tokenizer: tokenizer
+    )
+    return MLXLMCommon.ModelContainer(context: context)
+}
+
+// MARK: - ToolScriptTokenizer
+
+private struct ToolScriptTokenizer: MLXLMCommon.Tokenizer {
+    var bosToken: String? { nil }
+    var eosToken: String? { nil }
+    var unknownToken: String? { nil }
+
+    func encode(text _: String, addSpecialTokens _: Bool) -> [Int] { [0] }
+
+    func decode(tokenIds: [Int], skipSpecialTokens _: Bool) -> String {
+        tokenIds.map { token in
+            token == 1
+                ? "<|tool_call_start|>[lookup(enabled='true', count='2')]<|tool_call_end|>"
+                : ""
+        }
+        .joined()
+    }
+
+    func convertTokenToId(_ token: String) -> Int? {
+        token.isEmpty ? 0 : 1
+    }
+
+    func convertIdToToken(_ id: Int) -> String? {
+        decode(tokenIds: [id], skipSpecialTokens: false)
+    }
+
+    func applyChatTemplate(
+        messages: [[String: any Sendable]],
+        tools _: [[String: any Sendable]]?,
+        additionalContext _: [String: any Sendable]?
+    ) throws -> [Int] {
+        Array(repeating: 0, count: max(messages.count, 1))
+    }
+}
+
+// MARK: - ToolScriptProcessor
+
+private struct ToolScriptProcessor: UserInputProcessor {
+    private let generator = MLXLMCommon.DefaultMessageGenerator()
+
+    func prepare(input: MLXLMCommon.UserInput) throws -> LMInput {
+        let messages = generator.generate(from: input)
+        return LMInput(tokens: MLXArray(Array(repeating: Int32(0), count: max(messages.count, 1))))
+    }
+}
+
+// MARK: - ToolScriptModel
+
+private final class ToolScriptModel: MLXNN.Module, LLMModel, KVCacheDimensionProvider {
+    let kvHeads = [1]
+    var loraLayers: [MLXNN.Module] { [] }
+
+    func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+        let sequenceLength = inputs.dim(1)
+        let values = inputs.asType(.float32).reshaped([1, 1, sequenceLength, 1])
+        if let cache {
+            for layer in cache {
+                _ = layer.update(keys: values, values: values)
+            }
+        }
+
+        let logits: [Float] = [0, 10, 0]
+        return MLXArray(Array(repeating: logits, count: sequenceLength).flatMap(\.self), [1, sequenceLength, 3])
     }
 }
 

--- a/swama/Tests/SwamaRuntimeTests/RuntimeCoreEngineTests.swift
+++ b/swama/Tests/SwamaRuntimeTests/RuntimeCoreEngineTests.swift
@@ -1,0 +1,249 @@
+import Foundation
+@testable import MLXEmbedders
+@testable import SwamaRuntime
+import Testing
+
+// MARK: - RuntimeCoreEngineTests
+
+@Suite("Runtime Core bridge", .serialized)
+struct RuntimeCoreEngineTests {
+    @Test func generationMapsTextUsageFinishAndAwaitedEvents() async throws {
+        let engine = RuntimeCoreEngine(pool: makePool())
+        let events = RuntimeEventCollector()
+        let result = try await engine.generate(request(maxTokens: 4)) { event in
+            await events.append(event)
+        }
+
+        #expect(!result.output.isEmpty)
+        #expect(result.usage.promptTokens > 0)
+        #expect(result.usage.completionTokens == 4)
+        #expect(result.finishReason == .length)
+        #expect(await events.text == result.output)
+    }
+
+    @Test func callbackCancellationThrowsInsteadOfReturningPartialResponse() async throws {
+        let engine = RuntimeCoreEngine(pool: makePool())
+        do {
+            _ = try await engine.generate(request(maxTokens: 20)) { event in
+                if case .textDelta = event {
+                    throw CancellationError()
+                }
+            }
+            Issue.record("cancelled runtime generation returned a response")
+        }
+        catch {
+            #expect(error is CancellationError)
+        }
+    }
+
+    @Test func invalidImageDataUsesABoundedRuntimeError() async throws {
+        let engine = RuntimeCoreEngine(pool: makePool())
+        let invalid = RuntimeGenerationRequest(
+            model: "test/model",
+            messages: [.init(
+                role: .user,
+                content: [.imageData(Data([0x00]), mediaType: "image/png")],
+                toolCalls: [],
+                toolCallID: nil
+            )],
+            options: options(maxTokens: 1),
+            tools: []
+        )
+
+        do {
+            _ = try await engine.generate(invalid)
+            Issue.record("invalid image unexpectedly reached generation")
+        }
+        catch let error as RuntimeCoreError {
+            #expect(error.code == .invalidImage)
+            #expect(error.model == nil)
+        }
+    }
+
+    @Test func requestScopedContextLimitIsEnforced() async throws {
+        let engine = RuntimeCoreEngine(pool: makePool())
+        var limited = request(maxTokens: 1)
+        limited = .init(
+            model: limited.model,
+            messages: limited.messages,
+            options: options(maxTokens: 1, contextLimit: 1),
+            tools: limited.tools
+        )
+
+        do {
+            _ = try await engine.generate(limited)
+            Issue.record("request-scoped context limit was ignored")
+        }
+        catch let error as RuntimeCoreError {
+            #expect(error.code == .contextLimitExceeded)
+        }
+    }
+
+    @Test func embeddingMapsVectorsAndUsage() async throws {
+        let tokenizer = WordVocabTokenizer(contentVocabSize: 16)
+        let container = EmbedderModelContainer(context: .init(
+            configuration: .init(id: "runtime-core-embedding"),
+            model: FixedEmbeddingModel(),
+            tokenizer: tokenizer,
+            pooling: Pooling(strategy: .mean)
+        ))
+        let runner = EmbeddingRunner(container: container)
+        let pool = ModelPool(
+            memoryHooks: .init(activeMemory: { 0 }, clearCache: {}),
+            loadOverrides: .init(
+                modelExistsLocally: { _ in true },
+                determineIsVLM: { _ in false },
+                loadLanguage: { _, _ in fatalError("unexpected language load") },
+                loadEmbedding: { _ in runner }
+            )
+        )
+        let result = try await RuntimeCoreEngine(pool: pool).embed(.init(
+            model: "test/embedding",
+            inputs: ["w1 w2", "w3"]
+        ))
+
+        #expect(result.embeddings.count == 2)
+        #expect(result.embeddings.allSatisfy { $0.count == 2 })
+        #expect(result.usage.promptTokens == 3)
+        #expect(result.usage.completionTokens == 0)
+    }
+
+    @Test func publicModelCatalogRejectsLegacyAudioIdentifiers() {
+        for model in [
+            "whisper-tiny",
+            "mlx-community/Qwen3-ASR-0.6B-4bit",
+            "mlx-community/Qwen3-TTS-0.6B",
+            "mlx-community/Kokoro-82M"
+        ] {
+            #expect(RuntimeCoreEngine.isUnsupportedAudioModelID(model))
+        }
+        for model in [
+            "mlx-community/Qwen3-1.7B-4bit",
+            "mlx-community/embeddinggemma-300m-4bit",
+            "mlx-community/gemma-3-4b-it-4bit"
+        ] {
+            #expect(!RuntimeCoreEngine.isUnsupportedAudioModelID(model))
+        }
+    }
+
+    @Test func embeddingCapabilityRequiresASupportedLocalModelType() {
+        let supported = RuntimeCoreEngine.capabilities(
+            for: "mlx-community/embeddinggemma-300m-4bit",
+            modelType: "gemma3"
+        )
+        #expect(supported.embeddings)
+        #expect(!supported.textGeneration)
+        #expect(!supported.vision)
+
+        let unsupported = RuntimeCoreEngine.capabilities(
+            for: "mlx-community/nomicai-modernbert-embed-base-4bit",
+            modelType: "modernbert"
+        )
+        #expect(!unsupported.embeddings)
+        #expect(!unsupported.textGeneration)
+        #expect(!unsupported.vision)
+        #expect(!unsupported.tools)
+    }
+
+    @Test func audioIdentifiersCannotEnterTheCoreRuntime() async throws {
+        let engine = RuntimeCoreEngine(pool: makePool())
+        do {
+            _ = try await engine.generate(.init(
+                model: "whisper-tiny",
+                messages: [.init(
+                    role: .user,
+                    content: [.text("transcribe")],
+                    toolCalls: [],
+                    toolCallID: nil
+                )],
+                options: options(maxTokens: 1),
+                tools: []
+            ))
+            Issue.record("audio identifier entered generation")
+        }
+        catch let error as RuntimeCoreError {
+            #expect(error.code == .invalidRequest)
+            #expect(error.model == "whisper-tiny")
+        }
+    }
+
+    @Test func toolCallJSONRoundTripsAcrossTheRuntimeBoundary() {
+        let call = RuntimeToolCall(
+            id: "call-1",
+            name: "lookup",
+            arguments: [
+                "enabled": .bool(true),
+                "count": .int(2),
+                "nested": .object(["value": .string("x")])
+            ]
+        )
+        #expect(RuntimeToolCall(call.mlxValue) == call)
+    }
+
+    private func request(maxTokens: Int) -> RuntimeGenerationRequest {
+        .init(
+            model: "test/model",
+            messages: [.init(
+                role: .user,
+                content: [.text("w1 w2")],
+                toolCalls: [],
+                toolCallID: nil
+            )],
+            options: options(maxTokens: maxTokens),
+            tools: []
+        )
+    }
+
+    private func options(maxTokens: Int, contextLimit: Int = 4096) -> RuntimeGenerationOptions {
+        .init(
+            maxTokens: maxTokens,
+            temperature: 0,
+            topP: 1,
+            topK: 0,
+            minP: 0,
+            repetitionPenalty: nil,
+            repetitionContextSize: 20,
+            presencePenalty: nil,
+            presenceContextSize: 20,
+            frequencyPenalty: nil,
+            frequencyContextSize: 20,
+            seed: 1,
+            contextLimit: contextLimit
+        )
+    }
+
+    private func makePool() -> ModelPool {
+        let container = makeTestContainer().container
+        return ModelPool(
+            memoryHooks: .init(activeMemory: { 0 }, clearCache: {}),
+            loadOverrides: .init(
+                modelExistsLocally: { _ in true },
+                determineIsVLM: { _ in false },
+                loadLanguage: { _, _ in container },
+                loadEmbedding: { _ in fatalError("unexpected embedding load") }
+            )
+        )
+    }
+}
+
+// MARK: - RuntimeEventCollector
+
+private actor RuntimeEventCollector {
+    func append(_ event: RuntimeGenerationEvent) {
+        events.append(event)
+    }
+
+    var text: String {
+        events.compactMap { event in
+            if case let .textDelta(value) = event {
+                value
+            }
+            else {
+                nil
+            }
+        }
+        .joined()
+    }
+
+    private var events: [RuntimeGenerationEvent] = []
+}

--- a/swama/Tests/SwamaRuntimeTests/RuntimeLineageTests.swift
+++ b/swama/Tests/SwamaRuntimeTests/RuntimeLineageTests.swift
@@ -158,7 +158,7 @@ private let lineage: [LineageEntry] = [
     .init(
         path: "Model/ModelRunner.swift",
         legacySHA256: "c5715822d87ff73f9ca54f8577d1f9873a45088b098575b464a1a4660903ef3e",
-        runtimeSHA256: "7b1feb15e90047e8963c045a757f85d6728e2c0967d54c7bb71e600ee116f34a",
+        runtimeSHA256: "51bfa63e4a30504fcb06f12473c673d31663a7bdf18090c11b00cd2c2016e3e0",
         derivedSymbols: ["actor ModelRunner", "struct ChatRunResult", "func runChat"]
     ),
     .init(

--- a/swama/Tests/SwamaRuntimeTests/RuntimeLineageTests.swift
+++ b/swama/Tests/SwamaRuntimeTests/RuntimeLineageTests.swift
@@ -37,7 +37,7 @@ struct RuntimeLineageTests {
 
 // MARK: - LineageEntry
 
-private struct LineageEntry: Sendable {
+private struct LineageEntry {
     let path: String
     let legacySHA256: String
     let runtimeSHA256: String
@@ -126,7 +126,7 @@ private let lineage: [LineageEntry] = [
     .init(
         path: "Model/ModelDownloader.swift",
         legacySHA256: "2c9d70bf028ea98e445518b62cd7306791a1d1833640fbf6c4ae6b13bbda6bd3",
-        runtimeSHA256: "1a398c7e9ad593701a67b268b5722e5d41990088fb576f1e6c7288de331083ae",
+        runtimeSHA256: "9483e3b49da81478966c1cfee4b741db5ba744fef75d5dca094208ed5b00d682",
         derivedSymbols: ["enum ModelDownloader", "static func downloadModel", "static func fetchModel"]
     ),
     .init(
@@ -138,7 +138,7 @@ private let lineage: [LineageEntry] = [
     .init(
         path: "Model/ModelPaths.swift",
         legacySHA256: "6a9d06eccae50a263918f02d20db2c080c283bc1a39091b43aced760dd61b970",
-        runtimeSHA256: "02fd17c31c6876b2e8cb89ca5b6f814191e35fafe9147d40e6cd8b33576819ad",
+        runtimeSHA256: "98723afb43af742da669d786f916ce0846a286db79dbe2b8bc10e4a726386219",
         derivedSymbols: ["enum ModelPaths", "static func getModelDirectory", "static func removeModel"]
     ),
     .init(
@@ -158,7 +158,7 @@ private let lineage: [LineageEntry] = [
     .init(
         path: "Model/ModelRunner.swift",
         legacySHA256: "c5715822d87ff73f9ca54f8577d1f9873a45088b098575b464a1a4660903ef3e",
-        runtimeSHA256: "a0bf76f97db07edc815c296c281f27948c42de8a85e29d2c80bd7b5028bd63f0",
+        runtimeSHA256: "eb60d9b94d013522be7ceb2c810d1eb9027ce9f0ca958df68b585d04747fe32c",
         derivedSymbols: ["actor ModelRunner", "struct ChatRunResult", "func runChat"]
     ),
     .init(

--- a/swama/Tests/SwamaRuntimeTests/RuntimeLineageTests.swift
+++ b/swama/Tests/SwamaRuntimeTests/RuntimeLineageTests.swift
@@ -120,13 +120,13 @@ private let lineage: [LineageEntry] = [
     .init(
         path: "Model/ModelCreator.swift",
         legacySHA256: "5a1887f4d13f8a230c72241a4fe9e232170ded5beb1e71226db9a8cf05f7d77e",
-        runtimeSHA256: "d58301027704d95b6ca86666f469da866e1a6f202fea13128a062beb5093c919",
+        runtimeSHA256: "0c43f694704ec7595f9c084eec0788c6a360e4cdc8aefdd94186e6eaf0b0ed49",
         derivedSymbols: ["enum ModelCreator"]
     ),
     .init(
         path: "Model/ModelDownloader.swift",
         legacySHA256: "2c9d70bf028ea98e445518b62cd7306791a1d1833640fbf6c4ae6b13bbda6bd3",
-        runtimeSHA256: "38bf2a46c78a2988b3d8638159ec90ec8f68920e0cc6b4a45e5d932bf869da50",
+        runtimeSHA256: "1a398c7e9ad593701a67b268b5722e5d41990088fb576f1e6c7288de331083ae",
         derivedSymbols: ["enum ModelDownloader", "static func downloadModel", "static func fetchModel"]
     ),
     .init(
@@ -138,7 +138,7 @@ private let lineage: [LineageEntry] = [
     .init(
         path: "Model/ModelPaths.swift",
         legacySHA256: "6a9d06eccae50a263918f02d20db2c080c283bc1a39091b43aced760dd61b970",
-        runtimeSHA256: "9192dc4701507b081acbfe962f6638ea192e5cfdd212186e079cc9acc16f96ab",
+        runtimeSHA256: "02fd17c31c6876b2e8cb89ca5b6f814191e35fafe9147d40e6cd8b33576819ad",
         derivedSymbols: ["enum ModelPaths", "static func getModelDirectory", "static func removeModel"]
     ),
     .init(
@@ -158,7 +158,7 @@ private let lineage: [LineageEntry] = [
     .init(
         path: "Model/ModelRunner.swift",
         legacySHA256: "c5715822d87ff73f9ca54f8577d1f9873a45088b098575b464a1a4660903ef3e",
-        runtimeSHA256: "51bfa63e4a30504fcb06f12473c673d31663a7bdf18090c11b00cd2c2016e3e0",
+        runtimeSHA256: "a0bf76f97db07edc815c296c281f27948c42de8a85e29d2c80bd7b5028bd63f0",
         derivedSymbols: ["actor ModelRunner", "struct ChatRunResult", "func runChat"]
     ),
     .init(

--- a/swama/Tests/SwamaRuntimeTests/RuntimeParityTests.swift
+++ b/swama/Tests/SwamaRuntimeTests/RuntimeParityTests.swift
@@ -92,6 +92,14 @@ struct RuntimeParityTests {
                 "language ID was rejected: \(model)"
             )
         }
+
+        #expect(SwamaRuntime.RuntimeCoreEngine.isUnsupportedAudioModelID(
+            "acme/nemotron-language-nemotron-3.5-asr-streaming"
+        ))
+        #expect(SwamaRuntime.RuntimeCoreEngine.isUnsupportedAudioModelID("acme/nemotron-language") == false)
+        #expect(SwamaRuntime.RuntimeCoreEngine.isUnsupportedAudioModelID(
+            "acme/nemotron-3.5-language-asr"
+        ) == false)
     }
 }
 

--- a/swama/Tests/SwamaRuntimeTests/RuntimeParityTests.swift
+++ b/swama/Tests/SwamaRuntimeTests/RuntimeParityTests.swift
@@ -73,7 +73,7 @@ struct RuntimeParityTests {
 
 // MARK: - FixedEmbeddingModel
 
-private final class FixedEmbeddingModel: MLXNN.Module, EmbeddingModel {
+final class FixedEmbeddingModel: MLXNN.Module, EmbeddingModel {
     let vocabularySize = 32
     let poolingStrategy: Pooling.Strategy? = .mean
     let maxPositionEmbeddings: Int? = nil

--- a/swama/Tests/SwamaRuntimeTests/RuntimeParityTests.swift
+++ b/swama/Tests/SwamaRuntimeTests/RuntimeParityTests.swift
@@ -69,6 +69,30 @@ struct RuntimeParityTests {
         #expect(runtimeResult.usage.promptTokens == legacyResult.usage.promptTokens)
         #expect(runtimeResult.usage.totalTokens == legacyResult.usage.totalTokens)
     }
+
+    @Test func everyMaintainedAudioAliasIsExcludedWithoutRejectingLanguageAliases() {
+        let maintainedAudioIDs =
+            Array(SwamaKit.ModelAliasResolver.sttAliases.keys) +
+            Array(SwamaKit.ModelAliasResolver.sttAliases.values) +
+            Array(SwamaKit.ModelAliasResolver.ttsAliases.keys) +
+            Array(SwamaKit.ModelAliasResolver.ttsAliases.values)
+        for model in maintainedAudioIDs {
+            #expect(
+                SwamaRuntime.RuntimeCoreEngine.isUnsupportedAudioModelID(model),
+                "audio ID escaped Core: \(model)"
+            )
+        }
+
+        let maintainedLanguageIDs =
+            Array(SwamaKit.ModelAliasResolver.aliases.keys) +
+            Array(SwamaKit.ModelAliasResolver.aliases.values)
+        for model in maintainedLanguageIDs {
+            #expect(
+                SwamaRuntime.RuntimeCoreEngine.isUnsupportedAudioModelID(model) == false,
+                "language ID was rejected: \(model)"
+            )
+        }
+    }
 }
 
 // MARK: - FixedEmbeddingModel


### PR DESCRIPTION
## Summary

Adds the first functional, Swama-owned public Core API:

- public request, response, streaming, tool, embedding, model, capability, sampling, and error value types
- a public `SwamaEngine` entry point for generation, embeddings, model listing, preload, eviction, and cache clearing
- package-internal bridging to the no-Audio `SwamaRuntime`
- migration of the external acceptance fixture to consume only `SwamaCore`

The public compiler symbol graph contains 160 intentional Swama-owned symbols and no MLX, NIO, AppKit, or Audio types. `SwamaCore` directly depends only on `SwamaRuntime`; its transitive Audio dependency set is empty. The Runtime public graph remains empty.

## Compatibility and scope

This is additive. Existing `SwamaKit` production sources and behavior remain unchanged.

Deliberately excluded from this PR:

- CLI and HTTP migration to Core
- public audio/STT/TTS APIs
- FoundationModels integration
- deletion of the transitional legacy/runtime implementation

Model lifecycle paths use lexical plus existing-symlink containment checks. Tool schemas survive cache bypass/miss/hit paths, role/content combinations are validated, sampling rejects non-finite or out-of-range values, and Audio model aliases are rejected using parity against the maintained legacy catalog.

## Verification

Exact reviewed head: `cb6009c1c2d265f51cd67fb7d4fc0f96dd22c18b`

- Swama tests: 277/277
- acceptance harness: 45/45
- pinned SwiftFormat 0.56.2: 0/116 findings
- stable release build: pass
- external pure-Core fixture release build: pass
- real Core generation, embedding, cancellation, and model catalog probes: pass
- compiler public manifest: 160 intentional Core symbols, 0 upstream leaks
- independent second-machine custody and code-semantics reviews: GO

This PR does not release or deploy anything.
