### PR TITLE
Route swama run through SwamaCore

### DIFF
--- a/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
+++ b/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
@@ -400,6 +400,15 @@ struct AcceptanceTests {
         #expect(declarations.map(\.line) == [1, 2, 3])
     }
 
+    @Test func cliRunSourceUsesCoreWithoutLegacyRuntimeImports() throws {
+        let file = repositoryRoot.appendingPathComponent("swama/Sources/Swama/CLI/Run.swift")
+        let source = try String(contentsOf: file, encoding: .utf8)
+        let imports = try Set(parsedSwiftImports(source: source, file: file).map(\.module))
+
+        #expect(imports.contains("SwamaCore"))
+        #expect(imports.isDisjoint(with: ["MLX", "MLXLLM", "MLXLMCommon", "SwamaKit"]))
+    }
+
     @Test func compilerPublicAPIGateRejectsUpstreamTypesAndConformances() throws {
         let graph: JSONObject = [
             "module": ["name": "SwamaCore"],

--- a/swama/Package.swift
+++ b/swama/Package.swift
@@ -140,7 +140,7 @@ let package = Package(
         ),
         .testTarget(
             name: "SwamaCLITests",
-            dependencies: ["Swama", "SwamaCore"]
+            dependencies: ["Swama", "SwamaCore", "SwamaRuntime"]
         ),
     ]
 )

--- a/swama/Package.swift
+++ b/swama/Package.swift
@@ -107,6 +107,7 @@ let package = Package(
         .executableTarget(
             name: "Swama",
             dependencies: [
+                .target(name: "SwamaCore"),
                 .target(name: "SwamaKit"),
                 .target(name: "SwamaServer"),
                 .target(name: "SwamaAppSupport"),
@@ -136,6 +137,10 @@ let package = Package(
         .testTarget(
             name: "SwamaCoreTests",
             dependencies: ["SwamaCore"]
+        ),
+        .testTarget(
+            name: "SwamaCLITests",
+            dependencies: ["Swama", "SwamaCore"]
         ),
     ]
 )

--- a/swama/Sources/Swama/CLI/Run.swift
+++ b/swama/Sources/Swama/CLI/Run.swift
@@ -121,6 +121,14 @@ enum RunRoute: Equatable {
     case server
 }
 
+// MARK: - RunExecutionOperations
+
+struct RunExecutionOperations {
+    let fetch: (ModelID) async throws -> ModelID
+    let core: (ModelID) async throws -> Void
+    let server: (ModelID) async throws -> Void
+}
+
 // MARK: - Run
 
 struct Run: AsyncParsableCommand {
@@ -186,75 +194,77 @@ struct Run: AsyncParsableCommand {
 
     func run() async throws {
         try await SwamaEngine.withCLIDiagnostics {
-            let route = try executionRoute()
-            if route == .server {
-                try validateServerOptions()
-            }
-
             let engine = SwamaEngine()
-            let resolvedModel = try await engine.fetchResolved(ModelID(modelName))
+            try await execute(using: .init(
+                fetch: { try await engine.fetchResolved($0) },
+                core: { try await runWithCore(engine: engine, model: $0) },
+                server: { try await runWithServer(model: $0) }
+            ))
+        }
+    }
 
-            switch route {
-            case .core:
-                try await runWithCore(engine: engine, model: resolvedModel)
+    func execute(using operations: RunExecutionOperations) async throws {
+        let route = try executionRoute()
+        if route == .server {
+            try validateServerOptions()
+        }
 
-            case .server:
-                if await isServerRunning() == false,
-                   await startServerAndWait() == false
-                {
-                    throw RunError.serverError("local server is unavailable")
-                }
-                try await runViaServer(modelName: resolvedModel.rawValue)
+        let resolvedModel = try await operations.fetch(ModelID(modelName))
+        switch route {
+        case .core:
+            try await operations.core(resolvedModel)
+        case .server:
+            try await operations.server(resolvedModel)
+        }
+    }
+
+    func waitForServerReady(
+        timeout: Duration,
+        checkInterval: Duration,
+        readiness: () async throws -> Bool
+    ) async throws -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while clock.now < deadline {
+            try Task.checkCancellation()
+            if try await readiness() {
+                return true
             }
+            try await Task.sleep(for: checkInterval)
+        }
+
+        try Task.checkCancellation()
+        return false
+    }
+
+    private func runWithServer(model: ModelID) async throws {
+        if try await isServerRunning() == false,
+           try await startServerAndWait() == false
+        {
+            throw RunError.serverError("local server is unavailable")
+        }
+        try await runViaServer(modelName: model.rawValue)
+    }
+
+    private func waitForServerReady(
+        timeout: Duration = .seconds(30),
+        checkInterval: Duration = .seconds(1)
+    ) async throws -> Bool {
+        try await waitForServerReady(timeout: timeout, checkInterval: checkInterval) {
+            try await isServerRunning()
         }
     }
 
-    func executionRoute() throws -> RunRoute {
-        guard direct == false || server == false else {
-            throw ValidationError("--direct and --server cannot be used together")
-        }
-
-        return server ? .server : .core
-    }
-
-    func validateServerOptions() throws {
-        guard commonOptions.resolvedContextLimit == nil else {
-            throw ValidationError("--context-limit/--num-ctx is not supported with --server")
-        }
-    }
-
-    func makeCoreRequest(modelName: String) -> GenerationRequest {
-        let images = imagePaths.map { path in
-            ContentPart.imageURL(URL(fileURLWithPath: path))
-        }
-        return GenerationRequest(
-            model: ModelID(modelName),
-            messages: [.init(role: .user, content: [.text(prompt)] + images)],
-            options: .init(
-                maxTokens: maxTokens,
-                temperature: temperature,
-                topP: topP,
-                repetitionPenalty: repetitionPenalty,
-                contextLimit: commonOptions.resolvedContextLimit
-            )
-        )
-    }
-
-    func encodedServerRequest(modelName: String) throws -> Data {
-        try JSONEncoder().encode(makeServerRequest(modelName: modelName))
-    }
-
-    // MARK: - Server Detection and Management
-
-    private func isServerRunning() async -> Bool {
+    private func isServerRunning() async throws -> Bool {
         do {
+            try Task.checkCancellation()
             let url = URL(string: "http://\(serverHost):\(serverPort)/v1/models")!
             var request = URLRequest(url: url)
             request.timeoutInterval = 2.0
 
             let (data, response) = try await URLSession.shared.data(for: request)
+            try Task.checkCancellation()
 
-            // Check both status code and that we got valid JSON response
             guard let httpResponse = response as? HTTPURLResponse,
                   httpResponse.statusCode == 200
             else {
@@ -265,19 +275,21 @@ struct Run: AsyncParsableCommand {
             return true
         }
         catch {
+            try Task.checkCancellation()
             return false
         }
     }
 
-    private func startServerAndWait() async -> Bool {
+    private func startServerAndWait() async throws -> Bool {
         let success = launchSwamaApp()
         if !success {
             return false
         }
 
-        // Wait for server to be ready
-        return await waitForServerReady()
+        return try await waitForServerReady()
     }
+
+    // MARK: - Server Detection and Management
 
     private func launchSwamaApp() -> Bool {
         let appPath = "/Applications/Swama.app"
@@ -299,20 +311,6 @@ struct Run: AsyncParsableCommand {
             }
         }
         return true
-    }
-
-    private func waitForServerReady(timeout: TimeInterval = 30) async -> Bool {
-        let startTime = Date()
-        let checkInterval: TimeInterval = 1.0
-
-        while Date().timeIntervalSince(startTime) < timeout {
-            if await isServerRunning() {
-                return true
-            }
-            try? await Task.sleep(nanoseconds: UInt64(checkInterval * 1_000_000_000))
-        }
-
-        return false
     }
 
     // MARK: - Common Processing
@@ -437,6 +435,41 @@ struct Run: AsyncParsableCommand {
                 }
             }
         }
+    }
+
+    func executionRoute() throws -> RunRoute {
+        guard direct == false || server == false else {
+            throw ValidationError("--direct and --server cannot be used together")
+        }
+
+        return server ? .server : .core
+    }
+
+    func validateServerOptions() throws {
+        guard commonOptions.resolvedContextLimit == nil else {
+            throw ValidationError("--context-limit/--num-ctx is not supported with --server")
+        }
+    }
+
+    func makeCoreRequest(modelName: String) -> GenerationRequest {
+        let images = imagePaths.map { path in
+            ContentPart.imageURL(URL(fileURLWithPath: path))
+        }
+        return GenerationRequest(
+            model: ModelID(modelName),
+            messages: [.init(role: .user, content: [.text(prompt)] + images)],
+            options: .init(
+                maxTokens: maxTokens,
+                temperature: temperature,
+                topP: topP,
+                repetitionPenalty: repetitionPenalty,
+                contextLimit: commonOptions.resolvedContextLimit
+            )
+        )
+    }
+
+    func encodedServerRequest(modelName: String) throws -> Data {
+        try JSONEncoder().encode(makeServerRequest(modelName: modelName))
     }
 
     private func sendNonStreamingRequest(_ request: CompletionRequest) async throws {

--- a/swama/Sources/Swama/CLI/Run.swift
+++ b/swama/Sources/Swama/CLI/Run.swift
@@ -1,10 +1,7 @@
 import AppKit
 import ArgumentParser
 import Foundation
-import MLX
-import MLXLLM
-@preconcurrency import MLXLMCommon
-import SwamaKit
+import SwamaCore
 
 // MARK: - CompletionRequest
 
@@ -14,6 +11,7 @@ private struct CompletionRequest: Codable {
     let temperature: Float?
     let top_p: Float?
     let max_tokens: Int?
+    let repetition_penalty: Float?
     let stream: Bool?
 }
 
@@ -116,6 +114,13 @@ private enum RunError: Error, LocalizedError {
     }
 }
 
+// MARK: - RunRoute
+
+enum RunRoute: Equatable {
+    case core
+    case server
+}
+
 // MARK: - Run
 
 struct Run: AsyncParsableCommand {
@@ -133,6 +138,7 @@ struct Run: AsyncParsableCommand {
           swama run gemma3 "What's in this image?" --image-paths image.jpg
           swama run llama-vision "Describe these images" -i img1.png -i img2.jpg
           swama run qwen3 "Explain this" --no-stream  # Disable streaming for complete response
+          swama run qwen3 "Hello" --server             # Explicitly use the local HTTP server
         """
     )
 
@@ -163,8 +169,11 @@ struct Run: AsyncParsableCommand {
     @Flag(name: [.customShort("s"), .long], inversion: .prefixedNo, help: "Enable streaming output (default: true)")
     var stream: Bool = true
 
-    @Flag(name: [.long], help: "Force direct model execution (bypass server)")
+    @Flag(name: [.long], help: "Use in-process execution (kept for compatibility; this is now the default)")
     var direct: Bool = false
+
+    @Flag(name: [.long], help: "Run through the local HTTP server instead of in-process SwamaCore")
+    var server: Bool = false
 
     @Option(name: [.long], help: "Server host (default: localhost)")
     var serverHost: String = "localhost"
@@ -176,43 +185,63 @@ struct Run: AsyncParsableCommand {
     var commonOptions: CommonRunOptions
 
     func run() async throws {
-        try await SwamaDiagnostics.withSession(mode: .cli) {
-            let resolvedModelName = try await ModelDownloader.fetchModel(modelName: modelName)
-
-            if let limit = commonOptions.resolvedContextLimit {
-                await ContextLimitConfig.shared.updateLimit(limit)
+        try await SwamaEngine.withCLIDiagnostics {
+            let route = try executionRoute()
+            if route == .server {
+                try validateServerOptions()
             }
 
-            if !direct {
-                if await isServerRunning() {
-                    do {
-                        try await runViaServer(modelName: resolvedModelName)
-                        return
-                    }
-                    catch {
-                        print("⚠️  Server request failed, falling back to direct execution...")
-                    }
-                }
-                else {
-                    // Try to start server silently
-                    if await startServerAndWait() {
-                        do {
-                            try await runViaServer(modelName: resolvedModelName)
-                            return
-                        }
-                        catch {
-                            print("⚠️  Server request failed, falling back to direct execution...")
-                        }
-                    }
-                    else {
-                        print("⚠️  Server startup failed, falling back to direct execution...")
-                    }
-                }
-            }
+            let engine = SwamaEngine()
+            let resolvedModel = try await engine.fetchResolved(ModelID(modelName))
 
-            // Fallback: Direct execution
-            try await runDirectly(modelName: resolvedModelName)
+            switch route {
+            case .core:
+                try await runWithCore(engine: engine, model: resolvedModel)
+
+            case .server:
+                if await isServerRunning() == false,
+                   await startServerAndWait() == false
+                {
+                    throw RunError.serverError("local server is unavailable")
+                }
+                try await runViaServer(modelName: resolvedModel.rawValue)
+            }
         }
+    }
+
+    func executionRoute() throws -> RunRoute {
+        guard direct == false || server == false else {
+            throw ValidationError("--direct and --server cannot be used together")
+        }
+
+        return server ? .server : .core
+    }
+
+    func validateServerOptions() throws {
+        guard commonOptions.resolvedContextLimit == nil else {
+            throw ValidationError("--context-limit/--num-ctx is not supported with --server")
+        }
+    }
+
+    func makeCoreRequest(modelName: String) -> GenerationRequest {
+        let images = imagePaths.map { path in
+            ContentPart.imageURL(URL(fileURLWithPath: path))
+        }
+        return GenerationRequest(
+            model: ModelID(modelName),
+            messages: [.init(role: .user, content: [.text(prompt)] + images)],
+            options: .init(
+                maxTokens: maxTokens,
+                temperature: temperature,
+                topP: topP,
+                repetitionPenalty: repetitionPenalty,
+                contextLimit: commonOptions.resolvedContextLimit
+            )
+        )
+    }
+
+    func encodedServerRequest(modelName: String) throws -> Data {
+        try JSONEncoder().encode(makeServerRequest(modelName: modelName))
     }
 
     // MARK: - Server Detection and Management
@@ -337,36 +366,37 @@ struct Run: AsyncParsableCommand {
             messageContent = .multimodal(contentParts)
         }
 
-        // Prepare request
-        let message = Message(role: "user", content: messageContent)
-        let request = CompletionRequest(
+        let request = makeServerRequest(modelName: modelName, content: messageContent)
+
+        showResponseHeader()
+
+        if stream {
+            try await sendStreamingRequest(request)
+        }
+        else {
+            try await sendNonStreamingRequest(request)
+        }
+
+        showCompletionIndicator()
+    }
+
+    private func makeServerRequest(
+        modelName: String,
+        content: MessageContent? = nil
+    ) -> CompletionRequest {
+        let message = Message(
+            role: "user",
+            content: content ?? .text(prompt)
+        )
+        return CompletionRequest(
             model: modelName,
             messages: [message],
             temperature: temperature,
             top_p: topP,
             max_tokens: maxTokens,
+            repetition_penalty: repetitionPenalty,
             stream: stream
         )
-
-        showResponseHeader()
-
-        // Send HTTP request with fallback
-        do {
-            if stream {
-                try await sendStreamingRequest(request)
-            }
-            else {
-                try await sendNonStreamingRequest(request)
-            }
-
-            showCompletionIndicator()
-        }
-        catch {
-            // If server request fails, fall back to direct execution
-            fputs("\n⚠️  Server request failed, falling back to direct execution...\n", stdout)
-            fflush(stdout)
-            try await runDirectly(modelName: modelName)
-        }
     }
 
     private func sendStreamingRequest(_ request: CompletionRequest) async throws {
@@ -439,9 +469,9 @@ struct Run: AsyncParsableCommand {
         print(content)
     }
 
-    // MARK: - Direct Execution (Fallback)
+    // MARK: - In-process Core Execution
 
-    private func runDirectly(modelName: String) async throws {
+    private func runWithCore(engine: SwamaEngine, model: ModelID) async throws {
         // Animation for model loading and response generation
         let animatedMessagePrefix = "Generating response"
         let spinnerFrames = ["/", "-", "\\", "|"]
@@ -487,21 +517,7 @@ struct Run: AsyncParsableCommand {
             // that's handled by the main thread's explicit cleanup or the defer block.
         }
 
-        // Use ModelPool to properly handle both LLM and VLM models
-        let modelPool = ModelPool.shared
-
-        // Validate and process image files
         try validateImageFiles()
-        var processedImages: [MLXLMCommon.UserInput.Image] = []
-        if !imagePaths.isEmpty {
-            for imagePath in imagePaths {
-                let imageURL = URL(fileURLWithPath: imagePath)
-                processedImages.append(.url(imageURL))
-            }
-        }
-
-        // Copy images to avoid capture issues in async closure
-        let imagesToUse = processedImages
 
         // Stop animation before starting output
         if let task = animationDisplayTask {
@@ -517,55 +533,21 @@ struct Run: AsyncParsableCommand {
 
         showResponseHeader()
 
-        let output = try await modelPool.run(modelName: modelName) { runner in
-            // Create chat messages with images if provided
-            let chatMessages: [MLXLMCommon.Chat.Message] = [
-                MLXLMCommon.Chat.Message(role: .user, content: prompt, images: imagesToUse)
-            ]
-            let userInput = MLXLMCommon.UserInput(chat: chatMessages)
-
-            if stream {
-                // Use streaming output for real-time response
-                let result = try await runner.runChat(
-                    userInput: userInput,
-                    parameters: .init(
-                        maxTokens: maxTokens,
-                        temperature: temperature,
-                        topP: topP,
-                        repetitionPenalty: repetitionPenalty
-                    ),
-                    onToken: { chunk in
-                        // Print each token as it's generated
-                        fputs(chunk, stdout)
-                        fflush(stdout)
-                    }
-                )
-
-                // Print newline after completion
-                fputs("\n", stdout)
-                fflush(stdout)
-
-                return result.output
+        let request = makeCoreRequest(modelName: model.rawValue)
+        let response: GenerationResponse
+        if stream {
+            response = try await engine.generate(request) { event in
+                if case let .textDelta(chunk) = event {
+                    fputs(chunk, stdout)
+                    fflush(stdout)
+                }
             }
-            else {
-                // Use non-streaming for complete response at once
-                let result = try await runner.runChatNonStream(
-                    userInput: userInput,
-                    parameters: .init(
-                        maxTokens: maxTokens,
-                        temperature: temperature,
-                        topP: topP,
-                        repetitionPenalty: repetitionPenalty
-                    )
-                )
-
-                return result.output
-            }
+            fputs("\n", stdout)
+            fflush(stdout)
         }
-
-        // For non-streaming mode, print the complete output
-        if !stream {
-            print(output)
+        else {
+            response = try await engine.generate(request)
+            print(response.output)
         }
 
         showCompletionIndicator()

--- a/swama/Sources/SwamaCore/SwamaEngine.swift
+++ b/swama/Sources/SwamaCore/SwamaEngine.swift
@@ -64,8 +64,12 @@ public actor SwamaEngine {
     }
 
     public func fetch(_ model: ModelID) async throws {
+        _ = try await fetchResolved(model)
+    }
+
+    package func fetchResolved(_ model: ModelID) async throws -> ModelID {
         try validate(model)
-        try await backend.fetch(model)
+        return try await backend.fetch(model)
     }
 
     public func remove(_ model: ModelID) async throws {
@@ -83,6 +87,12 @@ public actor SwamaEngine {
 
     public func clearCache() async {
         await backend.clearCache()
+    }
+
+    package static func withCLIDiagnostics<T>(
+        operation: () async throws -> T
+    ) async throws -> T {
+        try await SwamaDiagnostics.withSession(mode: .cli, operation: operation)
     }
 
     private let backend: any SwamaEngineBackend
@@ -190,7 +200,7 @@ protocol SwamaEngineBackend: Sendable {
 
     func embed(_ request: EmbeddingRequest) async throws -> EmbeddingResponse
     func models() async throws -> [ModelInfo]
-    func fetch(_ model: ModelID) async throws
+    func fetch(_ model: ModelID) async throws -> ModelID
     func remove(_ model: ModelID) async throws
     func clearCache(for model: ModelID) async
     func clearCache() async
@@ -241,9 +251,10 @@ private struct RuntimeEngineBackend: SwamaEngineBackend {
         await runtime.models().map(\.coreValue)
     }
 
-    func fetch(_ model: ModelID) async throws {
+    func fetch(_ model: ModelID) async throws -> ModelID {
         do {
-            try await runtime.fetch(model.rawValue)
+            let resolved = try await runtime.fetch(model.rawValue)
+            return .init(resolved)
         }
         catch let error as RuntimeCoreError {
             throw error.coreValue

--- a/swama/Sources/SwamaRuntime/CoreBridge/RuntimeCoreEngine.swift
+++ b/swama/Sources/SwamaRuntime/CoreBridge/RuntimeCoreEngine.swift
@@ -449,11 +449,11 @@ package actor RuntimeCoreEngine {
             .sorted { $0.id < $1.id }
     }
 
-    package func fetch(_ model: String) async throws {
+    package func fetch(_ model: String) async throws -> String {
         try validateModelID(model)
         try rejectUnsupportedAudioModel(model)
         do {
-            _ = try await ModelDownloader.fetchModel(modelName: model)
+            return try await ModelDownloader.fetchModel(modelName: model)
         }
         catch {
             throw mapError(error, model: model, fallback: .downloadFailed)

--- a/swama/Tests/SwamaCLITests/RunCommandTests.swift
+++ b/swama/Tests/SwamaCLITests/RunCommandTests.swift
@@ -105,6 +105,29 @@ struct RunCommandTests {
         ))
     }
 
+    @Test func serverCancellationKeepsItsTypeAndNeverFallsBackToCore() async throws {
+        let recorder = RunExecutionRecorder()
+        let command = try Run.parse(["alias", "hello", "--server"])
+        await #expect(throws: CancellationError.self) {
+            try await command.execute(using: .init(
+                fetch: {
+                    await recorder.recordFetch($0)
+                    return .init("org/resolved")
+                },
+                core: { await recorder.recordCore($0) },
+                server: {
+                    await recorder.recordServer($0)
+                    throw CancellationError()
+                }
+            ))
+        }
+        #expect(await recorder.snapshot() == .init(
+            fetched: [ModelID("alias")],
+            core: [],
+            server: [ModelID("org/resolved")]
+        ))
+    }
+
     @Test func readinessCancellationReturnsPromptly() async throws {
         let command = try Run.parse(["org/model", "hello", "--server"])
         let clock = ContinuousClock()

--- a/swama/Tests/SwamaCLITests/RunCommandTests.swift
+++ b/swama/Tests/SwamaCLITests/RunCommandTests.swift
@@ -2,9 +2,12 @@ import ArgumentParser
 import Foundation
 @testable import Swama
 import SwamaCore
+@testable import SwamaRuntime
 import Testing
 
-@Suite("swama run Core adapter")
+// MARK: - RunCommandTests
+
+@Suite("swama run Core adapter", .serialized)
 struct RunCommandTests {
     @Test func inProcessCoreIsTheDefaultAndDirectRemainsCompatible() throws {
         let defaultCommand = try Run.parse(["org/model", "hello"])
@@ -44,6 +47,121 @@ struct RunCommandTests {
         ])
     }
 
+    @Test func executionFetchesOnceAndRoutesTheResolvedModel() async throws {
+        let resolved = ModelID("org/resolved")
+        let coreRecorder = RunExecutionRecorder()
+        let coreCommand = try Run.parse(["alias", "hello"])
+        try await coreCommand.execute(using: .init(
+            fetch: {
+                await coreRecorder.recordFetch($0)
+                return resolved
+            },
+            core: { await coreRecorder.recordCore($0) },
+            server: { await coreRecorder.recordServer($0) }
+        ))
+        #expect(await coreRecorder.snapshot() == .init(
+            fetched: [ModelID("alias")],
+            core: [resolved],
+            server: []
+        ))
+
+        let serverRecorder = RunExecutionRecorder()
+        let serverCommand = try Run.parse(["alias", "hello", "--server"])
+        try await serverCommand.execute(using: .init(
+            fetch: {
+                await serverRecorder.recordFetch($0)
+                return resolved
+            },
+            core: { await serverRecorder.recordCore($0) },
+            server: { await serverRecorder.recordServer($0) }
+        ))
+        #expect(await serverRecorder.snapshot() == .init(
+            fetched: [ModelID("alias")],
+            core: [],
+            server: [resolved]
+        ))
+    }
+
+    @Test func serverFailureNeverFallsBackToCore() async throws {
+        let recorder = RunExecutionRecorder()
+        let command = try Run.parse(["alias", "hello", "--server"])
+        await #expect(throws: RunExecutionTestError.self) {
+            try await command.execute(using: .init(
+                fetch: {
+                    await recorder.recordFetch($0)
+                    return .init("org/resolved")
+                },
+                core: { await recorder.recordCore($0) },
+                server: {
+                    await recorder.recordServer($0)
+                    throw RunExecutionTestError.serverFailed
+                }
+            ))
+        }
+        #expect(await recorder.snapshot() == .init(
+            fetched: [ModelID("alias")],
+            core: [],
+            server: [ModelID("org/resolved")]
+        ))
+    }
+
+    @Test func readinessCancellationReturnsPromptly() async throws {
+        let command = try Run.parse(["org/model", "hello", "--server"])
+        let clock = ContinuousClock()
+        let start = clock.now
+        let task = Task {
+            try await command.waitForServerReady(
+                timeout: .seconds(1),
+                checkInterval: .milliseconds(500),
+                readiness: { false }
+            )
+        }
+
+        try await Task.sleep(for: .milliseconds(20))
+        task.cancel()
+        await #expect(throws: CancellationError.self) {
+            _ = try await task.value
+        }
+        #expect(start.duration(to: clock.now) < .milliseconds(200))
+    }
+
+    @Test func cliDiagnosticSessionEndsCancelled() async throws {
+        let primary = LockedData()
+        let recorder = SwamaDiagnosticRecorder(
+            enabled: true,
+            sessionID: UUID(uuidString: "11111111-2222-3333-4444-555555555555")!,
+            primaryWrite: { primary.append($0) },
+            fallbackWrite: { _ in },
+            now: { Date(timeIntervalSince1970: 0) }
+        )
+        let previous = SwamaDiagnostics.installRecorderForTesting(recorder)
+        defer { SwamaDiagnostics.restoreRecorderForTesting(previous) }
+
+        await #expect(throws: CancellationError.self) {
+            try await SwamaEngine.withCLIDiagnostics {
+                throw CancellationError()
+            }
+        }
+        recorder.flush()
+
+        let events: [SwamaDiagnosticEvent]
+        switch SwamaDiagnosticTimeline.parse(primary.data) {
+        case let .valid(value):
+            events = value
+        case .degraded,
+             .unknown:
+            throw RunExecutionTestError.invalidDiagnostics
+        }
+        #expect(events.map(\.event) == [.sessionStarted, .sessionStopped])
+        guard case let .string(mode)? = events.first?.data?["mode"] else {
+            Issue.record("CLI diagnostic session is missing its mode")
+            return
+        }
+
+        #expect(mode == "cli")
+        #expect(events.last?.outcome == .cancelled)
+    }
+
     @Test func explicitServerModeMapsSupportedOptionsAndRejectsContextLimit() throws {
         let command = try Run.parse([
             "org/model", "hello", "--server", "--temperature", "0.2", "--top-p", "0.8",
@@ -69,4 +187,60 @@ struct RunCommandTests {
             try unsupported.validateServerOptions()
         }
     }
+}
+
+// MARK: - RunExecutionRecorder
+
+private actor RunExecutionRecorder {
+    func recordFetch(_ model: ModelID) {
+        fetched.append(model)
+    }
+
+    func recordCore(_ model: ModelID) {
+        core.append(model)
+    }
+
+    func recordServer(_ model: ModelID) {
+        server.append(model)
+    }
+
+    func snapshot() -> Snapshot {
+        .init(fetched: fetched, core: core, server: server)
+    }
+
+    private var fetched: [ModelID] = []
+    private var core: [ModelID] = []
+    private var server: [ModelID] = []
+}
+
+// MARK: - Snapshot
+
+private struct Snapshot: Equatable {
+    let fetched: [ModelID]
+    let core: [ModelID]
+    let server: [ModelID]
+}
+
+// MARK: - RunExecutionTestError
+
+private enum RunExecutionTestError: Error {
+    case serverFailed
+    case invalidDiagnostics
+}
+
+// MARK: - LockedData
+
+private final class LockedData: @unchecked Sendable {
+    var data: Data {
+        lock.withLock { storage }
+    }
+
+    func append(_ data: Data) {
+        lock.withLock {
+            storage.append(data)
+        }
+    }
+
+    private let lock: NSLock = .init()
+    private var storage: Data = .init()
 }

--- a/swama/Tests/SwamaCLITests/RunCommandTests.swift
+++ b/swama/Tests/SwamaCLITests/RunCommandTests.swift
@@ -1,0 +1,72 @@
+import ArgumentParser
+import Foundation
+@testable import Swama
+import SwamaCore
+import Testing
+
+@Suite("swama run Core adapter")
+struct RunCommandTests {
+    @Test func inProcessCoreIsTheDefaultAndDirectRemainsCompatible() throws {
+        let defaultCommand = try Run.parse(["org/model", "hello"])
+        #expect(try defaultCommand.executionRoute() == .core)
+
+        let directCommand = try Run.parse(["org/model", "hello", "--direct"])
+        #expect(try directCommand.executionRoute() == .core)
+
+        let serverCommand = try Run.parse(["org/model", "hello", "--server"])
+        #expect(try serverCommand.executionRoute() == .server)
+
+        let conflictingCommand = try Run.parse(["org/model", "hello", "--direct", "--server"])
+        #expect(throws: ValidationError.self) {
+            _ = try conflictingCommand.executionRoute()
+        }
+    }
+
+    @Test func everyCoreOptionMapsWithoutAnUpstreamType() throws {
+        let command = try Run.parse([
+            "org/model", "describe", "--temperature", "0.25", "--top-p", "0.75",
+            "--max-tokens", "42", "--repetition-penalty", "1.1", "--context-limit", "4096",
+            "--image-paths", "/tmp/example.png", "--no-stream"
+        ])
+
+        let request = command.makeCoreRequest(modelName: "resolved/model")
+        #expect(request.model == ModelID("resolved/model"))
+        #expect(request.options.maxTokens == 42)
+        #expect(request.options.temperature == 0.25)
+        #expect(request.options.topP == 0.75)
+        #expect(request.options.repetitionPenalty == 1.1)
+        #expect(request.options.contextLimit == 4096)
+        #expect(request.messages.count == 1)
+        #expect(request.messages[0].role == .user)
+        #expect(request.messages[0].content == [
+            .text("describe"),
+            .imageURL(URL(fileURLWithPath: "/tmp/example.png"))
+        ])
+    }
+
+    @Test func explicitServerModeMapsSupportedOptionsAndRejectsContextLimit() throws {
+        let command = try Run.parse([
+            "org/model", "hello", "--server", "--temperature", "0.2", "--top-p", "0.8",
+            "--max-tokens", "17", "--repetition-penalty", "1.05", "--no-stream"
+        ])
+        try command.validateServerOptions()
+
+        let object = try #require(
+            JSONSerialization.jsonObject(with: command.encodedServerRequest(modelName: "resolved/model"))
+                as? [String: Any]
+        )
+        #expect(object["model"] as? String == "resolved/model")
+        #expect((object["temperature"] as? NSNumber)?.floatValue == 0.2)
+        #expect((object["top_p"] as? NSNumber)?.floatValue == 0.8)
+        #expect((object["max_tokens"] as? NSNumber)?.intValue == 17)
+        #expect((object["repetition_penalty"] as? NSNumber)?.floatValue == 1.05)
+        #expect((object["stream"] as? NSNumber)?.boolValue == false)
+
+        let unsupported = try Run.parse([
+            "org/model", "hello", "--server", "--context-limit", "4096"
+        ])
+        #expect(throws: ValidationError.self) {
+            try unsupported.validateServerOptions()
+        }
+    }
+}

--- a/swama/Tests/SwamaCoreTests/SwamaCoreTests.swift
+++ b/swama/Tests/SwamaCoreTests/SwamaCoreTests.swift
@@ -171,6 +171,19 @@ struct SwamaCoreTests {
         #expect(await backend.modelCacheClearCalls == 0)
     }
 
+    @Test func packageConsumerCanReuseTheResolvedFetchedModel() async throws {
+        let resolvedModel = ModelID("org/resolved-model")
+        let backend = StubBackend(
+            generationResponse: emptyResponse,
+            resolvedModel: resolvedModel
+        )
+        let engine = SwamaEngine(backend: backend)
+
+        #expect(try await engine.fetchResolved(.init("alias")) == resolvedModel)
+        try await engine.fetch(.init("alias"))
+        #expect(await backend.fetchCalls == 2)
+    }
+
     @Test func invalidRoleFieldsAndSamplingValuesFailBeforeBackendExecution() async throws {
         let backend = StubBackend(generationResponse: emptyResponse)
         let engine = SwamaEngine(backend: backend)
@@ -247,9 +260,14 @@ private actor EventCollector {
 // MARK: - StubBackend
 
 private actor StubBackend: SwamaEngineBackend {
-    init(generationResponse: GenerationResponse, cancelGeneration: Bool = false) {
+    init(
+        generationResponse: GenerationResponse,
+        cancelGeneration: Bool = false,
+        resolvedModel: ModelID? = nil
+    ) {
         self.generationResponse = generationResponse
         self.cancelGeneration = cancelGeneration
+        self.resolvedModel = resolvedModel
     }
 
     func generate(
@@ -273,8 +291,9 @@ private actor StubBackend: SwamaEngineBackend {
         []
     }
 
-    func fetch(_: ModelID) async throws {
+    func fetch(_ model: ModelID) async throws -> ModelID {
         fetchCalls += 1
+        return resolvedModel ?? model
     }
 
     func remove(_: ModelID) async throws {
@@ -289,6 +308,7 @@ private actor StubBackend: SwamaEngineBackend {
 
     private let generationResponse: GenerationResponse
     private let cancelGeneration: Bool
+    private let resolvedModel: ModelID?
     private(set) var generationCalls = 0
     private(set) var embeddingCalls = 0
     private(set) var fetchCalls = 0


### PR DESCRIPTION
## Summary

Migrates only the `swama run` generation path onto the public `SwamaCore` contract:

- in-process `SwamaEngine` execution is now the default
- existing `--direct` remains compatible
- server-backed execution is explicit through `--server`
- server failure and cancellation never silently fall back to Core
- sampling, context-limit, streaming and image inputs map through typed Core values
- `Run.swift` no longer imports `SwamaKit`, `MLX`, `MLXLLM`, or `MLXLMCommon`

A package-only fetch seam returns the resolved model ID so aliases are downloaded and generated by the same Core engine. A package-only diagnostics wrapper keeps model load, tokenizer, generation, cancellation and terminal events in one CLI session. Neither seam expands the public Core symbol graph.

## Scope

This PR intentionally does not migrate:

- HTTP handlers
- audio transcription
- pull/list/remove/create/logs/serve/menubar commands
- public Audio or FoundationModels APIs
- concurrency policy or legacy implementation removal

## Verification

Reviewed exact: `2d0098b0d4937c5f81ca67f5326813f5992b413a`

- CLI adapter tests: 8/8
- Swama tests: 286/286 on the independent final review
- acceptance harness: 46/46
- public Core manifest: unchanged at 160 intentional symbols
- Runtime public manifest: empty
- pinned SwiftFormat 0.56.2: 0/117
- stable release build: pass
- real small-model streaming and non-streaming CLI probes: pass
- daemon-running default still uses in-process Core; dead explicit server reports an error without fallback
- cancellation/readiness, alias routing, server fallback, option mapping, diagnostics and escaped-import reverse mutations: RED and restored
- independent internal review: GO (`84e981cd`)

No release or deployment is included.
