### PR TITLE
Migrate HTTP generation and embeddings to SwamaCore

### DIFF
--- a/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
+++ b/Tools/SwamaAcceptance/Tests/SwamaAcceptanceTests/AcceptanceTests.swift
@@ -409,6 +409,43 @@ struct AcceptanceTests {
         #expect(imports.isDisjoint(with: ["MLX", "MLXLLM", "MLXLMCommon", "SwamaKit"]))
     }
 
+    @Test func nonAudioHTTPHandlersUseCoreWithoutLegacyRuntimeImports() throws {
+        let serverRoot = repositoryRoot.appendingPathComponent("swama/Sources/SwamaServer")
+        let coreHandlers = ["CompletionsHandler.swift", "EmbeddingsHandler.swift"]
+        let forbidden: Set = ["MLX", "MLXLLM", "MLXLMCommon", "SwamaKit", "Tokenizers"]
+
+        for name in coreHandlers {
+            let file = serverRoot.appendingPathComponent(name)
+            let source = try String(contentsOf: file, encoding: .utf8)
+            let imports = try Set(parsedSwiftImports(source: source, file: file).map(\.module))
+            #expect(imports.contains("SwamaCore"))
+            #expect(imports.isDisjoint(with: forbidden))
+        }
+
+        let shell = serverRoot.appendingPathComponent("HTTPHandler.swift")
+        let shellSource = try String(contentsOf: shell, encoding: .utf8)
+        let shellImports = try Set(parsedSwiftImports(source: shellSource, file: shell).map(\.module))
+        #expect(shellImports.isDisjoint(with: forbidden))
+        #expect(shellSource.contains("ModelsHandler.handle"))
+
+        let models = serverRoot.appendingPathComponent("ModelsHandler.swift")
+        let modelsSource = try String(contentsOf: models, encoding: .utf8)
+        let modelsImports = try Set(parsedSwiftImports(source: modelsSource, file: models).map(\.module))
+        #expect(modelsImports.contains("SwamaKit"))
+        #expect(!modelsImports.contains("SwamaCore"))
+
+        for name in [
+            "LegacyServerCoreBackend.swift",
+            "TextToSpeechHandler.swift",
+            "TranscriptionsHandler.swift"
+        ] {
+            let file = serverRoot.appendingPathComponent(name)
+            let source = try String(contentsOf: file, encoding: .utf8)
+            #expect(source.contains("ServerModelPool.shared"), "\(name) must use the shared server pool")
+            #expect(!source.contains("ModelPool()"), "\(name) must not create a second pool")
+        }
+    }
+
     @Test func compilerPublicAPIGateRejectsUpstreamTypesAndConformances() throws {
         let graph: JSONObject = [
             "module": ["name": "SwamaCore"],

--- a/swama/Package.swift
+++ b/swama/Package.swift
@@ -88,6 +88,7 @@ let package = Package(
         .target(
             name: "SwamaServer",
             dependencies: [
+                .target(name: "SwamaCore"),
                 .target(name: "SwamaKit"),
                 .product(name: "NIO", package: "swift-nio"),
                 .product(name: "NIOHTTP1", package: "swift-nio"),
@@ -120,6 +121,7 @@ let package = Package(
         .testTarget(
             name: "SwamaKitTests",
             dependencies: [
+                "SwamaCore",
                 "SwamaKit",
                 "SwamaServer",
                 .product(name: "NIOEmbedded", package: "swift-nio"),

--- a/swama/Sources/SwamaCore/SwamaEngine.swift
+++ b/swama/Sources/SwamaCore/SwamaEngine.swift
@@ -8,7 +8,7 @@ public actor SwamaEngine {
         backend = RuntimeEngineBackend(configuration: configuration)
     }
 
-    init(backend: any SwamaEngineBackend) {
+    package init(backend: any SwamaEngineBackend) {
         self.backend = backend
     }
 
@@ -192,7 +192,7 @@ private extension ContentPart {
 
 // MARK: - SwamaEngineBackend
 
-protocol SwamaEngineBackend: Sendable {
+package protocol SwamaEngineBackend: Sendable {
     func generate(
         _ request: GenerationRequest,
         onEvent: (@Sendable (GenerationEvent) async throws -> Void)?

--- a/swama/Sources/SwamaKit/Model/ModelRunner.swift
+++ b/swama/Sources/SwamaKit/Model/ModelRunner.swift
@@ -81,6 +81,22 @@ public actor ModelRunner {
         onToken: (@Sendable (String) async throws -> Void)? = nil,
         onToolCall: (@Sendable (MLXLMCommon.ToolCall) async throws -> Void)? = nil
     ) async throws -> ChatRunResult {
+        try await runChatForCore(
+            userInput: userInput,
+            parameters: parameters,
+            contextLimit: nil,
+            onToken: onToken,
+            onToolCall: onToolCall
+        )
+    }
+
+    package nonisolated func runChatForCore(
+        userInput: MLXLMCommon.UserInput,
+        parameters: GenerateParameters,
+        contextLimit: Int?,
+        onToken: (@Sendable (String) async throws -> Void)? = nil,
+        onToolCall: (@Sendable (MLXLMCommon.ToolCall) async throws -> Void)? = nil
+    ) async throws -> ChatRunResult {
         try await withError {
             let modelName = await container.configuration.name
             let diagnosticOperation = SwamaDiagnostics.startGeneration(model: modelName)
@@ -124,7 +140,13 @@ public actor ModelRunner {
 
             let rawOutputStorage = RawOutputBuffer()
             let hasMediaInput = userInput.hasMediaContent
-            let configuredContextLimit = await ContextLimitConfig.shared.currentLimit()
+            let configuredContextLimit: Int =
+                if let contextLimit {
+                    contextLimit
+                }
+                else {
+                    await ContextLimitConfig.shared.currentLimit()
+                }
             let effectiveContextLimit = hasMediaInput
                 ? min(configuredContextLimit, InferenceSafetyLimits.multimodalContextLimit)
                 : configuredContextLimit

--- a/swama/Sources/SwamaServer/CompletionsHandler.swift
+++ b/swama/Sources/SwamaServer/CompletionsHandler.swift
@@ -4,18 +4,14 @@
 //
 
 import Foundation
-@preconcurrency import MLXLMCommon
 import NIOCore
 import NIOHTTP1
-import SwamaKit
-import struct Tokenizers.ToolSpec
+import SwamaCore
 
 // MARK: - CompletionsHandler
 
 public enum CompletionsHandler {
     // MARK: Public
-
-    private static let qwen35MultimodalResize: CGSize = .init(width: 1344, height: 1344)
 
     public struct CompletionRequest: Decodable, Sendable {
         let model: String
@@ -28,6 +24,7 @@ public enum CompletionsHandler {
         let repetition_context_size: Int?
         let presence_penalty: Float?
         let frequency_penalty: Float?
+        let context_limit: Int?
         let max_tokens: Int?
         let stream: Bool?
         let tools: [Tool]?
@@ -38,17 +35,20 @@ public enum CompletionsHandler {
         let role: String
         let content: MessageContent
         let tool_calls: [ResponseToolCall]?
+        let tool_call_id: String?
 
         private enum CodingKeys: String, CodingKey {
             case role
             case content
             case tool_calls
+            case tool_call_id
         }
 
         public init(role: String, content: MessageContent, tool_calls: [ResponseToolCall]? = nil) {
             self.role = role
             self.content = content
             self.tool_calls = tool_calls
+            tool_call_id = nil
         }
 
         public init(from decoder: Decoder) throws {
@@ -56,6 +56,7 @@ public enum CompletionsHandler {
             role = try container.decode(String.self, forKey: .role)
             content = try container.decode(MessageContent.self, forKey: .content)
             tool_calls = try container.decodeIfPresent([ResponseToolCall].self, forKey: .tool_calls)
+            tool_call_id = try container.decodeIfPresent(String.self, forKey: .tool_call_id)
         }
 
         public func encode(to encoder: Encoder) throws {
@@ -65,6 +66,7 @@ public enum CompletionsHandler {
             if let tool_calls, !tool_calls.isEmpty {
                 try container.encode(tool_calls, forKey: .tool_calls)
             }
+            try container.encodeIfPresent(tool_call_id, forKey: .tool_call_id)
         }
     }
 
@@ -406,9 +408,23 @@ public enum CompletionsHandler {
     }
 
     public static func handle(
-        requestHead _: HTTPRequestHead,
+        requestHead: HTTPRequestHead,
         body: ByteBuffer?,
         channel: Channel
+    ) async {
+        await handle(
+            requestHead: requestHead,
+            body: body,
+            channel: channel,
+            engine: ServerCoreEngine.shared
+        )
+    }
+
+    static func handle(
+        requestHead _: HTTPRequestHead,
+        body: ByteBuffer?,
+        channel: Channel,
+        engine: SwamaEngine
     ) async {
         do {
             guard let payload = parsePayload(body),
@@ -422,38 +438,33 @@ public enum CompletionsHandler {
                 return
             }
 
-            let resolvedModelName = ModelAliasResolver.resolve(name: payload.model)
-
-            // Convert messages to MLX Chat.Message format
-            let chatMessages = try convertToMLXChatMessages(payload.messages)
-
-            let parameters = generateParameters(from: payload)
-
-            // Convert tools to MLX ToolSpec format once here
-            let tools: [ToolSpec]? = convertToolsToMLX(payload.tools)
+            let request = try coreRequest(from: payload)
 
             if payload.stream == true {
                 try await sendStreamResponse(
                     channel: channel,
-                    modelName: resolvedModelName,
-                    chatMessages: chatMessages,
+                    request: request,
                     model: payload.model,
-                    parameters: parameters,
-                    tools: tools
+                    engine: engine
                 )
             }
             else {
                 try await sendNonStreamResponse(
                     channel: channel,
-                    modelName: resolvedModelName,
-                    chatMessages: chatMessages,
+                    request: request,
                     model: payload.model,
-                    parameters: parameters,
-                    mlxTools: tools
+                    engine: engine
                 )
             }
         }
-        catch let error as ContextLimitError {
+        catch let error as SwamaError {
+            try? await respondError(
+                channel: channel,
+                status: status(for: error),
+                message: error.message
+            )
+        }
+        catch let error as CompletionsError {
             try? await respondError(
                 channel: channel,
                 status: .badRequest,
@@ -469,117 +480,116 @@ public enum CompletionsHandler {
         }
     }
 
-    // MARK: - Tool Conversion Helper
+    // MARK: - Core conversion
 
-    private static func convertToolsToMLX(_ tools: [Tool]?) -> [ToolSpec]? {
-        tools?.map { tool in
-            var functionDict: [String: any Sendable] = [
-                "name": tool.function.name
-            ]
-
-            if let description = tool.function.description {
-                functionDict["description"] = description
-            }
-
-            if let parameters = tool.function.parameters {
-                // Convert JSON string back to object
-                if let jsonData = parameters.data(using: .utf8),
-                   let jsonObject = try? JSONSerialization.jsonObject(with: jsonData)
-                {
-                    // JSON objects are always Sendable (they're value types)
-                    // Using as! because JSONSerialization guarantees Sendable types (Dictionary, Array, String, Number,
-                    // etc.)
-                    functionDict["parameters"] = (jsonObject as! any Sendable)
-                }
-            }
-
-            return [
-                "type": tool.type,
-                "function": functionDict
-            ]
-        }
+    static func coreRequest(from payload: CompletionRequest) throws -> GenerationRequest {
+        try .init(
+            model: .init(payload.model),
+            messages: payload.messages.map(coreMessage),
+            options: .init(
+                maxTokens: payload.max_tokens,
+                temperature: payload.temperature ?? 0.6,
+                topP: payload.top_p ?? 1,
+                topK: payload.top_k ?? 0,
+                minP: payload.min_p ?? 0,
+                repetitionPenalty: payload.repetition_penalty,
+                repetitionContextSize: payload.repetition_context_size ?? 20,
+                presencePenalty: payload.presence_penalty,
+                frequencyPenalty: payload.frequency_penalty,
+                contextLimit: payload.context_limit
+            ),
+            tools: payload.tools?.map(coreTool) ?? []
+        )
     }
 
-    // MARK: - Chat Message Conversion
-
-    private static func convertToMLXChatMessages(_ messages: [Message]) throws -> [MLXLMCommon.Chat.Message] {
-        try messages.map { message in
-            let role: MLXLMCommon.Chat.Message.Role
+    private static func coreMessage(_ message: Message) throws -> SwamaCore.Message {
+        let role: SwamaCore.Message.Role =
             switch message.role {
             case "system":
-                role = .system
+                .system
             case "user":
-                role = .user
+                .user
             case "assistant":
-                role = .assistant
+                .assistant
             case "tool":
-                role = .tool
+                .tool
             default:
                 throw CompletionsError.invalidRole(message.role)
             }
 
-            let content = message.content.textContent
-            let imageURLs = message.content.imageURLs
-            let images = imageURLs.compactMap { urlString in
-                URL(string: urlString).map { MLXLMCommon.UserInput.Image.url($0) }
+        let content: [SwamaCore.ContentPart] =
+            switch message.content {
+            case let .text(text):
+                [.text(text)]
+            case let .multimodal(parts):
+                try parts.map { part -> SwamaCore.ContentPart in
+                    switch part {
+                    case let .text(text):
+                        return .text(text)
+                    case let .imageURL(image):
+                        guard let url = URL(string: image.url) else {
+                            throw CompletionsError.invalidImageURL(image.url)
+                        }
+
+                        return SwamaCore.ContentPart.imageURL(url)
+                    }
+                }
             }
 
-            return MLXLMCommon.Chat.Message(
-                role: role,
-                content: content,
-                images: images
-            )
-        }
-    }
-
-    private static func buildUserInput(
-        chatMessages: [MLXLMCommon.Chat.Message],
-        modelName: String,
-        tools: [ToolSpec]?
-    ) -> MLXLMCommon.UserInput {
-        guard chatMessages.contains(where: { !$0.images.isEmpty || !$0.videos.isEmpty }) else {
-            return MLXLMCommon.UserInput(chat: chatMessages, tools: tools)
-        }
-        guard shouldApplyQwen35MultimodalSafety(modelName: modelName) else {
-            return MLXLMCommon.UserInput(chat: chatMessages, tools: tools)
-        }
-
-        return MLXLMCommon.UserInput(
-            chat: chatMessages,
-            processing: .init(resize: qwen35MultimodalResize),
-            tools: tools
+        return try .init(
+            role: role,
+            content: content,
+            toolCalls: message.tool_calls?.map(coreToolCall) ?? [],
+            toolCallID: message.tool_call_id
         )
     }
 
-    private static func shouldApplyQwen35MultimodalSafety(modelName: String) -> Bool {
-        let lowered = modelName.lowercased()
-        return lowered.contains("qwen3.5") || lowered.contains("qwen3_5")
+    private static func coreTool(_ tool: Tool) throws -> ToolDefinition {
+        let parameters: SwamaCore.JSONValue
+        if let raw = tool.function.parameters {
+            let decoded = try JSONDecoder().decode(SwamaCore.JSONValue.self, from: Data(raw.utf8))
+            guard case .object = decoded else {
+                throw CompletionsError.invalidToolJSON(tool.function.name)
+            }
+
+            parameters = decoded
+        }
+        else {
+            parameters = .object([:])
+        }
+        return .init(
+            name: tool.function.name,
+            description: tool.function.description,
+            parameters: parameters
+        )
+    }
+
+    private static func coreToolCall(_ toolCall: ResponseToolCall) throws -> SwamaCore.ToolCall {
+        let decoded = try JSONDecoder().decode(
+            SwamaCore.JSONValue.self,
+            from: Data(toolCall.function.arguments.utf8)
+        )
+        guard case let .object(arguments) = decoded else {
+            throw CompletionsError.invalidToolJSON(toolCall.function.name)
+        }
+
+        return .init(
+            id: toolCall.id,
+            name: toolCall.function.name,
+            arguments: arguments
+        )
     }
 
     // MARK: - Chat Response Methods
 
-    public static func sendNonStreamResponse(
+    static func sendNonStreamResponse(
         channel: Channel,
-        modelName: String,
-        chatMessages: [MLXLMCommon.Chat.Message],
+        request: GenerationRequest,
         model: String,
-        parameters: GenerateParameters,
-        mlxTools: [ToolSpec]? = nil
+        engine: SwamaEngine
     ) async throws {
         let result = try await runCancellingOnClose(channel: channel) {
-            try await modelPool.run(
-                modelName: modelName
-            ) { runner in
-                let userInput = buildUserInput(
-                    chatMessages: chatMessages,
-                    modelName: modelName,
-                    tools: mlxTools
-                )
-                return try await runner.runChatNonStream(
-                    userInput: userInput,
-                    parameters: parameters
-                )
-            }
+            try await engine.generate(request)
         }
 
         // The client disconnected mid-generation; the run above was cancelled promptly, and
@@ -588,30 +598,16 @@ public enum CompletionsHandler {
             return
         }
 
-        // Calculate completion tokens from completion info
-        let completionTokens = result.completionInfo?.generationTokenCount ?? 0
-
-        // Convert MLX ToolCalls to OpenAI format
         let toolCalls: [ResponseToolCall]? = result.toolCalls.isEmpty ? nil : result.toolCalls
             .enumerated()
-            .compactMap { index, toolCall in
-                let argumentsDict = toolCall.function.arguments.mapValues { $0.anyValue }
-                let argumentsJSON: String =
-                    if let jsonData = try? JSONSerialization.data(withJSONObject: argumentsDict),
-                    let jsonString = String(data: jsonData, encoding: .utf8) {
-                        jsonString
-                    }
-                    else {
-                        "{}"
-                    }
-
-                return ResponseToolCall(
+            .map { index, toolCall in
+                ResponseToolCall(
                     index: index,
-                    id: "call_\(UUID().uuidString)",
+                    id: toolCall.id ?? "call_\(UUID().uuidString)",
                     type: "function",
                     function: ResponseFunction(
-                        name: toolCall.function.name,
-                        arguments: argumentsJSON
+                        name: toolCall.name,
+                        arguments: encodedArguments(toolCall.arguments)
                     )
                 )
             }
@@ -627,17 +623,16 @@ public enum CompletionsHandler {
         let choice = CompletionChoice(
             index: 0,
             message: responseMessage,
-            finish_reason: toolCalls?.isEmpty == false ? "tool_calls" : "stop"
+            finish_reason: wireFinishReason(result.finishReason)
         )
 
-        // Calculate performance metrics
-        let tokensPerSecond = result.completionInfo?.tokensPerSecond ?? 0.0
-        let totalDuration = (result.completionInfo?.promptTime ?? 0.0) + (result.completionInfo?.generateTime ?? 0.0)
+        let tokensPerSecond = result.metrics?.tokensPerSecond ?? 0
+        let totalDuration = (result.metrics?.promptSeconds ?? 0) + (result.metrics?.generationSeconds ?? 0)
 
         let usage = CompletionUsage(
-            prompt_tokens: result.promptTokens,
-            completion_tokens: completionTokens,
-            total_tokens: result.promptTokens + completionTokens,
+            prompt_tokens: result.usage.promptTokens,
+            completion_tokens: result.usage.completionTokens,
+            total_tokens: result.usage.totalTokens,
             response_token_s: tokensPerSecond > 0 ? tokensPerSecond : nil,
             total_duration: totalDuration > 0 ? totalDuration : nil
         )
@@ -666,13 +661,11 @@ public enum CompletionsHandler {
         try await channel.writeAndFlush(HTTPServerResponsePart.end(nil))
     }
 
-    public static func sendStreamResponse(
+    static func sendStreamResponse(
         channel: Channel,
-        modelName: String,
-        chatMessages: [MLXLMCommon.Chat.Message],
+        request: GenerationRequest,
         model: String,
-        parameters: GenerateParameters,
-        tools: [ToolSpec]? = nil
+        engine: SwamaEngine
     ) async throws {
         actor ToolCallCounter {
             private var index = 0
@@ -706,74 +699,46 @@ public enum CompletionsHandler {
 
         try await writeSSEJSON(channel: channel, payload: initialJSON)
 
-        // Execute model with error handling
-        let result: ModelRunner.ChatRunResult
+        let result: GenerationResponse
 
         do {
             result = try await runCancellingOnClose(channel: channel) {
-                try await modelPool.run(
-                    modelName: modelName
-                ) { runner in
-                    let userInput = buildUserInput(
-                        chatMessages: chatMessages,
-                        modelName: modelName,
-                        tools: tools
-                    )
-                    let toolCallCounter = ToolCallCounter()
-                    return try await runner.runChat(
-                        userInput: userInput,
-                        parameters: parameters,
-                        onToken: { chunk in
-                            let deltaJSON: [String: Any] = [
-                                "id": chunkId,
-                                "object": "chat.completion.chunk",
-                                "created": timestamp,
-                                "model": model,
-                                "choices": [["index": 0, "delta": ["content": chunk], "finish_reason": NSNull()]]
-                            ]
-                            // Awaited directly: the write is ordered and fully drained before
-                            // `runChat` moves on to the next generation event, and a failed
-                            // write (client gone) throws here, stopping generation and flowing
-                            // through the existing catch below rather than needing an explicit
-                            // channel.close(promise: nil) to converge on the cancellation path.
-                            try await writeSSEJSON(channel: channel, payload: deltaJSON)
-                        },
-                        onToolCall: { toolCall in
-                            let argumentsDict = toolCall.function.arguments.mapValues { $0.anyValue }
-                            let argumentsJSON: String =
-                                if let jsonData = try? JSONSerialization
-                                    .data(withJSONObject: argumentsDict),
-                                    let jsonString = String(data: jsonData, encoding: .utf8)
-                                {
-                                    jsonString
-                                }
-                                else {
-                                    "{}"
-                                }
+                let toolCallCounter = ToolCallCounter()
+                return try await engine.generate(request) { event in
+                    switch event {
+                    case let .textDelta(chunk):
+                        let deltaJSON: [String: Any] = [
+                            "id": chunkId,
+                            "object": "chat.completion.chunk",
+                            "created": timestamp,
+                            "model": model,
+                            "choices": [["index": 0, "delta": ["content": chunk], "finish_reason": NSNull()]]
+                        ]
+                        try await writeSSEJSON(channel: channel, payload: deltaJSON)
 
-                            let index = await toolCallCounter.next()
-                            let toolCallDict: [String: Any] = [
-                                "index": index,
-                                "id": "call_\(UUID().uuidString)",
-                                "type": "function",
-                                "function": [
-                                    "name": toolCall.function.name,
-                                    "arguments": argumentsJSON
-                                ]
+                    case let .toolCall(toolCall):
+                        let index = await toolCallCounter.next()
+                        let toolCallDict: [String: Any] = [
+                            "index": index,
+                            "id": toolCall.id ?? "call_\(UUID().uuidString)",
+                            "type": "function",
+                            "function": [
+                                "name": toolCall.name,
+                                "arguments": encodedArguments(toolCall.arguments)
                             ]
+                        ]
 
-                            let toolCallDelta: [String: Any] = [
-                                "id": chunkId,
-                                "object": "chat.completion.chunk",
-                                "created": timestamp,
-                                "model": model,
-                                "choices": [["index": 0, "delta": ["tool_calls": [toolCallDict]],
-                                             "finish_reason": NSNull()]]
-                            ]
+                        let toolCallDelta: [String: Any] = [
+                            "id": chunkId,
+                            "object": "chat.completion.chunk",
+                            "created": timestamp,
+                            "model": model,
+                            "choices": [["index": 0, "delta": ["tool_calls": [toolCallDict]],
+                                         "finish_reason": NSNull()]]
+                        ]
 
-                            try await writeSSEJSON(channel: channel, payload: toolCallDelta)
-                        }
-                    )
+                        try await writeSSEJSON(channel: channel, payload: toolCallDelta)
+                    }
                 }
             }
         }
@@ -808,23 +773,19 @@ public enum CompletionsHandler {
         }
 
         // Send final chunk with usage information
-        let finalCompletionTokens = result.completionInfo?.generationTokenCount ?? 0
-        let tokensPerSecond = result.completionInfo?.tokensPerSecond ?? 0.0
-        let totalDuration = (result.completionInfo?.promptTime ?? 0.0) + (result.completionInfo?.generateTime ?? 0.0)
-
-        // Determine finish reason based on whether tool calls were made
-        let finishReason = result.toolCalls.isEmpty ? "stop" : "tool_calls"
+        let tokensPerSecond = result.metrics?.tokensPerSecond ?? 0
+        let totalDuration = (result.metrics?.promptSeconds ?? 0) + (result.metrics?.generationSeconds ?? 0)
 
         let finishJSON: [String: Any] = [
             "id": chunkId,
             "object": "chat.completion.chunk",
             "created": timestamp,
             "model": model,
-            "choices": [["index": 0, "delta": [:], "finish_reason": finishReason]],
+            "choices": [["index": 0, "delta": [:], "finish_reason": wireFinishReason(result.finishReason)]],
             "usage": [
-                "prompt_tokens": result.promptTokens,
-                "completion_tokens": finalCompletionTokens,
-                "total_tokens": result.promptTokens + finalCompletionTokens,
+                "prompt_tokens": result.usage.promptTokens,
+                "completion_tokens": result.usage.completionTokens,
+                "total_tokens": result.usage.totalTokens,
                 "response_token/s": tokensPerSecond,
                 "total_duration": totalDuration
             ]
@@ -837,12 +798,9 @@ public enum CompletionsHandler {
 
     // MARK: - Helper Methods
 
-    private static let modelPool: ModelPool = .shared
-
     /// Runs `operation` in a child task, cancelling that task as soon as `channel`'s connection
-    /// closes (the client disconnecting mid-request). `operation` is expected to observe
-    /// `Task.isCancelled` and return promptly rather than throw, so its (possibly partial)
-    /// result is still returned normally here.
+    /// closes (the client disconnecting mid-request). Core operations propagate
+    /// `CancellationError`; already-written stream deltas are not retracted.
     ///
     /// Not marked `private` so tests can drive this channel-close -> cancellation path directly
     /// with a stub `operation` and an `EmbeddedChannel`, without needing a real model.
@@ -940,20 +898,43 @@ public enum CompletionsHandler {
         try await sendFullResponse(channel: channel, data: jsonData, status: status, version: .http1_1)
     }
 
-    /// Maps request sampling fields onto the engine's `GenerateParameters`,
-    /// falling back to the engine defaults when a field is absent.
-    static func generateParameters(from payload: CompletionRequest) -> GenerateParameters {
-        GenerateParameters(
-            maxTokens: payload.max_tokens,
-            temperature: payload.temperature ?? 0.6,
-            topP: payload.top_p ?? 1.0,
-            topK: payload.top_k ?? 0,
-            minP: payload.min_p ?? 0.0,
-            repetitionPenalty: payload.repetition_penalty,
-            repetitionContextSize: payload.repetition_context_size ?? 20,
-            presencePenalty: payload.presence_penalty,
-            frequencyPenalty: payload.frequency_penalty
-        )
+    private static func encodedArguments(_ arguments: [String: SwamaCore.JSONValue]) -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        guard let data = try? encoder.encode(SwamaCore.JSONValue.object(arguments)) else {
+            return "{}"
+        }
+
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    private static func wireFinishReason(_ reason: FinishReason) -> String {
+        switch reason {
+        case .completed,
+             .unknown:
+            "stop"
+        case .length:
+            "length"
+        case .toolCall:
+            "tool_calls"
+        }
+    }
+
+    private static func status(for error: SwamaError) -> HTTPResponseStatus {
+        switch error.code {
+        case .contextLimitExceeded,
+             .invalidImage,
+             .invalidRequest:
+            .badRequest
+        case .modelNotFound:
+            .notFound
+        case .backendFailure,
+             .downloadFailed,
+             .embeddingFailed,
+             .modelLoadFailed,
+             .removalFailed:
+            .internalServerError
+        }
     }
 
     private static func parsePayload(_ buffer: ByteBuffer?) -> CompletionRequest? {
@@ -995,11 +976,17 @@ public enum CompletionsHandler {
 
 enum CompletionsError: Error, LocalizedError {
     case invalidRole(String)
+    case invalidImageURL(String)
+    case invalidToolJSON(String)
 
     public var errorDescription: String? {
         switch self {
         case let .invalidRole(role):
-            "Invalid role: \(role). Must be 'system', 'user', or 'assistant'"
+            "Invalid role: \(role). Must be 'system', 'user', 'assistant', or 'tool'"
+        case let .invalidImageURL(value):
+            "Invalid image URL: \(value)"
+        case let .invalidToolJSON(name):
+            "Tool '\(name)' requires JSON object arguments or parameters"
         }
     }
 }

--- a/swama/Sources/SwamaServer/EmbeddingsHandler.swift
+++ b/swama/Sources/SwamaServer/EmbeddingsHandler.swift
@@ -1,7 +1,7 @@
 import Foundation
 import NIOCore
 import NIOHTTP1
-import SwamaKit
+import SwamaCore
 
 // MARK: - EmbeddingsRequest
 
@@ -116,6 +116,20 @@ public enum EmbeddingsHandler {
         body: ByteBuffer,
         channel: Channel
     ) async {
+        await handle(
+            requestHead: requestHead,
+            body: body,
+            channel: channel,
+            engine: ServerCoreEngine.shared
+        )
+    }
+
+    static func handle(
+        requestHead: HTTPRequestHead,
+        body: ByteBuffer,
+        channel: Channel,
+        engine: SwamaEngine
+    ) async {
         do {
             // Parse JSON body
             var mutableBody = body
@@ -145,14 +159,18 @@ public enum EmbeddingsHandler {
                 return
             }
 
-            // Generate embeddings using MLXEmbedders
-            let (embeddings, usage): ([[Float]], EmbeddingUsage)
+            let result: SwamaCore.EmbeddingResponse
             do {
-                (embeddings, usage) = try await modelPool.runEmbeddingWithConcurrencyControl(
-                    modelName: request.model
-                ) { runner in
-                    try await runner.generateEmbeddings(inputs: inputs)
-                }
+                result = try await engine.embed(.init(model: .init(request.model), inputs: inputs))
+            }
+            catch let error as SwamaError {
+                try await sendErrorResponse(
+                    channel: channel,
+                    status: status(for: error),
+                    error: error.message,
+                    requestVersion: requestHead.version
+                )
+                return
             }
             catch {
                 try await sendErrorResponse(
@@ -165,7 +183,7 @@ public enum EmbeddingsHandler {
             }
 
             // Create response
-            let embeddingData = embeddings.enumerated().map { index, embedding in
+            let embeddingData = result.embeddings.enumerated().map { index, embedding in
                 EmbeddingsResponse.EmbeddingData(
                     object: "embedding",
                     embedding: embedding,
@@ -178,8 +196,8 @@ public enum EmbeddingsHandler {
                 data: embeddingData,
                 model: request.model,
                 usage: EmbeddingsResponse.Usage(
-                    promptTokens: usage.promptTokens,
-                    totalTokens: usage.totalTokens
+                    promptTokens: result.usage.promptTokens,
+                    totalTokens: result.usage.totalTokens
                 )
             )
 
@@ -198,6 +216,23 @@ public enum EmbeddingsHandler {
                 error: "Internal server error: \(error.localizedDescription)",
                 requestVersion: requestHead.version
             )
+        }
+    }
+
+    private static func status(for error: SwamaError) -> HTTPResponseStatus {
+        switch error.code {
+        case .contextLimitExceeded,
+             .invalidImage,
+             .invalidRequest:
+            .badRequest
+        case .modelNotFound:
+            .notFound
+        case .backendFailure,
+             .downloadFailed,
+             .embeddingFailed,
+             .modelLoadFailed,
+             .removalFailed:
+            .internalServerError
         }
     }
 

--- a/swama/Sources/SwamaServer/HTTPHandler.swift
+++ b/swama/Sources/SwamaServer/HTTPHandler.swift
@@ -4,14 +4,8 @@
 //
 
 import Foundation
-import MLXLMCommon
 import NIOCore
 import NIOHTTP1
-import SwamaKit
-
-/// This modelPool instance should ideally be managed and injected by ServerManager or a DI system.
-/// For now, keeping it global within SwamaKit as per original Router.swift structure.
-let modelPool: ModelPool = .shared // Use the same shared instance as CompletionsHandler
 
 // MARK: - HTTPHandler
 

--- a/swama/Sources/SwamaServer/LegacyCompletionsCompatibility.swift
+++ b/swama/Sources/SwamaServer/LegacyCompletionsCompatibility.swift
@@ -1,0 +1,248 @@
+import Foundation
+@preconcurrency import MLXLMCommon
+import NIOCore
+import NIOHTTP1
+import SwamaKit
+import struct Tokenizers.ToolSpec
+
+// MARK: - Legacy source compatibility
+
+public extension CompletionsHandler {
+    @available(*, deprecated, message: "Use the HTTP route or SwamaCore.SwamaEngine")
+    static func sendNonStreamResponse(
+        channel: Channel,
+        modelName: String,
+        chatMessages: [MLXLMCommon.Chat.Message],
+        model: String,
+        parameters: GenerateParameters,
+        mlxTools: [ToolSpec]? = nil
+    ) async throws {
+        let result = try await runCancellingOnClose(channel: channel) {
+            try await ServerModelPool.shared.run(modelName: modelName) { runner in
+                try await runner.runChatNonStream(
+                    userInput: legacyUserInput(chatMessages, modelName: modelName, tools: mlxTools),
+                    parameters: parameters
+                )
+            }
+        }
+        guard channel.isActive else {
+            return
+        }
+
+        let completionTokens = result.completionInfo?.generationTokenCount ?? 0
+        let toolCalls: [ResponseToolCall]? = result.toolCalls.isEmpty ? nil : result.toolCalls
+            .enumerated()
+            .map { index, toolCall in
+                ResponseToolCall(
+                    index: index,
+                    id: toolCall.id ?? "call_\(UUID().uuidString)",
+                    type: "function",
+                    function: ResponseFunction(
+                        name: toolCall.function.name,
+                        arguments: legacyArguments(toolCall)
+                    )
+                )
+            }
+
+        let response = CompletionResponse(
+            id: "chatcmpl-" + UUID().uuidString,
+            object: "chat.completion",
+            created: Int(Date().timeIntervalSince1970),
+            model: model,
+            choices: [.init(
+                index: 0,
+                message: .init(role: "assistant", content: .text(result.output), tool_calls: toolCalls),
+                finish_reason: toolCalls?.isEmpty == false ? "tool_calls" : "stop"
+            )],
+            usage: .init(
+                prompt_tokens: result.promptTokens,
+                completion_tokens: completionTokens,
+                total_tokens: result.promptTokens + completionTokens,
+                response_token_s: result.completionInfo?.tokensPerSecond,
+                total_duration: result.completionInfo.map { $0.promptTime + $0.generateTime }
+            )
+        )
+        let data = try JSONEncoder().encode(response)
+        var headers = HTTPHeaders()
+        headers.add(name: "Content-Type", value: "application/json")
+        HTTPHandler.applyCORSHeaders(&headers)
+        try await channel.writeAndFlush(HTTPServerResponsePart.head(.init(
+            version: .http1_1,
+            status: .ok,
+            headers: headers
+        )))
+        try await channel.writeAndFlush(HTTPServerResponsePart.body(.byteBuffer(.init(bytes: data))))
+        try await channel.writeAndFlush(HTTPServerResponsePart.end(nil))
+    }
+
+    @available(*, deprecated, message: "Use the HTTP route or SwamaCore.SwamaEngine")
+    static func sendStreamResponse(
+        channel: Channel,
+        modelName: String,
+        chatMessages: [MLXLMCommon.Chat.Message],
+        model: String,
+        parameters: GenerateParameters,
+        tools: [ToolSpec]? = nil
+    ) async throws {
+        actor ToolCallCounter {
+            private var index = 0
+            func next() -> Int {
+                defer { index += 1 }
+                return index
+            }
+        }
+
+        let headers = HTTPHeaders([
+            ("Content-Type", "text/event-stream"),
+            ("Cache-Control", "no-cache"),
+            ("Connection", "keep-alive")
+        ])
+        try await channel.writeAndFlush(HTTPServerResponsePart.head(.init(
+            version: .http1_1,
+            status: .ok,
+            headers: headers
+        )))
+
+        let chunkID = "chatcmpl-" + UUID().uuidString
+        let timestamp = Int(Date().timeIntervalSince1970)
+        try await legacyWriteSSE(channel: channel, payload: [
+            "id": chunkID,
+            "object": "chat.completion.chunk",
+            "created": timestamp,
+            "model": model,
+            "choices": [["index": 0, "delta": ["role": "assistant"], "finish_reason": NSNull()]]
+        ])
+
+        let result: ModelRunner.ChatRunResult
+        do {
+            result = try await runCancellingOnClose(channel: channel) {
+                try await ServerModelPool.shared.run(modelName: modelName) { runner in
+                    let counter = ToolCallCounter()
+                    return try await runner.runChat(
+                        userInput: legacyUserInput(chatMessages, modelName: modelName, tools: tools),
+                        parameters: parameters,
+                        onToken: { chunk in
+                            try await legacyWriteSSE(channel: channel, payload: [
+                                "id": chunkID,
+                                "object": "chat.completion.chunk",
+                                "created": timestamp,
+                                "model": model,
+                                "choices": [[
+                                    "index": 0,
+                                    "delta": ["content": chunk],
+                                    "finish_reason": NSNull()
+                                ]]
+                            ])
+                        },
+                        onToolCall: { toolCall in
+                            let index = await counter.next()
+                            try await legacyWriteSSE(channel: channel, payload: [
+                                "id": chunkID,
+                                "object": "chat.completion.chunk",
+                                "created": timestamp,
+                                "model": model,
+                                "choices": [[
+                                    "index": 0,
+                                    "delta": ["tool_calls": [[
+                                        "index": index,
+                                        "id": toolCall.id ?? "call_\(UUID().uuidString)",
+                                        "type": "function",
+                                        "function": [
+                                            "name": toolCall.function.name,
+                                            "arguments": legacyArguments(toolCall)
+                                        ]
+                                    ]]],
+                                    "finish_reason": NSNull()
+                                ]]
+                            ])
+                        }
+                    )
+                }
+            }
+        }
+        catch {
+            guard channel.isActive else {
+                return
+            }
+
+            try await legacyWriteSSE(channel: channel, payload: [
+                "id": chunkID,
+                "object": "chat.completion.chunk",
+                "created": timestamp,
+                "model": model,
+                "choices": [["index": 0, "delta": [:], "finish_reason": "error"]],
+                "error": ["message": error.localizedDescription, "type": "request_error"]
+            ])
+            try await legacyWriteLine(channel: channel, line: "data: [DONE]\n\n")
+            try await channel.writeAndFlush(HTTPServerResponsePart.end(nil))
+            return
+        }
+
+        guard channel.isActive else {
+            return
+        }
+
+        let completionTokens = result.completionInfo?.generationTokenCount ?? 0
+        try await legacyWriteSSE(channel: channel, payload: [
+            "id": chunkID,
+            "object": "chat.completion.chunk",
+            "created": timestamp,
+            "model": model,
+            "choices": [[
+                "index": 0,
+                "delta": [:],
+                "finish_reason": result.toolCalls.isEmpty ? "stop" : "tool_calls"
+            ]],
+            "usage": [
+                "prompt_tokens": result.promptTokens,
+                "completion_tokens": completionTokens,
+                "total_tokens": result.promptTokens + completionTokens,
+                "response_token/s": result.completionInfo?.tokensPerSecond ?? 0,
+                "total_duration": (result.completionInfo?.promptTime ?? 0) +
+                    (result.completionInfo?.generateTime ?? 0)
+            ]
+        ])
+        try await legacyWriteLine(channel: channel, line: "data: [DONE]\n\n")
+        try await channel.writeAndFlush(HTTPServerResponsePart.end(nil))
+    }
+}
+
+private func legacyUserInput(
+    _ messages: [MLXLMCommon.Chat.Message],
+    modelName: String,
+    tools: [ToolSpec]?
+) -> MLXLMCommon.UserInput {
+    let hasMedia = messages.contains { !$0.images.isEmpty || !$0.videos.isEmpty }
+    let lowered = modelName.lowercased()
+    if hasMedia, lowered.contains("qwen3.5") || lowered.contains("qwen3_5") {
+        return .init(
+            chat: messages,
+            processing: .init(resize: .init(width: 1344, height: 1344)),
+            tools: tools
+        )
+    }
+    return .init(chat: messages, tools: tools)
+}
+
+private func legacyArguments(_ toolCall: MLXLMCommon.ToolCall) -> String {
+    let object = toolCall.function.arguments.mapValues(\.anyValue)
+    guard let data = try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys]) else {
+        return "{}"
+    }
+
+    return String(decoding: data, as: UTF8.self)
+}
+
+private func legacyWriteSSE(channel: Channel, payload: [String: Any]) async throws {
+    let data = try JSONSerialization.data(withJSONObject: payload)
+    try await legacyWriteLine(
+        channel: channel,
+        line: "data: \(String(decoding: data, as: UTF8.self))\n\n"
+    )
+}
+
+private func legacyWriteLine(channel: Channel, line: String) async throws {
+    var buffer = channel.allocator.buffer(capacity: line.utf8.count)
+    buffer.writeString(line)
+    try await channel.writeAndFlush(HTTPServerResponsePart.body(.byteBuffer(buffer)))
+}

--- a/swama/Sources/SwamaServer/LegacyServerCoreBackend.swift
+++ b/swama/Sources/SwamaServer/LegacyServerCoreBackend.swift
@@ -1,0 +1,371 @@
+import CoreImage
+import Foundation
+import MLXLMCommon
+import SwamaCore
+import SwamaKit
+
+// MARK: - ServerModelPool
+
+enum ServerModelPool {
+    static let shared: ModelPool = .shared
+}
+
+// MARK: - ServerCoreEngine
+
+enum ServerCoreEngine {
+    static let backend: LegacyServerCoreBackend = .init(modelPool: ServerModelPool.shared)
+    static let shared: SwamaEngine = .init(backend: backend)
+    static var modelPoolIdentity: ObjectIdentifier { backend.modelPoolIdentity }
+}
+
+// MARK: - LegacyServerCoreBackend
+
+/// Transitional package-only Core backend for the HTTP server.
+///
+/// The server still exposes legacy audio routes in v2, so non-audio Core requests must use the
+/// exact same `ModelPool.shared` actor as STT/TTS. Constructing the default Runtime-backed engine
+/// here would split the accepted global concurrency, live-operation, eviction, and cleanup state.
+/// This adapter is removed with the v3 Runtime migration tracked by task #30.
+struct LegacyServerCoreBackend: SwamaEngineBackend {
+    init(modelPool: ModelPool) {
+        self.modelPool = modelPool
+    }
+
+    var modelPoolIdentity: ObjectIdentifier {
+        ObjectIdentifier(modelPool)
+    }
+
+    func generate(
+        _ request: GenerationRequest,
+        onEvent: (@Sendable (GenerationEvent) async throws -> Void)?
+    ) async throws -> GenerationResponse {
+        let modelName = ModelAliasResolver.resolve(name: request.model.rawValue)
+        do {
+            let result = try await modelPool.run(modelName: modelName) { runner in
+                let input = try makeUserInput(
+                    request.messages,
+                    tools: request.tools,
+                    modelName: modelName
+                )
+                return try await runner.runChatForCore(
+                    userInput: input,
+                    parameters: makeParameters(request.options),
+                    contextLimit: request.options.contextLimit,
+                    onToken: { try await onEvent?(.textDelta($0)) },
+                    onToolCall: { try await onEvent?(.toolCall(.init($0))) }
+                )
+            }
+            try Task.checkCancellation()
+            if result.completionInfo?.stopReason == .cancelled {
+                throw CancellationError()
+            }
+
+            let toolCalls = result.toolCalls.map(ToolCall.init)
+            let completionTokens = result.completionInfo?.generationTokenCount ?? 0
+            return GenerationResponse(
+                output: result.output,
+                toolCalls: toolCalls,
+                usage: .init(
+                    promptTokens: result.promptTokens,
+                    completionTokens: completionTokens
+                ),
+                finishReason: finishReason(
+                    result.completionInfo?.stopReason,
+                    hasToolCalls: !toolCalls.isEmpty
+                ),
+                metrics: result.completionInfo.map {
+                    .init(
+                        promptSeconds: $0.promptTime,
+                        generationSeconds: $0.generateTime,
+                        tokensPerSecond: $0.tokensPerSecond
+                    )
+                }
+            )
+        }
+        catch is CancellationError {
+            throw CancellationError()
+        }
+        catch {
+            throw mapError(error, model: request.model, fallback: .backendFailure)
+        }
+    }
+
+    func embed(_ request: EmbeddingRequest) async throws -> EmbeddingResponse {
+        let modelName = ModelAliasResolver.resolve(name: request.model.rawValue)
+        do {
+            let result = try await modelPool.runEmbeddingWithConcurrencyControl(modelName: modelName) { runner in
+                try await runner.generateEmbeddings(inputs: request.inputs)
+            }
+            try Task.checkCancellation()
+            return .init(
+                embeddings: result.embeddings,
+                usage: .init(promptTokens: result.usage.promptTokens, completionTokens: 0)
+            )
+        }
+        catch is CancellationError {
+            throw CancellationError()
+        }
+        catch {
+            throw mapError(error, model: request.model, fallback: .embeddingFailed)
+        }
+    }
+
+    func models() async throws -> [SwamaCore.ModelInfo] {
+        ModelManager.models()
+            .filter { model in
+                !ModelAliasResolver.isAudioModel(model.id) && !ModelAliasResolver.isTTSModel(model.id)
+            }
+            .map { model in
+                SwamaCore.ModelInfo(
+                    id: .init(model.id),
+                    created: Date(timeIntervalSince1970: TimeInterval(model.created)),
+                    sizeInBytes: model.sizeInBytes,
+                    capabilities: capabilities(for: model.id)
+                )
+            }
+            .sorted { $0.id.rawValue < $1.id.rawValue }
+    }
+
+    func fetch(_ model: ModelID) async throws -> ModelID {
+        do {
+            let resolved = try await ModelDownloader.fetchModel(modelName: model.rawValue)
+            return .init(resolved)
+        }
+        catch {
+            throw mapError(error, model: model, fallback: .downloadFailed)
+        }
+    }
+
+    func remove(_ model: ModelID) async throws {
+        let modelName = ModelAliasResolver.resolve(name: model.rawValue)
+        await modelPool.remove(modelName: modelName)
+        do {
+            guard try ModelPaths.removeModel(modelName) else {
+                throw SwamaError(code: .modelNotFound, message: "The model was not found.", model: model)
+            }
+        }
+        catch let error as SwamaError {
+            throw error
+        }
+        catch {
+            throw SwamaError(code: .removalFailed, message: "The model could not be removed.", model: model)
+        }
+    }
+
+    func clearCache(for model: ModelID) async {
+        await modelPool.remove(modelName: ModelAliasResolver.resolve(name: model.rawValue))
+    }
+
+    func clearCache() async {
+        await modelPool.clearCache()
+    }
+
+    private let modelPool: ModelPool
+
+    private func makeUserInput(
+        _ messages: [SwamaCore.Message],
+        tools: [ToolDefinition],
+        modelName: String
+    ) throws -> MLXLMCommon.UserInput {
+        let chat = try messages.map(makeChatMessage)
+        let mlxTools = tools.isEmpty ? nil : tools.map(\.mlxValue)
+        if messages.contains(where: \.hasMedia), shouldApplyQwen35MultimodalSafety(modelName: modelName) {
+            return .init(
+                chat: chat,
+                processing: .init(resize: .init(width: 1344, height: 1344)),
+                tools: mlxTools
+            )
+        }
+        return .init(chat: chat, tools: mlxTools)
+    }
+
+    private func makeChatMessage(_ message: SwamaCore.Message) throws -> MLXLMCommon.Chat.Message {
+        var textParts = [String]()
+        var images = [MLXLMCommon.UserInput.Image]()
+        for part in message.content {
+            switch part {
+            case let .text(text):
+                textParts.append(text)
+            case let .imageURL(url):
+                images.append(.url(url))
+            case let .imageData(data, _):
+                guard let image = CIImage(data: data) else {
+                    throw SwamaError(code: .invalidImage, message: "The image data is invalid.")
+                }
+
+                images.append(.ciImage(image))
+            }
+        }
+        let text = textParts.joined(separator: "\n")
+        switch message.role {
+        case .system:
+            return .system(text, images: images)
+
+        case .user:
+            return .user(text, images: images)
+
+        case .assistant:
+            return .assistant(
+                text,
+                images: images,
+                toolCalls: message.toolCalls.isEmpty ? nil : message.toolCalls.map(\.mlxValue)
+            )
+
+        case .tool:
+            return .tool(text, id: message.toolCallID)
+        }
+    }
+
+    func makeParameters(_ options: GenerationOptions) -> GenerateParameters {
+        .init(
+            maxTokens: options.maxTokens,
+            temperature: options.temperature,
+            topP: options.topP,
+            topK: options.topK,
+            minP: options.minP,
+            repetitionPenalty: options.repetitionPenalty,
+            repetitionContextSize: options.repetitionContextSize,
+            presencePenalty: options.presencePenalty,
+            presenceContextSize: options.presenceContextSize,
+            frequencyPenalty: options.frequencyPenalty,
+            frequencyContextSize: options.frequencyContextSize,
+            seed: options.seed
+        )
+    }
+
+    private func finishReason(_ reason: GenerateStopReason?, hasToolCalls: Bool) -> FinishReason {
+        if hasToolCalls {
+            return .toolCall
+        }
+        return reason == .length ? .length : .completed
+    }
+
+    private func mapError(
+        _ error: Error,
+        model: ModelID?,
+        fallback: SwamaError.Code
+    ) -> SwamaError {
+        if let error = error as? SwamaError {
+            return error
+        }
+        if let error = error as? ModelPoolError {
+            return switch error {
+            case .modelNotFoundLocally:
+                .init(code: .modelNotFound, message: "The model is not available locally.", model: model)
+            case .failedToLoadModel:
+                .init(code: .modelLoadFailed, message: "The model could not be loaded.", model: model)
+            }
+        }
+        if error is ContextLimitError {
+            return .init(code: .contextLimitExceeded, message: error.localizedDescription, model: model)
+        }
+        if error is EmbeddingError {
+            return .init(code: .embeddingFailed, message: "Embedding generation failed.", model: model)
+        }
+        return .init(code: fallback, message: "The local model backend failed.", model: model)
+    }
+
+    private func capabilities(for model: String) -> ModelCapabilities {
+        let normalized = model.lowercased()
+        let embedding = ["embed", "bge", "e5-", "gte-"].contains(where: normalized.contains)
+        return .init(
+            textGeneration: !embedding,
+            vision: !embedding && ["vl", "vision", "gemma-3", "gemma3"].contains(where: normalized.contains),
+            tools: !embedding,
+            embeddings: embedding
+        )
+    }
+
+    private func shouldApplyQwen35MultimodalSafety(modelName: String) -> Bool {
+        let lowered = modelName.lowercased()
+        return lowered.contains("qwen3.5") || lowered.contains("qwen3_5")
+    }
+}
+
+private extension SwamaCore.Message {
+    var hasMedia: Bool {
+        content.contains { part in
+            switch part {
+            case .imageData,
+                 .imageURL:
+                true
+            case .text:
+                false
+            }
+        }
+    }
+}
+
+private extension ToolDefinition {
+    var mlxValue: [String: any Sendable] {
+        var function: [String: any Sendable] = [
+            "name": name,
+            "parameters": parameters.sendableValue
+        ]
+        if let description {
+            function["description"] = description
+        }
+        return ["type": "function", "function": function]
+    }
+}
+
+private extension SwamaCore.ToolCall {
+    init(_ value: MLXLMCommon.ToolCall) {
+        self.init(
+            id: value.id,
+            name: value.function.name,
+            arguments: value.function.arguments.mapValues { SwamaCore.JSONValue($0) }
+        )
+    }
+
+    var mlxValue: MLXLMCommon.ToolCall {
+        .init(
+            function: .init(
+                name: name,
+                arguments: arguments.mapValues { MLXLMCommon.JSONValue.from($0.sendableValue) }
+            ),
+            id: id
+        )
+    }
+}
+
+private extension SwamaCore.JSONValue {
+    init(_ value: MLXLMCommon.JSONValue) {
+        self =
+            switch value {
+            case .null:
+                .null
+            case let .bool(value):
+                .bool(value)
+            case let .int(value):
+                .int(value)
+            case let .double(value):
+                .double(value)
+            case let .string(value):
+                .string(value)
+            case let .array(value):
+                .array(value.map(Self.init))
+            case let .object(value):
+                .object(value.mapValues(Self.init))
+            }
+    }
+
+    var sendableValue: any Sendable {
+        switch self {
+        case .null:
+            NSNull()
+        case let .bool(value):
+            value
+        case let .int(value):
+            value
+        case let .double(value):
+            value
+        case let .string(value):
+            value
+        case let .array(value):
+            value.map(\.sendableValue)
+        case let .object(value):
+            value.mapValues(\.sendableValue)
+        }
+    }
+}

--- a/swama/Sources/SwamaServer/TextToSpeechHandler.swift
+++ b/swama/Sources/SwamaServer/TextToSpeechHandler.swift
@@ -57,7 +57,7 @@ public enum TextToSpeechHandler {
 
             let responseFormat = try resolveResponseFormat(request.response_format)
 
-            let result = try await ModelPool.shared.runTTS(
+            let result = try await ServerModelPool.shared.runTTS(
                 modelKey: modelResolution.cacheKey,
                 kind: modelResolution.kind,
                 repository: modelResolution.repository

--- a/swama/Sources/SwamaServer/TranscriptionsHandler.swift
+++ b/swama/Sources/SwamaServer/TranscriptionsHandler.swift
@@ -137,7 +137,7 @@ public enum TranscriptionsHandler {
 
         if responseFormat == .verboseJson {
             // For verbose format, get detailed results with timestamps
-            let transcriptionOutput = try await ModelPool.shared.runSpeechToText(modelName: modelName) { runner in
+            let transcriptionOutput = try await ServerModelPool.shared.runSpeechToText(modelName: modelName) { runner in
                 try await runner.transcribe(
                     audioFile: tempURL,
                     language: language,
@@ -172,7 +172,7 @@ public enum TranscriptionsHandler {
         }
         else {
             // Simple transcription
-            let transcriptionOutput = try await ModelPool.shared.runSpeechToText(modelName: modelName) { runner in
+            let transcriptionOutput = try await ServerModelPool.shared.runSpeechToText(modelName: modelName) { runner in
                 try await runner.transcribe(
                     audioFile: tempURL,
                     language: language,

--- a/swama/Tests/SwamaKitTests/CompletionsHandlerTests.swift
+++ b/swama/Tests/SwamaKitTests/CompletionsHandlerTests.swift
@@ -1,8 +1,8 @@
 import Foundation
-@preconcurrency import MLXLMCommon
 import NIOCore
 import NIOEmbedded
 import NIOHTTP1
+import SwamaCore
 @testable import SwamaKit
 @testable import SwamaServer
 import Testing
@@ -104,7 +104,8 @@ final class CompletionsHandlerTests {
             "repetition_penalty": 1.15,
             "repetition_context_size": 64,
             "presence_penalty": 0.5,
-            "frequency_penalty": 0.3
+            "frequency_penalty": 0.3,
+            "context_limit": 4096
         ]
         return try! JSONSerialization.data(withJSONObject: request)
     }
@@ -122,14 +123,15 @@ final class CompletionsHandlerTests {
         #expect(payload?.repetition_context_size == 64)
         #expect(payload?.presence_penalty == 0.5)
         #expect(payload?.frequency_penalty == 0.3)
+        #expect(payload?.context_limit == 4096)
     }
 
-    @Test func samplingParametersMapToGenerateParameters() throws {
+    @Test func samplingParametersMapToCoreOptions() throws {
         let requestData = createSamplingCompletionRequest()
         let buffer = ByteBuffer(bytes: requestData)
 
         let payload = try #require(CompletionsHandler.parsePayload(buffer))
-        let parameters = CompletionsHandler.generateParameters(from: payload)
+        let parameters = try CompletionsHandler.coreRequest(from: payload).options
 
         #expect(parameters.topK == 40)
         #expect(parameters.minP == 0.05)
@@ -137,6 +139,7 @@ final class CompletionsHandlerTests {
         #expect(parameters.repetitionContextSize == 64)
         #expect(parameters.presencePenalty == 0.5)
         #expect(parameters.frequencyPenalty == 0.3)
+        #expect(parameters.contextLimit == 4096)
     }
 
     @Test func absentSamplingParametersKeepEngineDefaults() throws {
@@ -151,8 +154,8 @@ final class CompletionsHandlerTests {
         #expect(payload.presence_penalty == nil)
         #expect(payload.frequency_penalty == nil)
 
-        let parameters = CompletionsHandler.generateParameters(from: payload)
-        let defaults = GenerateParameters()
+        let parameters = try CompletionsHandler.coreRequest(from: payload).options
+        let defaults = GenerationOptions()
 
         #expect(parameters.topK == defaults.topK)
         #expect(parameters.minP == defaults.minP)

--- a/swama/Tests/SwamaKitTests/DiagnosticsTests.swift
+++ b/swama/Tests/SwamaKitTests/DiagnosticsTests.swift
@@ -332,7 +332,7 @@ struct DiagnosticsTests {
         #expect(events.map(\.model) == identities.map(Optional.some))
     }
 
-    @Test func embeddingsRequestRelativeModelCannotLeakIntoDiagnostics() async throws {
+    @Test func embeddingsRequestRelativeModelIsRejectedBeforeDiagnostics() async throws {
         let primary = LockedData()
         let recorder = makeRecorder(primary: primary)
         recorder.start(mode: .serve)
@@ -354,11 +354,10 @@ struct DiagnosticsTests {
         #expect(!text.contains("prompt-secret"))
         #expect(!text.contains("poison-input"))
         let modelEvents = try validEvents(primary.data).filter { $0.subsystem == "model" }
-        #expect(modelEvents.map(\.event) == [.modelLoadStarted, .modelLoadFailed])
-        #expect(modelEvents.allSatisfy { $0.model?.hasPrefix("local:") == true })
+        #expect(modelEvents.isEmpty)
     }
 
-    @Test func embeddingsRequestCredentialURLCannotLeakIntoDiagnostics() async throws {
+    @Test func embeddingsRequestCredentialURLIsRejectedBeforeDiagnostics() async throws {
         let primary = LockedData()
         let recorder = makeRecorder(primary: primary)
         recorder.start(mode: .serve)
@@ -383,8 +382,7 @@ struct DiagnosticsTests {
         #expect(!text.contains("example.invalid"))
         #expect(!text.contains("poison-input"))
         let modelEvents = try validEvents(primary.data).filter { $0.subsystem == "model" }
-        #expect(modelEvents.map(\.event) == [.modelLoadStarted, .modelLoadFailed])
-        #expect(modelEvents.allSatisfy { $0.model?.hasPrefix("local:") == true })
+        #expect(modelEvents.isEmpty)
     }
 
     @Test func disabledRecorderHasNoSideEffects() {

--- a/swama/Tests/SwamaKitTests/HTTPToCoreTests.swift
+++ b/swama/Tests/SwamaKitTests/HTTPToCoreTests.swift
@@ -1,0 +1,416 @@
+import Foundation
+import NIOCore
+import NIOEmbedded
+import NIOHTTP1
+import SwamaCore
+@testable import SwamaKit
+@testable import SwamaServer
+import Testing
+
+// MARK: - HTTPToCoreTests
+
+@MainActor @Suite("HTTP to Core adapters", .serialized)
+struct HTTPToCoreTests {
+    @Test func serverCoreAndAudioRoutesShareTheLegacyPool() {
+        let legacyIdentity = ObjectIdentifier(ModelPool.shared)
+        #expect(ObjectIdentifier(ServerModelPool.shared) == legacyIdentity)
+        #expect(ServerCoreEngine.modelPoolIdentity == legacyIdentity)
+    }
+
+    @Test func legacyBackendMapsEveryCoreSamplingOption() {
+        let backend = LegacyServerCoreBackend(modelPool: ServerModelPool.shared)
+        let parameters = backend.makeParameters(.init(
+            maxTokens: 17,
+            temperature: 0.2,
+            topP: 0.8,
+            topK: 7,
+            minP: 0.1,
+            repetitionPenalty: 1.05,
+            repetitionContextSize: 64,
+            presencePenalty: 0.4,
+            presenceContextSize: 30,
+            frequencyPenalty: 0.3,
+            frequencyContextSize: 40,
+            seed: 42,
+            contextLimit: 4096
+        ))
+
+        #expect(parameters.maxTokens == 17)
+        #expect(parameters.temperature == 0.2)
+        #expect(parameters.topP == 0.8)
+        #expect(parameters.topK == 7)
+        #expect(parameters.minP == 0.1)
+        #expect(parameters.repetitionPenalty == 1.05)
+        #expect(parameters.repetitionContextSize == 64)
+        #expect(parameters.presencePenalty == 0.4)
+        #expect(parameters.presenceContextSize == 30)
+        #expect(parameters.frequencyPenalty == 0.3)
+        #expect(parameters.frequencyContextSize == 40)
+        #expect(parameters.seed == 42)
+    }
+
+    @Test func completionWireFieldsMapToCoreValues() throws {
+        let data = Data(#"""
+        {
+          "model":"alias",
+          "messages":[
+            {"role":"system","content":"system"},
+            {"role":"user","content":[
+              {"type":"text","text":"look"},
+              {"type":"image_url","image_url":{"url":"https://example.invalid/image.png"}}
+            ]},
+            {"role":"assistant","content":"calling","tool_calls":[{
+              "id":"call-1","type":"function","function":{"name":"lookup","arguments":"{\"key\":\"x\"}"}
+            }]},
+            {"role":"tool","content":"result","tool_call_id":"call-1"}
+          ],
+          "temperature":0.2,
+          "top_p":0.8,
+          "top_k":7,
+          "min_p":0.1,
+          "repetition_penalty":1.05,
+          "repetition_context_size":64,
+          "presence_penalty":0.4,
+          "frequency_penalty":0.3,
+          "context_limit":4096,
+          "max_tokens":17,
+          "tools":[{"type":"function","function":{
+            "name":"lookup","description":"Lookup","parameters":{"type":"object","properties":{}}
+          }}]
+        }
+        """#.utf8)
+        let payload = try JSONDecoder().decode(CompletionsHandler.CompletionRequest.self, from: data)
+        let request = try CompletionsHandler.coreRequest(from: payload)
+
+        #expect(request.model == ModelID("alias"))
+        #expect(request.options == .init(
+            maxTokens: 17,
+            temperature: 0.2,
+            topP: 0.8,
+            topK: 7,
+            minP: 0.1,
+            repetitionPenalty: 1.05,
+            repetitionContextSize: 64,
+            presencePenalty: 0.4,
+            frequencyPenalty: 0.3,
+            contextLimit: 4096
+        ))
+        #expect(request.messages.count == 4)
+        #expect(try request.messages[1].content == [
+            .text("look"),
+            .imageURL(#require(URL(string: "https://example.invalid/image.png")))
+        ])
+        #expect(request.messages[2].toolCalls == [
+            .init(id: "call-1", name: "lookup", arguments: ["key": .string("x")])
+        ])
+        #expect(request.messages[3].toolCallID == "call-1")
+        #expect(request.tools == [.init(
+            name: "lookup",
+            description: "Lookup",
+            parameters: .object([
+                "type": .string("object"),
+                "properties": .object([:])
+            ])
+        )])
+    }
+
+    @Test func nonStreamingHandlerUsesInjectedCoreAndPreservesWireResponse() async throws {
+        let backend = HTTPStubBackend(
+            generationResponse: .init(
+                output: "answer",
+                toolCalls: [.init(id: "call-1", name: "lookup", arguments: ["key": .string("x")])],
+                usage: .init(promptTokens: 3, completionTokens: 2),
+                finishReason: .toolCall,
+                metrics: .init(promptSeconds: 0.1, generationSeconds: 0.2, tokensPerSecond: 10)
+            )
+        )
+        let engine = SwamaEngine(backend: backend)
+        let channel = NIOAsyncTestingChannel()
+        try await channel.connect(to: .init(ipAddress: "127.0.0.1", port: 28100))
+        await channel.testingEventLoop.run()
+        let completed = AsyncFlag()
+        let body = ByteBuffer(bytes: Data(#"""
+        {"model":"org/model","messages":[{"role":"user","content":"hello"}],"stream":false}
+        """#.utf8))
+
+        let task = Task {
+            await CompletionsHandler.handle(
+                requestHead: .init(version: .http1_1, method: .POST, uri: "/v1/chat/completions"),
+                body: body,
+                channel: channel,
+                engine: engine
+            )
+            await completed.set()
+        }
+        try await pump(channel, until: completed)
+        await task.value
+        await channel.testingEventLoop.run()
+
+        let response = try await responseJSON(from: channel)
+        #expect(response["model"] as? String == "org/model")
+        let choices = try #require(response["choices"] as? [[String: Any]])
+        #expect(choices.first?["finish_reason"] as? String == "tool_calls")
+        let usage = try #require(response["usage"] as? [String: Any])
+        #expect(usage["prompt_tokens"] as? Int == 3)
+        #expect(usage["completion_tokens"] as? Int == 2)
+        #expect(await backend.generationRequests.map(\.model) == [ModelID("org/model")])
+    }
+
+    @Test func embeddingHandlerUsesInjectedCore() async throws {
+        let backend = HTTPStubBackend(
+            embeddingResponse: .init(
+                embeddings: [[1, 2], [3, 4]],
+                usage: .init(promptTokens: 5, completionTokens: 0)
+            )
+        )
+        let engine = SwamaEngine(backend: backend)
+        let channel = NIOAsyncTestingChannel()
+        let completed = AsyncFlag()
+        let body = ByteBuffer(bytes: Data(#"""
+        {"model":"org/embed","input":["one","two"]}
+        """#.utf8))
+
+        let task = Task {
+            await EmbeddingsHandler.handle(
+                requestHead: .init(version: .http1_1, method: .POST, uri: "/v1/embeddings"),
+                body: body,
+                channel: channel,
+                engine: engine
+            )
+            await completed.set()
+        }
+        try await pump(channel, until: completed)
+        await task.value
+        await channel.testingEventLoop.run()
+
+        let response = try await responseJSON(from: channel)
+        let data = try #require(response["data"] as? [[String: Any]])
+        #expect(data.count == 2)
+        let usage = try #require(response["usage"] as? [String: Any])
+        #expect(usage["prompt_tokens"] as? Int == 5)
+        #expect(await backend.embeddingRequests == [
+            .init(model: .init("org/embed"), inputs: ["one", "two"])
+        ])
+    }
+
+    @Test func invalidEmbeddingModelReturnsBadRequestBeforeBackendExecution() async throws {
+        let backend = HTTPStubBackend()
+        let engine = SwamaEngine(backend: backend)
+        let channel = NIOAsyncTestingChannel()
+        let completed = AsyncFlag()
+        let body = ByteBuffer(bytes: Data(#"""
+        {"model":"../private/model","input":"hello"}
+        """#.utf8))
+
+        let task = Task {
+            await EmbeddingsHandler.handle(
+                requestHead: .init(version: .http1_1, method: .POST, uri: "/v1/embeddings"),
+                body: body,
+                channel: channel,
+                engine: engine
+            )
+            await completed.set()
+        }
+        try await pump(channel, until: completed)
+        await task.value
+        await channel.testingEventLoop.run()
+
+        let response = try await response(from: channel)
+        #expect(response.status == .badRequest)
+        #expect(await backend.embeddingRequests.isEmpty)
+    }
+
+    @Test func invalidCoreMessageFieldsReturnBadRequestBeforeBackendExecution() async throws {
+        let backend = HTTPStubBackend()
+        let engine = SwamaEngine(backend: backend)
+        let channel = NIOAsyncTestingChannel()
+        let completed = AsyncFlag()
+        let body = ByteBuffer(bytes: Data(#"""
+        {"model":"org/model","messages":[{"role":"tool","content":"result"}]}
+        """#.utf8))
+
+        let task = Task {
+            await CompletionsHandler.handle(
+                requestHead: .init(version: .http1_1, method: .POST, uri: "/v1/chat/completions"),
+                body: body,
+                channel: channel,
+                engine: engine
+            )
+            await completed.set()
+        }
+        try await pump(channel, until: completed)
+        await task.value
+        await channel.testingEventLoop.run()
+
+        let response = try await response(from: channel)
+        #expect(response.status == .badRequest)
+        let error = try #require(response.json["error"] as? [String: Any])
+        #expect(error["type"] as? String == "invalid_request_error")
+        #expect(await backend.generationRequests.isEmpty)
+    }
+
+    @Test func streamingHandlerPreservesCoreEventOrderAndTerminalUsage() async throws {
+        let backend = HTTPStubBackend(
+            generationResponse: .init(
+                output: "hello",
+                toolCalls: [.init(id: "call-1", name: "lookup", arguments: ["key": .string("x")])],
+                usage: .init(promptTokens: 3, completionTokens: 2),
+                finishReason: .toolCall
+            ),
+            generationEvents: [
+                .textDelta("hel"),
+                .textDelta("lo"),
+                .toolCall(.init(id: "call-1", name: "lookup", arguments: ["key": .string("x")]))
+            ]
+        )
+        let engine = SwamaEngine(backend: backend)
+        let channel = NIOAsyncTestingChannel()
+        try await channel.connect(to: .init(ipAddress: "127.0.0.1", port: 28100))
+        await channel.testingEventLoop.run()
+        let completed = AsyncFlag()
+        let body = ByteBuffer(bytes: Data(#"""
+        {"model":"org/model","messages":[{"role":"user","content":"hello"}],"stream":true}
+        """#.utf8))
+
+        let task = Task {
+            await CompletionsHandler.handle(
+                requestHead: .init(version: .http1_1, method: .POST, uri: "/v1/chat/completions"),
+                body: body,
+                channel: channel,
+                engine: engine
+            )
+            await completed.set()
+        }
+        try await pump(channel, until: completed)
+        await task.value
+        await channel.testingEventLoop.run()
+
+        let output = try await responseBodyString(from: channel)
+        let role = try #require(output.range(of: #""role":"assistant""#))
+        let firstText = try #require(output.range(of: #""content":"hel""#))
+        let secondText = try #require(output.range(of: #""content":"lo""#))
+        let tool = try #require(output.range(of: #""tool_calls""#))
+        let terminal = try #require(output.range(of: #""finish_reason":"tool_calls""#))
+        let done = try #require(output.range(of: "data: [DONE]"))
+        #expect(role.lowerBound < firstText.lowerBound)
+        #expect(firstText.lowerBound < secondText.lowerBound)
+        #expect(secondText.lowerBound < tool.lowerBound)
+        #expect(tool.lowerBound < terminal.lowerBound)
+        #expect(terminal.lowerBound < done.lowerBound)
+        #expect(output.contains(#""prompt_tokens":3"#))
+        #expect(output.contains(#""completion_tokens":2"#))
+    }
+
+    private func pump(_ channel: NIOAsyncTestingChannel, until flag: AsyncFlag) async throws {
+        for _ in 0 ..< 1000 {
+            await channel.testingEventLoop.run()
+            if await flag.value {
+                return
+            }
+            await Task.yield()
+        }
+        throw HTTPToCoreTestError.timeout
+    }
+
+    private func responseJSON(from channel: NIOAsyncTestingChannel) async throws -> [String: Any] {
+        let result = try await response(from: channel)
+        return result.json
+    }
+
+    private func response(
+        from channel: NIOAsyncTestingChannel
+    ) async throws -> (status: HTTPResponseStatus, json: [String: Any]) {
+        var status: HTTPResponseStatus?
+        var bytes = ByteBuffer()
+        while let part = try await channel.readOutbound(as: HTTPServerResponsePart.self) {
+            switch part {
+            case let .head(head):
+                status = head.status
+            case var .body(.byteBuffer(buffer)):
+                bytes.writeBuffer(&buffer)
+            case .body(.fileRegion),
+                 .end:
+                break
+            }
+        }
+        let body = String(decoding: bytes.readableBytesView, as: UTF8.self)
+        let data = Data(body.utf8)
+        return try (
+            #require(status),
+            #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        )
+    }
+
+    private func responseBodyString(from channel: NIOAsyncTestingChannel) async throws -> String {
+        var bytes = ByteBuffer()
+        while let part = try await channel.readOutbound(as: HTTPServerResponsePart.self) {
+            if case var .body(.byteBuffer(buffer)) = part {
+                bytes.writeBuffer(&buffer)
+            }
+        }
+        return String(decoding: bytes.readableBytesView, as: UTF8.self)
+    }
+}
+
+// MARK: - HTTPStubBackend
+
+private actor HTTPStubBackend: SwamaEngineBackend {
+    init(
+        generationResponse: GenerationResponse = .init(
+            output: "",
+            toolCalls: [],
+            usage: .init(promptTokens: 0, completionTokens: 0),
+            finishReason: .completed
+        ),
+        embeddingResponse: SwamaCore.EmbeddingResponse = .init(
+            embeddings: [],
+            usage: .init(promptTokens: 0, completionTokens: 0)
+        ),
+        generationEvents: [GenerationEvent] = []
+    ) {
+        self.generationResponse = generationResponse
+        self.embeddingResponse = embeddingResponse
+        self.generationEvents = generationEvents
+    }
+
+    func generate(
+        _ request: GenerationRequest,
+        onEvent: (@Sendable (GenerationEvent) async throws -> Void)?
+    ) async throws -> GenerationResponse {
+        generationRequests.append(request)
+        for event in generationEvents {
+            try await onEvent?(event)
+        }
+        return generationResponse
+    }
+
+    func embed(_ request: EmbeddingRequest) async throws -> SwamaCore.EmbeddingResponse {
+        embeddingRequests.append(request)
+        return embeddingResponse
+    }
+
+    func models() async throws -> [SwamaCore.ModelInfo] { [] }
+    func fetch(_ model: ModelID) async throws -> ModelID { model }
+    func remove(_: ModelID) async throws {}
+    func clearCache(for _: ModelID) async {}
+    func clearCache() async {}
+
+    private let generationResponse: GenerationResponse
+    private let embeddingResponse: SwamaCore.EmbeddingResponse
+    private(set) var generationRequests: [GenerationRequest] = []
+    private(set) var embeddingRequests: [EmbeddingRequest] = []
+    private let generationEvents: [GenerationEvent]
+}
+
+// MARK: - AsyncFlag
+
+private actor AsyncFlag {
+    func set() { value = true }
+    private(set) var value = false
+}
+
+// MARK: - HTTPToCoreTestError
+
+private enum HTTPToCoreTestError: Error {
+    case timeout
+}

--- a/swama/Tests/SwamaKitTests/LegacyCompletionsCompatibilityTests.swift
+++ b/swama/Tests/SwamaKitTests/LegacyCompletionsCompatibilityTests.swift
@@ -1,0 +1,30 @@
+@preconcurrency import MLXLMCommon
+import NIOCore
+@testable import SwamaServer
+import Testing
+import struct Tokenizers.ToolSpec
+
+@Suite("Legacy completion source compatibility")
+struct LegacyCompletionsCompatibilityTests {
+    @Test func publicHelperSignaturesRemainCallable() {
+        let nonStream: (
+            Channel,
+            String,
+            [MLXLMCommon.Chat.Message],
+            String,
+            GenerateParameters,
+            [ToolSpec]?
+        ) async throws -> Void = CompletionsHandler.sendNonStreamResponse
+        let stream: (
+            Channel,
+            String,
+            [MLXLMCommon.Chat.Message],
+            String,
+            GenerateParameters,
+            [ToolSpec]?
+        ) async throws -> Void = CompletionsHandler.sendStreamResponse
+
+        _ = nonStream
+        _ = stream
+    }
+}

--- a/swama/Tests/SwamaKitTests/ToolCallingTests.swift
+++ b/swama/Tests/SwamaKitTests/ToolCallingTests.swift
@@ -268,6 +268,7 @@ final class ToolCallingTests {
         #expect(message.role == "tool")
         #expect(message.content.textContent == "The weather in Tokyo is 22°C and sunny.")
         #expect(message.content.imageURLs.isEmpty)
+        #expect(message.tool_call_id == "call_123")
     }
 
     @Test func completionRequest_WithToolMessages() throws {
@@ -320,6 +321,7 @@ final class ToolCallingTests {
         let toolMessage = request.messages[2]
         #expect(toolMessage.role == "tool")
         #expect(toolMessage.content.textContent == "The weather in Tokyo is 22°C and sunny.")
+        #expect(toolMessage.tool_call_id == "call_123")
     }
 
     // MARK: - CompletionResponse Tests

--- a/swama/Tests/SwamaRuntimeTests/RuntimeLineageTests.swift
+++ b/swama/Tests/SwamaRuntimeTests/RuntimeLineageTests.swift
@@ -157,7 +157,7 @@ private let lineage: [LineageEntry] = [
     ),
     .init(
         path: "Model/ModelRunner.swift",
-        legacySHA256: "c5715822d87ff73f9ca54f8577d1f9873a45088b098575b464a1a4660903ef3e",
+        legacySHA256: "4e29ee4fb09d9fc8ec76e353a280214165936f7f09ba3a5b129e4b865c34fff6",
         runtimeSHA256: "eb60d9b94d013522be7ceb2c810d1eb9027ce9f0ca958df68b585d04747fe32c",
         derivedSymbols: ["actor ModelRunner", "struct ChatRunResult", "func runChat"]
     ),


### PR DESCRIPTION
## What changed

- make chat completions and embeddings thin HTTP-to-`SwamaCore` adapters
- preserve the existing single `SwamaKit.ModelPool.shared` concurrency, live-operation, eviction, and cleanup state through a package-only server backend
- keep `/v1/models`, STT, and TTS on the legacy path because the server catalog still includes Audio while Core v1 intentionally does not
- preserve the existing public completion helper symbols as deprecated source-compatible shims
- add request-scoped context limits without mutating the process-global setting

This is a transitional adapter, not a second runtime or scheduler. The package-only backend and compatibility shims are explicitly tracked for removal in the v3 cleanup task.

## Compatibility and boundaries

- `SwamaCore` public manifest remains 160 symbols
- `SwamaServer` public precise symbol IDs remain 156 → 156
- chat and embedding handlers import `SwamaCore` and no MLX/SwamaKit runtime modules
- chat, embeddings, STT, and TTS still use the same exact `ModelPool.shared` actor
- `/v1/models` remains behaviorally unchanged and continues to include Audio models

## Verification

- product tests: 295/295
- acceptance: 47/47
- stable release build: pass
- SwiftFormat 0.56.2: 0/121
- real HTTP probes: non-stream chat, ordered SSE stream, 2×768 embeddings, models catalog, and disconnect liveness
- reverse controls: second pool RED2; dropped sampling option RED1; dropped stream text RED1; reintroduced MLX handler import RED2

Independent internal review is GO on exact `9e67cdb6424fd4008406f4cbe9d157bc319821c8`.
