### PR TITLE
Tighten chat image URL validation

### DIFF
--- a/swama/Sources/SwamaServer/CompletionsHandler.swift
+++ b/swama/Sources/SwamaServer/CompletionsHandler.swift
@@ -527,11 +527,7 @@ public enum CompletionsHandler {
                     case let .text(text):
                         return .text(text)
                     case let .imageURL(image):
-                        guard let url = URL(string: image.url) else {
-                            throw CompletionsError.invalidImageURL(image.url)
-                        }
-
-                        return SwamaCore.ContentPart.imageURL(url)
+                        return try coreImagePart(image.url)
                     }
                 }
             }
@@ -542,6 +538,119 @@ public enum CompletionsHandler {
             toolCalls: message.tool_calls?.map(coreToolCall) ?? [],
             toolCallID: message.tool_call_id
         )
+    }
+
+    private static func coreImagePart(_ value: String) throws -> SwamaCore.ContentPart {
+        if value.lowercased().hasPrefix("data:") {
+            return try coreDataImagePart(value)
+        }
+
+        guard let url = URL(string: value, encodingInvalidCharacters: false),
+              let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              let scheme = components.scheme?.lowercased(),
+              ["http", "https"].contains(scheme),
+              components.host?.isEmpty == false,
+              components.user == nil,
+              components.password == nil,
+              hasValidExplicitPort(in: value),
+              components.port.map({ (1 ... 65535).contains($0) }) ?? true
+        else {
+            throw CompletionsError.invalidImageURL
+        }
+
+        return .imageURL(url)
+    }
+
+    private static func coreDataImagePart(_ value: String) throws -> SwamaCore.ContentPart {
+        guard let comma = value.firstIndex(of: ",") else {
+            throw CompletionsError.invalidImageURL
+        }
+
+        let header = String(value[..<comma])
+        let encoded = String(value[value.index(after: comma)...])
+        let components = header.split(separator: ";", omittingEmptySubsequences: false)
+        guard components.count == 2,
+              let mediaSubtype = components[0].split(separator: "/", omittingEmptySubsequences: false).last,
+              components[0].lowercased().hasPrefix("data:image/"),
+              components[0].count(where: { $0 == "/" }) == 1,
+              isASCIIMediaSubtype(mediaSubtype),
+              components[1].lowercased() == "base64",
+              let data = Data(base64Encoded: encoded),
+              !data.isEmpty
+        else {
+            throw CompletionsError.invalidImageURL
+        }
+
+        return .imageData(data, mediaType: String(components[0].dropFirst("data:".count)))
+    }
+
+    private static func hasValidExplicitPort(in value: String) -> Bool {
+        guard let schemeSeparator = value.range(of: "://") else {
+            return false
+        }
+
+        let authorityStart = schemeSeparator.upperBound
+        let authorityEnd = value[authorityStart...].firstIndex { ["/", "?", "#"].contains($0) } ?? value.endIndex
+        let authority = value[authorityStart ..< authorityEnd]
+
+        if authority.first == "[" {
+            guard let closingBracket = authority.firstIndex(of: "]") else {
+                return false
+            }
+
+            let remainder = authority[authority.index(after: closingBracket)...]
+            guard !remainder.isEmpty else {
+                return true
+            }
+            guard remainder.first == ":" else {
+                return false
+            }
+
+            return isValidPort(remainder.dropFirst())
+        }
+
+        guard let separator = authority.lastIndex(of: ":") else {
+            return true
+        }
+
+        return isValidPort(authority[authority.index(after: separator)...])
+    }
+
+    private static func isValidPort(_ value: Substring) -> Bool {
+        guard !value.isEmpty,
+              value.utf8.allSatisfy({ (48 ... 57).contains($0) }),
+              let port = Int(value)
+        else {
+            return false
+        }
+
+        return (1 ... 65535).contains(port)
+    }
+
+    private static func isASCIIMediaSubtype(_ value: Substring) -> Bool {
+        guard !value.isEmpty else {
+            return false
+        }
+
+        return value.utf8.allSatisfy { byte in
+            switch byte {
+            case 33,
+                 35 ... 39,
+                 42,
+                 43,
+                 45,
+                 46,
+                 48 ... 57,
+                 65 ... 90,
+                 94 ... 96,
+                 97 ... 122,
+                 124,
+                 126:
+                true
+            default:
+                false
+            }
+        }
     }
 
     private static func coreTool(_ tool: Tool) throws -> ToolDefinition {
@@ -976,15 +1085,15 @@ public enum CompletionsHandler {
 
 enum CompletionsError: Error, LocalizedError {
     case invalidRole(String)
-    case invalidImageURL(String)
+    case invalidImageURL
     case invalidToolJSON(String)
 
     public var errorDescription: String? {
         switch self {
         case let .invalidRole(role):
             "Invalid role: \(role). Must be 'system', 'user', 'assistant', or 'tool'"
-        case let .invalidImageURL(value):
-            "Invalid image URL: \(value)"
+        case .invalidImageURL:
+            "Invalid image URL"
         case let .invalidToolJSON(name):
             "Tool '\(name)' requires JSON object arguments or parameters"
         }

--- a/swama/Tests/SwamaKitTests/HTTPToCoreTests.swift
+++ b/swama/Tests/SwamaKitTests/HTTPToCoreTests.swift
@@ -114,6 +114,65 @@ struct HTTPToCoreTests {
         )])
     }
 
+    @Test func chatImageURLsUseOnlySupportedWireForms() throws {
+        let png = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+        let data = Data(#"""
+        {"model":"m","messages":[{"role":"user","content":[
+          {"type":"image_url","image_url":{"url":"https://example.com/image.png"}},
+          {"type":"image_url","image_url":{"url":"https://example.com/image%20name.png"}},
+          {"type":"image_url","image_url":{"url":"https://[::1]:65535/image.png"}},
+          {"type":"image_url","image_url":{"url":"data:image/png;base64,\#(png)"}},
+          {"type":"image_url","image_url":{"url":"data:image/svg+xml;base64,\#(png)"}},
+          {"type":"image_url","image_url":{"url":"data:image/vnd.example+json;base64,\#(png)"}}
+        ]}]}
+        """#.utf8)
+        let payload = try JSONDecoder().decode(CompletionsHandler.CompletionRequest.self, from: data)
+        let request = try CompletionsHandler.coreRequest(from: payload)
+
+        let expectedURL = try #require(URL(string: "https://example.com/image.png"))
+        let expectedEscapedURL = try #require(URL(string: "https://example.com/image%20name.png"))
+        let expectedIPv6URL = try #require(URL(string: "https://[::1]:65535/image.png"))
+        let expectedData = try #require(Data(base64Encoded: png))
+        #expect(request.messages[0].content == [
+            .imageURL(expectedURL),
+            .imageURL(expectedEscapedURL),
+            .imageURL(expectedIPv6URL),
+            .imageData(expectedData, mediaType: "image/png"),
+            .imageData(expectedData, mediaType: "image/svg+xml"),
+            .imageData(expectedData, mediaType: "image/vnd.example+json"),
+        ])
+
+        for value in [
+            "relative/image.png",
+            "file:///tmp/image.png",
+            "ftp://example.com/image.png",
+            "https://user:password@example.com/image.png",
+            "data:text/plain;base64,SGVsbG8=",
+            "data:image/png,not-base64",
+            "data:image/png;base64,not-base64",
+            "https://example.com/%zz",
+            "https://example.com/image.png\n",
+            "https://example.com:65536/image.png",
+            "https://example.com:999999999999999999999999/image.png",
+            "https://[::1]:999999999999999999999999/image.png",
+            "data:image/png/extra;base64,\(png)",
+            "data:image/png extra;base64,\(png)",
+        ] {
+            let encodedValue = try #require(String(data: JSONEncoder().encode(value), encoding: .utf8))
+            let wire = Data(#"""
+            {"model":"m","messages":[{"role":"user","content":[
+              {"type":"image_url","image_url":{"url":\#(encodedValue)}}
+            ]}]}
+            """#.utf8)
+            let invalid = try JSONDecoder().decode(CompletionsHandler.CompletionRequest.self, from: wire)
+            #expect(throws: CompletionsError.self, "must reject: \(value)") {
+                _ = try CompletionsHandler.coreRequest(from: invalid)
+            }
+        }
+
+        #expect(CompletionsError.invalidImageURL.localizedDescription == "Invalid image URL")
+    }
+
     @Test func nonStreamingHandlerUsesInjectedCoreAndPreservesWireResponse() async throws {
         let backend = HTTPStubBackend(
             generationResponse: .init(


### PR DESCRIPTION
## Summary

- accept chat image URLs only as credential-free `http` / `https` URLs with a valid authority and port
- decode well-formed `data:image/...;base64,...` inputs with an ASCII media subtype
- return a bounded validation error for unsupported or malformed image inputs

## Validation

- `swift test --no-parallel --build-system native`: 296/296
- Swama acceptance harness: 49/49
- stable-Xcode release build
- SwiftFormat 0.56.2: 0/121
- independent exact-head review: GO
